### PR TITLE
feat(byok): macOS Keychain store for BYOK provider keys (WHI-40)

### DIFF
--- a/Client/ByokKeyStore.swift
+++ b/Client/ByokKeyStore.swift
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import Security
+
+/// Provider whose API key the user can bring (BYOK).
+enum ProviderId: String, CaseIterable, Sendable {
+	case openai
+	case anthropic
+
+	var displayName: String {
+		switch self {
+		case .openai: return "OpenAI"
+		case .anthropic: return "Anthropic"
+		}
+	}
+}
+
+enum ByokKeyStoreError: LocalizedError {
+	case unexpectedStatus(OSStatus)
+
+	var errorDescription: String? {
+		switch self {
+		case .unexpectedStatus(let status):
+			let message = SecCopyErrorMessageString(status, nil) as String? ?? "OSStatus \(status)"
+			return "Keychain error: \(message)"
+		}
+	}
+}
+
+/// Stores BYOK provider keys in the macOS Keychain.
+///
+/// Keys are written with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` so they
+/// never sync to iCloud and never restore onto another device. The key material
+/// is read at request time and dropped — it is never persisted to UserDefaults,
+/// app-support files, or logs. See WHI-40.
+struct ByokKeyStore {
+	static let shared = ByokKeyStore()
+
+	/// One Keychain service per concern keeps BYOK keys isolated from the auth token.
+	private let service: String
+
+	init(service: String = "com.whispera.byok") {
+		self.service = service
+	}
+
+	func save(provider: ProviderId, key: String) throws {
+		let data = Data(key.utf8)
+
+		// SecItemUpdate can't change kSecAttrAccessible, so delete-then-add keeps
+		// the accessibility flag authoritative on every write.
+		try? delete(provider: provider)
+
+		let query: [String: Any] = [
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecAttrAccount as String: provider.rawValue,
+			kSecValueData as String: data,
+			kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+		]
+
+		let status = SecItemAdd(query as CFDictionary, nil)
+		guard status == errSecSuccess else { throw ByokKeyStoreError.unexpectedStatus(status) }
+	}
+
+	func load(provider: ProviderId) throws -> String? {
+		let query: [String: Any] = [
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecAttrAccount as String: provider.rawValue,
+			kSecReturnData as String: true,
+			kSecMatchLimit as String: kSecMatchLimitOne,
+		]
+
+		var item: CFTypeRef?
+		let status = SecItemCopyMatching(query as CFDictionary, &item)
+		if status == errSecItemNotFound { return nil }
+		guard status == errSecSuccess else { throw ByokKeyStoreError.unexpectedStatus(status) }
+		guard let data = item as? Data, let key = String(data: data, encoding: .utf8) else {
+			return nil
+		}
+		return key
+	}
+
+	func delete(provider: ProviderId) throws {
+		let query: [String: Any] = [
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecAttrAccount as String: provider.rawValue,
+		]
+		let status = SecItemDelete(query as CFDictionary)
+		guard status == errSecSuccess || status == errSecItemNotFound else {
+			throw ByokKeyStoreError.unexpectedStatus(status)
+		}
+	}
+
+	/// Returns providers that have a key stored WITHOUT loading the key material.
+	func providers() throws -> [ProviderId] {
+		let query: [String: Any] = [
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecReturnAttributes as String: true,
+			kSecMatchLimit as String: kSecMatchLimitAll,
+		]
+
+		var result: CFTypeRef?
+		let status = SecItemCopyMatching(query as CFDictionary, &result)
+		if status == errSecItemNotFound { return [] }
+		guard status == errSecSuccess else { throw ByokKeyStoreError.unexpectedStatus(status) }
+		guard let items = result as? [[String: Any]] else { return [] }
+
+		return items.compactMap { item in
+			(item[kSecAttrAccount as String] as? String).flatMap(ProviderId.init(rawValue:))
+		}
+	}
+}

--- a/Logger/Logger.swift
+++ b/Logger/Logger.swift
@@ -13,28 +13,47 @@ struct ExtendedLogger {
 	let category: String
 
 	func log(_ message: String) {
+		let message = LogRedactor.redact(message)
 		logger.log("\(message)")
 		LogManager.shared.writeLog(category: category, level: .default, message: message)
 	}
 
 	func info(_ message: String) {
+		let message = LogRedactor.redact(message)
 		logger.info("\(message)")
 		LogManager.shared.writeLog(category: category, level: .info, message: message)
 	}
 
 	func debug(_ message: String) {
+		let message = LogRedactor.redact(message)
 		logger.debug("\(message)")
 		LogManager.shared.writeLog(category: category, level: .debug, message: message)
 	}
 
 	func error(_ message: String) {
+		let message = LogRedactor.redact(message)
 		logger.error("\(message)")
 		LogManager.shared.writeLog(category: category, level: .error, message: message)
 	}
 
 	func fault(_ message: String) {
+		let message = LogRedactor.redact(message)
 		logger.fault("\(message)")
 		LogManager.shared.writeLog(category: category, level: .fault, message: message)
+	}
+}
+
+/// Defensively scrubs provider API keys from anything we log. A BYOK key should
+/// never reach a log file, but a careless string interpolation elsewhere
+/// shouldn't be able to leak one either. See WHI-40.
+enum LogRedactor {
+	private static let pattern = try? NSRegularExpression(pattern: "sk-[A-Za-z0-9-_]{20,}")
+
+	static func redact(_ message: String) -> String {
+		guard let pattern else { return message }
+		let range = NSRange(message.startIndex..., in: message)
+		return pattern.stringByReplacingMatches(
+			in: message, range: range, withTemplate: "sk-***REDACTED***")
 	}
 }
 

--- a/Whispera.xcodeproj/project.pbxproj
+++ b/Whispera.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		D6CLIENTSYNCGRP000000001 /* Client */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Client; sourceTree = "<group>"; };
 		D63850CC2E179188000FD465 /* WhisperaUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WhisperaUITests; sourceTree = "<group>"; };
 		D63850DF2E1791AF000FD465 /* WhisperaUnitTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WhisperaUnitTests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -224,6 +225,7 @@
 				D6077E972DF10E77009E7404 /* Assets.xcassets */,
 				D63850CC2E179188000FD465 /* WhisperaUITests */,
 				D63850DF2E1791AF000FD465 /* WhisperaUnitTests */,
+				D6CLIENTSYNCGRP000000001 /* Client */,
 				8A8A8A8A8A8A8A8A8A8A8A8A /* Products */,
 				2A2A2A2A2A2A2A2A2A2A2A2A /* WhisperaApp.swift */,
 				D6B81FB52DEFFE4000D32F2A /* RecordingIndicator.swift */,
@@ -385,6 +387,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				D6CLIENTSYNCGRP000000001 /* Client */,
 			);
 			name = Whispera;
 			productName = MacWhisper;

--- a/WhisperaUnitTests/ByokKeyStoreTests.swift
+++ b/WhisperaUnitTests/ByokKeyStoreTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+struct ByokKeyStoreTests {
+
+	/// A keychain store scoped to a unique service so parallel tests never collide
+	/// and never touch the user's real BYOK keys.
+	private func isolatedStore() -> ByokKeyStore {
+		ByokKeyStore(service: "com.whispera.byok.test.\(UUID().uuidString)")
+	}
+
+	@Test func saveThenLoadRoundTrips() throws {
+		let store = isolatedStore()
+		defer { try? store.delete(provider: .openai) }
+
+		try store.save(provider: .openai, key: "sk-test-roundtrip-1234567890")
+		#expect(try store.load(provider: .openai) == "sk-test-roundtrip-1234567890")
+	}
+
+	@Test func saveOverwritesExistingKey() throws {
+		let store = isolatedStore()
+		defer { try? store.delete(provider: .openai) }
+
+		try store.save(provider: .openai, key: "first")
+		try store.save(provider: .openai, key: "second")
+		#expect(try store.load(provider: .openai) == "second")
+	}
+
+	@Test func loadMissingReturnsNil() throws {
+		let store = isolatedStore()
+		#expect(try store.load(provider: .anthropic) == nil)
+	}
+
+	@Test func deleteRemovesKey() throws {
+		let store = isolatedStore()
+		try store.save(provider: .openai, key: "to-delete")
+		try store.delete(provider: .openai)
+		#expect(try store.load(provider: .openai) == nil)
+	}
+
+	@Test func deleteMissingDoesNotThrow() throws {
+		let store = isolatedStore()
+		#expect(throws: Never.self) { try store.delete(provider: .anthropic) }
+	}
+
+	@Test func providersListsStoredWithoutLoadingMaterial() throws {
+		let store = isolatedStore()
+		defer {
+			try? store.delete(provider: .openai)
+			try? store.delete(provider: .anthropic)
+		}
+
+		#expect(try store.providers().isEmpty)
+		try store.save(provider: .openai, key: "sk-openai")
+		try store.save(provider: .anthropic, key: "sk-ant-anthropic")
+
+		let providers = try store.providers()
+		#expect(Set(providers) == Set([.openai, .anthropic]))
+	}
+}
+
+struct LogRedactorTests {
+
+	@Test func redactsOpenAIStyleKey() {
+		let redacted = LogRedactor.redact("using key sk-proj-abcdefghij1234567890XYZ now")
+		#expect(!redacted.contains("abcdefghij1234567890"))
+		#expect(redacted.contains("REDACTED"))
+	}
+
+	@Test func redactsAnthropicStyleKey() {
+		let redacted = LogRedactor.redact("key=sk-ant-api03-abcdefghijklmnop1234567890")
+		#expect(!redacted.contains("abcdefghijklmnop"))
+	}
+
+	@Test func leavesNormalTextUntouched() {
+		let message = "recipe executed in 240ms, output 42 chars"
+		#expect(LogRedactor.redact(message) == message)
+	}
+}


### PR DESCRIPTION
## WHI-40 — macOS Keychain BYOK storage

First PR in the dictation→recipe-execution client stack.

### What
- `Client/ByokKeyStore.swift`: stores OpenAI/Anthropic API keys in the macOS Keychain.
  - Service `com.whispera.byok`, one item per provider (`openai`/`anthropic`).
  - `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` → never syncs to iCloud, never restores to another device.
  - API: `save / load / delete / providers()` — `providers()` lists stored keys without loading material.
  - Delete-then-add on save keeps the accessibility flag authoritative.
- `LogRedactor` in `AppLogger`: every log message is scrubbed of `sk-[A-Za-z0-9-_]{20,}` defensively.
- Registers a synchronized `Client/` source group so later stacked PRs add files without pbxproj churn.

### Hard rules honored
- Keys read at request time, never persisted to UserDefaults / app-support / logs.
- Backend `/auth/api-keys` (server-side key storage) is intentionally NOT used here.

### Verification
- `xcodebuild build` clean; `swift-format lint` clean.
- 9 unit tests pass (`ByokKeyStoreTests`, `LogRedactorTests`) — round-trip, overwrite, missing, delete, `providers()` without load, redaction.
- The `Early unexpected exit ... bootstrapping` harness flake is pre-existing and unrelated.

Stack base: `main`.