### PR TITLE
feat(client): Whispera API client + account auth (WHI-24/45)

### DIFF
--- a/Client/AccountSettingsView.swift
+++ b/Client/AccountSettingsView.swift
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import SwiftUI
+
+/// Settings tab for connecting the Mac client to the Whispera backend and
+/// signing in for Subscription mode. See WHI-24 / WHI-45.
+struct AccountSettingsView: View {
+	@State private var auth = AuthManager.shared
+	@AppStorage("whisperaServerURL") private var serverURL = WhisperaSettings.defaultServerURL
+	@State private var token = ""
+
+	var body: some View {
+		ScrollView {
+			VStack(spacing: 24) {
+				SettingsSection("Whispera Server") {
+					VStack(alignment: .leading, spacing: 8) {
+						Text("Server URL")
+							.font(.subheadline)
+						TextField(WhisperaSettings.defaultServerURL, text: $serverURL)
+							.textFieldStyle(.roundedBorder)
+							.autocorrectionDisabled()
+						Text("Used for Subscription and BYOK recipe execution. Local mode needs no server.")
+							.font(.caption)
+							.foregroundColor(.secondary)
+					}
+				}
+
+				SettingsSection("Account") {
+					if auth.isSignedIn {
+						signedInView
+					} else {
+						signedOutView
+					}
+
+					if let error = auth.lastError {
+						Text(error)
+							.font(.caption)
+							.foregroundColor(.red)
+							.frame(maxWidth: .infinity, alignment: .leading)
+					}
+				}
+			}
+			.padding(20)
+		}
+		.task { await auth.refresh() }
+	}
+
+	private var signedInView: some View {
+		HStack {
+			VStack(alignment: .leading, spacing: 2) {
+				Text("Signed in as")
+					.font(.caption)
+					.foregroundColor(.secondary)
+				Text(auth.displayName)
+					.font(.headline)
+			}
+			Spacer()
+			Button("Sign Out") { auth.signOut() }
+		}
+	}
+
+	private var signedOutView: some View {
+		VStack(alignment: .leading, spacing: 12) {
+			Button {
+				Task { await auth.signInWithClerk() }
+			} label: {
+				Label("Sign in with Clerk", systemImage: "person.crop.circle")
+			}
+			.buttonStyle(.borderedProminent)
+			.disabled(auth.isWorking)
+
+			Divider()
+
+			VStack(alignment: .leading, spacing: 6) {
+				Text("Developer token")
+					.font(.subheadline)
+				Text("Paste a Clerk session token, or any opaque token when the backend runs in test mode.")
+					.font(.caption)
+					.foregroundColor(.secondary)
+				HStack {
+					SecureField("token", text: $token)
+						.textFieldStyle(.roundedBorder)
+					Button("Verify & Sign In") {
+						Task {
+							await auth.signIn(token: token)
+							if auth.isSignedIn { token = "" }
+						}
+					}
+					.disabled(auth.isWorking || token.isEmpty)
+				}
+				if auth.isWorking {
+					ProgressView().scaleEffect(0.7)
+				}
+			}
+		}
+	}
+}

--- a/Client/AuthManager.swift
+++ b/Client/AuthManager.swift
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import SwiftUI
+
+/// Owns the signed-in state for Subscription mode. Sign-in is required ONLY for
+/// Subscription mode — Local and BYOK modes work without an account. See WHI-45.
+@MainActor
+@Observable
+final class AuthManager {
+	static let shared = AuthManager()
+
+	private(set) var isWorking = false
+	private(set) var isSignedIn = false
+	private(set) var user: WhisperaUser?
+	var lastError: String?
+
+	private let api: WhisperaAPIClient
+	private let tokenStore: AuthTokenStore
+
+	init(api: WhisperaAPIClient = .shared, tokenStore: AuthTokenStore = .shared) {
+		self.api = api
+		self.tokenStore = tokenStore
+	}
+
+	var displayName: String {
+		user?.email ?? user?.name ?? user?.clerkId ?? "Signed in"
+	}
+
+	/// Saves a token (Clerk JWT or dev token) and verifies it against /auth/me.
+	/// Reverts the stored token if verification fails so we never persist a bad one.
+	func signIn(token: String) async {
+		let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard !trimmed.isEmpty else {
+			lastError = "Enter a token first"
+			return
+		}
+
+		isWorking = true
+		lastError = nil
+		defer { isWorking = false }
+
+		do {
+			try tokenStore.save(trimmed)
+			let me = try await api.getMe()
+			user = me
+			isSignedIn = true
+		} catch {
+			try? tokenStore.delete()
+			isSignedIn = false
+			user = nil
+			lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+		}
+	}
+
+	/// Re-checks an existing stored token on launch. Silently signs out on 401.
+	func refresh() async {
+		guard let token = try? tokenStore.load(), !token.isEmpty else {
+			isSignedIn = false
+			user = nil
+			return
+		}
+		_ = token
+		do {
+			user = try await api.getMe()
+			isSignedIn = true
+		} catch WhisperaAPIError.http(let status, _) where status == 401 {
+			signOut()
+		} catch {
+			// Network blip — keep the stored token, just report unknown status.
+			lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+		}
+	}
+
+	func signOut() {
+		try? tokenStore.delete()
+		isSignedIn = false
+		user = nil
+		lastError = nil
+	}
+
+	// ponytail: native Clerk sign-in (Clerk Swift SDK / hosted WebView) is deferred
+	// until a Clerk app + publishable key exist to test against. The dev-token path
+	// above covers Subscription-mode development today (backend NODE_ENV=test). WHI-45.
+	func signInWithClerk() async {
+		lastError = "Clerk sign-in isn't wired yet — use a token for now."
+	}
+}

--- a/Client/AuthTokenStore.swift
+++ b/Client/AuthTokenStore.swift
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import Security
+
+/// Stores the Whispera auth token (Clerk session JWT or a dev token) in the
+/// Keychain with the same hygiene as BYOK keys: device-only, read at request
+/// time, dropped after use, never written to UserDefaults or logs. See WHI-45.
+struct AuthTokenStore {
+	static let shared = AuthTokenStore()
+
+	private let service: String
+	private let account = "session"
+
+	init(service: String = "com.whispera.clerk") {
+		self.service = service
+	}
+
+	func save(_ token: String) throws {
+		try? delete()
+		let query: [String: Any] = [
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecAttrAccount as String: account,
+			kSecValueData as String: Data(token.utf8),
+			kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+		]
+		let status = SecItemAdd(query as CFDictionary, nil)
+		guard status == errSecSuccess else { throw ByokKeyStoreError.unexpectedStatus(status) }
+	}
+
+	func load() throws -> String? {
+		let query: [String: Any] = [
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecAttrAccount as String: account,
+			kSecReturnData as String: true,
+			kSecMatchLimit as String: kSecMatchLimitOne,
+		]
+		var item: CFTypeRef?
+		let status = SecItemCopyMatching(query as CFDictionary, &item)
+		if status == errSecItemNotFound { return nil }
+		guard status == errSecSuccess else { throw ByokKeyStoreError.unexpectedStatus(status) }
+		guard let data = item as? Data else { return nil }
+		return String(data: data, encoding: .utf8)
+	}
+
+	func delete() throws {
+		let query: [String: Any] = [
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecAttrAccount as String: account,
+		]
+		let status = SecItemDelete(query as CFDictionary)
+		guard status == errSecSuccess || status == errSecItemNotFound else {
+			throw ByokKeyStoreError.unexpectedStatus(status)
+		}
+	}
+}

--- a/Client/WhisperaAPIClient.swift
+++ b/Client/WhisperaAPIClient.swift
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+struct WhisperaUser: Decodable, Sendable, Equatable {
+	let id: String
+	let clerkId: String
+	let email: String?
+	let name: String?
+}
+
+enum WhisperaAPIError: LocalizedError {
+	case invalidServerURL
+	case notAuthenticated
+	case http(status: Int, body: String)
+	case empty
+	case transport(Error)
+
+	var errorDescription: String? {
+		switch self {
+		case .invalidServerURL: return "Invalid Whispera server URL"
+		case .notAuthenticated: return "Not signed in"
+		case .http(let status, let body):
+			return "HTTP \(status)\(body.isEmpty ? "" : ": \(body)")"
+		case .empty: return "Server returned an empty response"
+		case .transport(let err): return "Network error: \(err.localizedDescription)"
+		}
+	}
+}
+
+/// Thin HTTP client for the Whispera backend.
+///
+/// The auth token and any BYOK provider key are read from the Keychain at
+/// request time and never cached on the instance. The base URL is read from
+/// `WhisperaSettings` per request so a settings change takes effect immediately.
+struct WhisperaAPIClient {
+	static let shared = WhisperaAPIClient()
+
+	private let session: URLSession
+	private let tokenStore: AuthTokenStore
+	private let serverURLProvider: () -> URL?
+
+	private let encoder: JSONEncoder = {
+		let e = JSONEncoder()
+		return e
+	}()
+	private let decoder: JSONDecoder = {
+		let d = JSONDecoder()
+		return d
+	}()
+
+	init(
+		session: URLSession = .shared,
+		tokenStore: AuthTokenStore = .shared,
+		serverURLProvider: @escaping () -> URL? = { WhisperaSettings.serverURL }
+	) {
+		self.session = session
+		self.tokenStore = tokenStore
+		self.serverURLProvider = serverURLProvider
+	}
+
+	// MARK: - Endpoints
+
+	func getMe() async throws -> WhisperaUser {
+		try await get("/auth/me")
+	}
+
+	// MARK: - Generic verbs (reused by later PRs)
+
+	func get<T: Decodable>(_ path: String, providerKey: String? = nil) async throws -> T {
+		let data = try await perform(path: path, method: "GET", body: Optional<Data>.none, providerKey: providerKey)
+		return try decode(data)
+	}
+
+	func send<B: Encodable, T: Decodable>(
+		_ path: String, method: String, body: B, providerKey: String? = nil
+	) async throws -> T {
+		let data = try await perform(
+			path: path, method: method, body: try encoder.encode(body), providerKey: providerKey)
+		return try decode(data)
+	}
+
+	/// For requests whose response body we don't care about (e.g. DELETE 204).
+	func sendNoContent<B: Encodable>(
+		_ path: String, method: String, body: B?, providerKey: String? = nil
+	) async throws {
+		let encoded = try body.map { try encoder.encode($0) }
+		_ = try await perform(path: path, method: method, body: encoded, providerKey: providerKey)
+	}
+
+	// MARK: - Core
+
+	@discardableResult
+	private func perform(
+		path: String, method: String, body: Data?, providerKey: String?
+	) async throws -> Data {
+		guard let base = serverURLProvider() else { throw WhisperaAPIError.invalidServerURL }
+		guard let token = try? tokenStore.load(), !token.isEmpty else {
+			throw WhisperaAPIError.notAuthenticated
+		}
+
+		var request = URLRequest(url: base.appendingPathComponent(path))
+		request.httpMethod = method
+		request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+		request.setValue("application/json", forHTTPHeaderField: "Accept")
+		if let body {
+			request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+			request.httpBody = body
+		}
+		if let providerKey, !providerKey.isEmpty {
+			request.setValue(providerKey, forHTTPHeaderField: "X-Provider-Key")
+		}
+
+		let data: Data
+		let response: URLResponse
+		do {
+			(data, response) = try await session.data(for: request)
+		} catch {
+			throw WhisperaAPIError.transport(error)
+		}
+
+		guard let http = response as? HTTPURLResponse else { throw WhisperaAPIError.empty }
+		guard (200..<300).contains(http.statusCode) else {
+			throw WhisperaAPIError.http(
+				status: http.statusCode, body: String(data: data, encoding: .utf8) ?? "")
+		}
+		return data
+	}
+
+	private func decode<T: Decodable>(_ data: Data) throws -> T {
+		if T.self == EmptyResponse.self, let empty = EmptyResponse() as? T { return empty }
+		guard !data.isEmpty else { throw WhisperaAPIError.empty }
+		return try decoder.decode(T.self, from: data)
+	}
+}
+
+struct EmptyResponse: Decodable {}

--- a/Client/WhisperaSettings.swift
+++ b/Client/WhisperaSettings.swift
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// App-global client settings backed by UserDefaults. Secrets (auth token,
+/// BYOK keys) never live here — they go in the Keychain. See WHI-24/40/45.
+enum WhisperaSettings {
+	private static let defaults = UserDefaults.standard
+	private static let serverURLKey = "whisperaServerURL"
+
+	static let defaultServerURL = "http://localhost:3000"
+
+	static var serverURLString: String {
+		get { defaults.string(forKey: serverURLKey) ?? defaultServerURL }
+		set { defaults.set(newValue, forKey: serverURLKey) }
+	}
+
+	static var serverURL: URL? {
+		URL(string: serverURLString.trimmingCharacters(in: .whitespacesAndNewlines))
+	}
+}

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -575,6 +575,12 @@ struct SettingsView: View {
 				Label("General", systemImage: "gear")
 			}
 
+			// MARK: - Account Tab
+			AccountSettingsView()
+				.tabItem {
+					Label("Account", systemImage: "person.crop.circle")
+				}
+
 			// MARK: - Storage & Downloads Tab
 			ScrollView {
 				VStack(spacing: 24) {

--- a/WhisperaUnitTests/WhisperaAPIClientTests.swift
+++ b/WhisperaUnitTests/WhisperaAPIClientTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+/// Intercepts URLSession traffic so client tests never hit the network.
+final class MockURLProtocol: URLProtocol {
+	nonisolated(unsafe) static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
+	nonisolated(unsafe) static var lastRequest: URLRequest?
+
+	override class func canInit(with request: URLRequest) -> Bool { true }
+	override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+	override func startLoading() {
+		MockURLProtocol.lastRequest = request
+		guard let handler = MockURLProtocol.handler else {
+			client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+			return
+		}
+		let (response, data) = handler(request)
+		client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+		client?.urlProtocol(self, didLoad: data)
+		client?.urlProtocolDidFinishLoading(self)
+	}
+
+	override func stopLoading() {}
+}
+
+@Suite(.serialized)
+struct WhisperaAPIClientTests {
+
+	private func makeClient(service: String) -> (WhisperaAPIClient, AuthTokenStore) {
+		let config = URLSessionConfiguration.ephemeral
+		config.protocolClasses = [MockURLProtocol.self]
+		let session = URLSession(configuration: config)
+		let store = AuthTokenStore(service: service)
+		let client = WhisperaAPIClient(
+			session: session,
+			tokenStore: store,
+			serverURLProvider: { URL(string: "http://localhost:3000") })
+		return (client, store)
+	}
+
+	private func respond(_ status: Int, _ json: String) {
+		MockURLProtocol.handler = { request in
+			let response = HTTPURLResponse(
+				url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+			return (response, Data(json.utf8))
+		}
+	}
+
+	@Test func getMeSendsBearerAndDecodes() async throws {
+		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
+		let (client, store) = makeClient(service: service)
+		defer { try? store.delete() }
+		try store.save("devtoken123")
+		respond(200, #"{"id":"u1","clerkId":"devtoken123","email":"a@b.co","name":null}"#)
+
+		let user = try await client.getMe()
+		#expect(user.id == "u1")
+		#expect(user.email == "a@b.co")
+		#expect(MockURLProtocol.lastRequest?.url?.path == "/auth/me")
+		#expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer devtoken123")
+	}
+
+	@Test func providerKeyHeaderIsSetWhenProvided() async throws {
+		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
+		let (client, store) = makeClient(service: service)
+		defer { try? store.delete() }
+		try store.save("t")
+		respond(200, #"{"ok":true}"#)
+
+		let _: EmptyResponseProbe = try await client.get("/x", providerKey: "sk-byok-123")
+		#expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "X-Provider-Key") == "sk-byok-123")
+	}
+
+	@Test func missingTokenThrowsNotAuthenticated() async {
+		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
+		let (client, store) = makeClient(service: service)
+		try? store.delete()
+		await #expect(throws: WhisperaAPIError.self) { _ = try await client.getMe() }
+	}
+
+	@Test func httpErrorIsMapped() async throws {
+		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
+		let (client, store) = makeClient(service: service)
+		defer { try? store.delete() }
+		try store.save("t")
+		respond(401, #"{"error":"Unauthorized"}"#)
+
+		await #expect(throws: WhisperaAPIError.self) { _ = try await client.getMe() }
+	}
+}
+
+private struct EmptyResponseProbe: Decodable {
+	let ok: Bool
+}
+
+@MainActor
+@Suite(.serialized)
+struct AuthManagerTests {
+
+	private func makeAuth(service: String) -> (AuthManager, AuthTokenStore) {
+		let config = URLSessionConfiguration.ephemeral
+		config.protocolClasses = [MockURLProtocol.self]
+		let session = URLSession(configuration: config)
+		let store = AuthTokenStore(service: service)
+		let client = WhisperaAPIClient(
+			session: session,
+			tokenStore: store,
+			serverURLProvider: { URL(string: "http://localhost:3000") })
+		return (AuthManager(api: client, tokenStore: store), store)
+	}
+
+	@Test func signInSuccessStoresUser() async {
+		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
+		let (auth, store) = makeAuth(service: service)
+		defer { try? store.delete() }
+		MockURLProtocol.handler = { request in
+			let r = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+			return (r, Data(#"{"id":"u1","clerkId":"tok","email":"x@y.z","name":null}"#.utf8))
+		}
+
+		await auth.signIn(token: "tok")
+		#expect(auth.isSignedIn)
+		#expect(auth.user?.email == "x@y.z")
+		#expect((try? store.load()) == "tok")
+	}
+
+	@Test func signInFailureRevertsToken() async {
+		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
+		let (auth, store) = makeAuth(service: service)
+		defer { try? store.delete() }
+		MockURLProtocol.handler = { request in
+			let r = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+			return (r, Data(#"{"error":"Unauthorized"}"#.utf8))
+		}
+
+		await auth.signIn(token: "bad")
+		#expect(!auth.isSignedIn)
+		#expect((try? store.load()) == nil)
+		#expect(auth.lastError != nil)
+	}
+}

--- a/WhisperaUnitTests/WhisperaBackendE2ETests.swift
+++ b/WhisperaUnitTests/WhisperaBackendE2ETests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+/// Live integration tests against a locally-running whispera-backend.
+///
+/// Opt-in: only runs when `WHISPERA_E2E=1` so normal/CI runs stay offline.
+/// Start the backend first (NODE_ENV=test, port 3000) — see the project memory
+/// `whispera-client-e2e-env`.
+@Suite(.serialized, .enabled(if: ProcessInfo.processInfo.environment["WHISPERA_E2E"] == "1"))
+struct WhisperaBackendE2ETests {
+
+	private let baseURL = URL(string: "http://localhost:3000")!
+	private let devToken = "whisperae2e"
+
+	private func client(_ store: AuthTokenStore) -> WhisperaAPIClient {
+		WhisperaAPIClient(tokenStore: store, serverURLProvider: { self.baseURL })
+	}
+
+	@Test func authMeReturnsClerkIdForDevToken() async throws {
+		let store = AuthTokenStore(service: "com.whispera.clerk.e2e.\(UUID().uuidString)")
+		defer { try? store.delete() }
+		try store.save(devToken)
+
+		let user = try await client(store).getMe()
+		#expect(user.clerkId == devToken)
+	}
+}


### PR DESCRIPTION
## WHI-24 + WHI-45 — API connection settings & auth

Stacked on #46 (WHI-40 Keychain). Base branch: `ismatulla/whi-40-keychain-byok`.

### What
- `WhisperaAPIClient`: Bearer auth + optional `X-Provider-Key`; base URL from settings; token read from Keychain per request (never cached). Generic `get/send/sendNoContent` reused by later PRs; `getMe()`.
- `AuthTokenStore`: Keychain storage for the session/dev token (`com.whispera.clerk`, device-only).
- `AuthManager` (`@Observable`): `signIn(token:)` verifies via `/auth/me`, reverts on failure; `refresh()` re-checks on launch, signs out on 401; `signOut()`.
- `WhisperaSettings`: server URL (default `http://localhost:3000`).
- Account settings tab: server URL, dev-token sign-in, signed-in status/sign-out, Clerk sign-in scaffold.

### Auth notes
- Dev-token path works against backend `NODE_ENV=test`, unblocking Subscription-mode dev now.
- Native Clerk sign-in deferred (`ponytail:` comment) until a Clerk app + key exist to test.

### Verification
- Build + `swift-format lint` clean.
- 6 mocked-`URLProtocol` unit tests + **live E2E** against the running backend (`/auth/me` returns the dev-token clerkId). All green.