### PR TITLE
refactor: migrate from ObservableObject to @Observable macro

### DIFF
--- a/GlobalShortcutManager.swift
+++ b/GlobalShortcutManager.swift
@@ -3,7 +3,8 @@ import Cocoa
 import Foundation
 import SwiftUI
 
-class GlobalShortcutManager: ObservableObject {
+@Observable
+final class GlobalShortcutManager {
 	private var globalMonitor: Any?
 	private var localMonitor: Any?
 	private var fileSelectionGlobalMonitor: Any?

--- a/Onboarding/PermissionsStepView.swift
+++ b/Onboarding/PermissionsStepView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct PermissionsStepView: View {
 	@Binding var hasPermissions: Bool
 	@Bindable var audioManager: AudioManager
-	@ObservedObject var globalShortcutManager: GlobalShortcutManager
+	var globalShortcutManager: GlobalShortcutManager
 	@State private var hasMicrophonePermission = false
 	@State private var permissionCheckTimer: Timer?
 	@State private var accessibilityCheckTimer: Timer?

--- a/OnboardingView.swift
+++ b/OnboardingView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct OnboardingView: View {
 	@Bindable var audioManager: AudioManager
-	@ObservedObject var shortcutManager: GlobalShortcutManager
+	var shortcutManager: GlobalShortcutManager
 
 	@State private var currentStep = 0
 	@State private var selectedModel = ""

--- a/RecordingIndicator.swift
+++ b/RecordingIndicator.swift
@@ -230,8 +230,9 @@ struct RecordingIndicatorView: View {
 	}
 }
 
+@Observable
 @MainActor
-class RecordingIndicatorManager: ObservableObject {
+final class RecordingIndicatorManager {
 	private var indicatorWindow: RecordingIndicatorWindow?
 
 	func showIndicator() {


### PR DESCRIPTION
## Summary
Migrate from legacy Combine-based `ObservableObject` pattern to Swift 6 Observation framework `@Observable` macro.

## Changes
- Convert `GlobalShortcutManager` from `ObservableObject` to `@Observable`
- Convert `RecordingIndicatorManager` from `ObservableObject` to `@Observable`
- Remove `@ObservedObject` property wrappers from views (replaced with plain `var`)
- Use `nonisolated(unsafe)` for event monitors accessed in deinit

## Why
- `@Observable` is the modern Swift 6 approach for reactive state
- Simpler API - no need for `@Published` or `@ObservedObject` wrappers
- Better performance with fine-grained observation tracking
- Aligns with SwiftUI best practices for macOS 14+

## Test plan
- [ ] Build succeeds
- [ ] Onboarding flow works correctly
- [ ] Global shortcuts still function
- [ ] Recording indicator shows/hides properly