### PR TITLE
feat(settings): add visibility settings for UI elements

### DIFF
--- a/LiveTranscription/LiveTranscriptionWindow.swift
+++ b/LiveTranscription/LiveTranscriptionWindow.swift
@@ -12,6 +12,7 @@ class LiveTranscriptionWindow: NSWindow {
 	@AppStorage("liveTranscriptionWindowOffset") private var windowOffset = 25.0
 	@AppStorage("liveTranscriptionMaxWidthPercentage") private var maxWidthPercentage = 0.6
 	@AppStorage("liveTranscriptionFollowCaret") private var followCaret = true
+	@AppStorage("showLiveTranscriptionWindow") private var showLiveTranscriptionWindow = true
 
 	init(audioManager: AudioManager) {
 		self.audioManager = audioManager
@@ -52,7 +53,9 @@ class LiveTranscriptionWindow: NSWindow {
 				guard let self = self else { return }
 
 				let shouldShow =
-					self.whisperKit.shouldShowLiveTranscriptionWindow && self.whisperKit.isTranscribing
+					self.showLiveTranscriptionWindow
+					&& self.whisperKit.shouldShowLiveTranscriptionWindow
+					&& self.whisperKit.isTranscribing
 
 				if shouldShow {
 					let newSize = self.calculateDynamicSize()

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -195,6 +195,11 @@ struct SettingsView: View {
 	@AppStorage("enableDebugLogging") private var enableDebugLogging = false
 	@AppStorage("modelComputeUnits") private var modelComputeUnits = 2
 
+	// Visibility settings
+	@AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
+	@AppStorage("showLiveTranscriptionWindow") private var showLiveTranscriptionWindow = true
+	@AppStorage("showListeningWindow") private var showListeningWindow = true
+
 	var body: some View {
 		TabView {
 			// MARK: - General Tab
@@ -565,6 +570,38 @@ struct SettingsView: View {
 								showOnboardingAgain()
 							}
 							.buttonStyle(.bordered)
+						}
+					}
+
+					Divider()
+
+					SettingsSection("Visibility") {
+						SettingRow(
+							"Menu Bar Icon",
+							description: "Show Whispera icon in the menu bar"
+						) {
+							Toggle("", isOn: $showMenuBarIcon)
+						}
+
+						if !showMenuBarIcon {
+							InfoBox(style: .info) {
+								Text("Click the Whispera icon in Dock or use Spotlight to open settings")
+									.font(.caption)
+							}
+						}
+
+						SettingRow(
+							"Live Transcription Window",
+							description: "Show floating window during live transcription"
+						) {
+							Toggle("", isOn: $showLiveTranscriptionWindow)
+						}
+
+						SettingRow(
+							"Recording Indicator",
+							description: "Show audio level bars while recording"
+						) {
+							Toggle("", isOn: $showListeningWindow)
 						}
 
 						if permissionManager.needsPermissions {

--- a/What's up?/ListeningWindow.swift
+++ b/What's up?/ListeningWindow.swift
@@ -13,6 +13,7 @@ class ListeningWindow: NSWindow {
 	private let audioManager: AudioManager
 	private var observationTimer: Timer?
 	@AppStorage("enableStreaming") private var enableStreaming = false
+	@AppStorage("showListeningWindow") private var showListeningWindow = true
 
 	init(audioManager: AudioManager) {
 		self.audioManager = audioManager
@@ -47,7 +48,7 @@ class ListeningWindow: NSWindow {
 			Task { @MainActor in
 				guard let self = self else { return }
 
-				let shouldShow = self.audioManager.currentState != .idle && !self.enableStreaming
+				let shouldShow = self.showListeningWindow && self.audioManager.currentState != .idle && !self.enableStreaming
 
 				if shouldShow && !self.isVisible {
 					self.positionAtBottomCenter()


### PR DESCRIPTION
## Summary
- Add toggles to show/hide menu bar icon, live transcription window, and recording indicator
- Open settings window when app is launched from Dock/Spotlight/Raycast without menu bar icon
- Dynamically hide/show status bar item based on user preference

## Changes
- `SettingsView.swift`: Added Visibility section with toggles for Menu Bar Icon, Live Transcription Window, and Recording Indicator
- `WhisperaApp.swift`: Added menu bar visibility logic and settings window opening on dock click
- `LiveTranscriptionWindow.swift`: Check `showLiveTranscriptionWindow` setting before showing
- `ListeningWindow.swift`: Check `showListeningWindow` setting before showing

## Test plan
- [ ] Toggle Menu Bar Icon off - verify icon disappears from menu bar
- [ ] Click Whispera in Dock - verify Settings window opens
- [ ] Toggle Menu Bar Icon back on - verify icon reappears
- [ ] Toggle Live Transcription Window off - verify window doesn't show during live transcription
- [ ] Toggle Recording Indicator off - verify audio level bars don't show during recording