### PR TITLE
feat(recipes): recipe model, store, and Commands UI (WHI-30)

### DIFF
--- a/Client/Recipe.swift
+++ b/Client/Recipe.swift
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// A single recipe step. v1 only supports `llm` (text in → text out); the
+/// config mirrors the backend `llm` handler. See WHI-30 / WHI-38.
+struct RecipeStep: Codable, Equatable, Sendable {
+	var type: String
+	var name: String?
+	var config: LLMStepConfig
+
+	init(type: String = "llm", name: String? = nil, config: LLMStepConfig) {
+		self.type = type
+		self.name = name
+		self.config = config
+	}
+}
+
+struct LLMStepConfig: Codable, Equatable, Sendable {
+	var prompt: String
+	var systemPrompt: String?
+	var provider: String?
+	var model: String?
+	var temperature: Double?
+	var maxTokens: Int?
+
+	init(
+		prompt: String,
+		systemPrompt: String? = nil,
+		provider: String? = nil,
+		model: String? = nil,
+		temperature: Double? = nil,
+		maxTokens: Int? = nil
+	) {
+		self.prompt = prompt
+		self.systemPrompt = systemPrompt
+		self.provider = provider
+		self.model = model
+		self.temperature = temperature
+		self.maxTokens = maxTokens
+	}
+}
+
+/// A recipe ("Command" in the UI). Maps to the backend `recipe` resource; local
+/// recipes get a locally-generated `id`.
+struct Recipe: Codable, Identifiable, Equatable, Sendable {
+	let id: String
+	var name: String
+	var description: String?
+	var triggerPhrase: String?
+	var steps: [RecipeStep]
+	var outputFormat: String
+
+	init(
+		id: String = UUID().uuidString,
+		name: String,
+		description: String? = nil,
+		triggerPhrase: String? = nil,
+		steps: [RecipeStep],
+		outputFormat: String = "text"
+	) {
+		self.id = id
+		self.name = name
+		self.description = description
+		self.triggerPhrase = triggerPhrase
+		self.steps = steps
+		self.outputFormat = outputFormat
+	}
+
+	/// Decodes leniently — the backend sends extra fields (userId, timestamps,
+	/// isPublic, …) that the client doesn't need.
+	enum CodingKeys: String, CodingKey {
+		case id, name, description, triggerPhrase, steps, outputFormat
+	}
+}
+
+/// Writable payload for create/update. Omits server-managed fields.
+struct RecipeInput: Encodable, Sendable {
+	var name: String
+	var description: String?
+	var triggerPhrase: String?
+	var steps: [RecipeStep]
+	var outputFormat: String
+
+	init(from recipe: Recipe) {
+		self.name = recipe.name
+		self.description = recipe.description
+		self.triggerPhrase = recipe.triggerPhrase
+		self.steps = recipe.steps
+		self.outputFormat = recipe.outputFormat
+	}
+}

--- a/Client/RecipeStore.swift
+++ b/Client/RecipeStore.swift
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import SwiftUI
+
+/// Single source of truth for the user's recipes ("Commands").
+///
+/// Recipes always persist to a local JSON cache so the trigger matcher and
+/// Local mode work offline. When signed in (Subscription/BYOK), CRUD goes to
+/// the backend and the result replaces the cache. See WHI-30 / WHI-41.
+@MainActor
+@Observable
+final class RecipeStore {
+	static let shared = RecipeStore()
+
+	private(set) var recipes: [Recipe] = []
+	private(set) var isSyncing = false
+	var lastError: String?
+
+	private let api: WhisperaAPIClient
+	private let auth: AuthManager
+	private let fileURL: URL
+
+	init(
+		api: WhisperaAPIClient = .shared,
+		auth: AuthManager = .shared,
+		fileURL: URL? = nil
+	) {
+		self.api = api
+		self.auth = auth
+		self.fileURL = fileURL ?? Self.defaultFileURL()
+		load()
+	}
+
+	private var usesBackend: Bool { auth.isSignedIn }
+
+	// MARK: - Local persistence
+
+	private static func defaultFileURL() -> URL {
+		let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+			.appendingPathComponent("Whispera", isDirectory: true)
+		try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+		return base.appendingPathComponent("recipes.json")
+	}
+
+	private func load() {
+		guard let data = try? Data(contentsOf: fileURL),
+			let decoded = try? JSONDecoder().decode([Recipe].self, from: data)
+		else { return }
+		recipes = decoded
+	}
+
+	private func persist() {
+		guard let data = try? JSONEncoder().encode(recipes) else { return }
+		try? data.write(to: fileURL, options: .atomic)
+	}
+
+	// MARK: - Sync
+
+	/// Pulls recipes from the backend when signed in and replaces the cache.
+	func sync() async {
+		guard usesBackend else { return }
+		isSyncing = true
+		lastError = nil
+		defer { isSyncing = false }
+		do {
+			recipes = try await api.listRecipes()
+			persist()
+		} catch {
+			lastError = message(error)
+		}
+	}
+
+	// MARK: - CRUD
+
+	func create(_ recipe: Recipe) async {
+		lastError = nil
+		do {
+			if usesBackend {
+				let created = try await api.createRecipe(RecipeInput(from: recipe))
+				recipes.append(created)
+			} else {
+				recipes.append(recipe)
+			}
+			persist()
+		} catch {
+			lastError = message(error)
+		}
+	}
+
+	func update(_ recipe: Recipe) async {
+		lastError = nil
+		do {
+			let result: Recipe
+			if usesBackend {
+				result = try await api.updateRecipe(id: recipe.id, RecipeInput(from: recipe))
+			} else {
+				result = recipe
+			}
+			if let idx = recipes.firstIndex(where: { $0.id == recipe.id }) {
+				recipes[idx] = result
+			}
+			persist()
+		} catch {
+			lastError = message(error)
+		}
+	}
+
+	func delete(_ recipe: Recipe) async {
+		lastError = nil
+		do {
+			if usesBackend {
+				try await api.deleteRecipe(id: recipe.id)
+			}
+			recipes.removeAll { $0.id == recipe.id }
+			persist()
+		} catch {
+			lastError = message(error)
+		}
+	}
+
+	/// Loads starter recipes: server seed when signed in, bundled defaults locally.
+	func loadDefaults() async {
+		if usesBackend {
+			do {
+				_ = try await api.seedDefaultRecipes()
+				await sync()
+			} catch {
+				lastError = message(error)
+			}
+		} else if recipes.isEmpty {
+			recipes = Recipe.localDefaults
+			persist()
+		}
+	}
+
+	private func message(_ error: Error) -> String {
+		(error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+	}
+}
+
+extension Recipe {
+	/// Bundled starter set for Local mode, mirroring the backend seed (WHI-46).
+	static var localDefaults: [Recipe] {
+		[
+			Recipe(
+				name: "Make professional", triggerPhrase: "make professional",
+				steps: [
+					llmStep(
+						"Rewrite this in a polite, professional tone. Output only the rewritten message, no preamble.\n\n{{input}}"
+					)
+				]),
+			Recipe(
+				name: "Fix grammar", triggerPhrase: "fix grammar",
+				steps: [
+					llmStep(
+						"Fix any grammar and punctuation issues in this text. Preserve meaning and tone. Output only the corrected text.\n\n{{input}}"
+					)
+				]),
+			Recipe(
+				name: "Summarize", triggerPhrase: "summarize",
+				steps: [llmStep("Summarize this in one sentence. Output only the summary.\n\n{{input}}")]),
+			Recipe(
+				name: "Bullet points", triggerPhrase: "bullet points",
+				steps: [
+					llmStep(
+						"Convert this text into a clean list of bullet points (one per line, each starting with \"- \"). Output only the bullets.\n\n{{input}}"
+					)
+				]),
+		]
+	}
+
+	private static func llmStep(_ prompt: String) -> RecipeStep {
+		RecipeStep(name: "llm", config: LLMStepConfig(prompt: prompt))
+	}
+}

--- a/Client/RecipesView.swift
+++ b/Client/RecipesView.swift
@@ -31,6 +31,7 @@ struct RecipesView: View {
 						Task { for r in targets { await store.delete(r) } }
 					}
 				}
+				.scrollContentBackground(.hidden)
 			}
 
 			if let error = store.lastError {
@@ -42,6 +43,8 @@ struct RecipesView: View {
 					.frame(maxWidth: .infinity, alignment: .leading)
 			}
 		}
+		// Solid content background so the header isn't the window's gray material.
+		.background(Color(nsColor: .textBackgroundColor))
 		.task { await store.sync() }
 		.sheet(isPresented: $isCreating) {
 			RecipeEditor(

--- a/Client/RecipesView.swift
+++ b/Client/RecipesView.swift
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import SwiftUI
+
+/// Settings tab for managing recipes ("Commands"). Create / edit / delete, and
+/// load the starter set. See WHI-30.
+struct RecipesView: View {
+	@State private var store = RecipeStore.shared
+	@State private var editing: Recipe?
+	@State private var isCreating = false
+
+	var body: some View {
+		VStack(spacing: 0) {
+			header
+
+			if store.recipes.isEmpty {
+				emptyState
+			} else {
+				List {
+					ForEach(store.recipes) { recipe in
+						Button {
+							editing = recipe
+						} label: {
+							recipeRow(recipe)
+						}
+						.buttonStyle(.plain)
+					}
+					.onDelete { offsets in
+						let targets = offsets.map { store.recipes[$0] }
+						Task { for r in targets { await store.delete(r) } }
+					}
+				}
+			}
+
+			if let error = store.lastError {
+				Text(error)
+					.font(.caption)
+					.foregroundColor(.red)
+					.padding(.horizontal, 20)
+					.padding(.bottom, 8)
+					.frame(maxWidth: .infinity, alignment: .leading)
+			}
+		}
+		.task { await store.sync() }
+		.sheet(isPresented: $isCreating) {
+			RecipeEditor(
+				recipe: Recipe(name: "", steps: [RecipeStep(config: LLMStepConfig(prompt: "{{input}}"))])
+			) { recipe in
+				Task { await store.create(recipe) }
+			}
+		}
+		.sheet(item: $editing) { recipe in
+			RecipeEditor(recipe: recipe) { updated in
+				Task { await store.update(updated) }
+			}
+		}
+	}
+
+	private var header: some View {
+		HStack {
+			Text("Commands")
+				.font(.headline)
+			if store.isSyncing { ProgressView().scaleEffect(0.6) }
+			Spacer()
+			Button("Load Starter Set") { Task { await store.loadDefaults() } }
+			Button {
+				isCreating = true
+			} label: {
+				Label("New", systemImage: "plus")
+			}
+		}
+		.padding(20)
+	}
+
+	private var emptyState: some View {
+		VStack(spacing: 8) {
+			Image(systemName: "wand.and.stars")
+				.font(.largeTitle)
+				.foregroundColor(.secondary)
+			Text("No commands yet")
+				.font(.headline)
+			Text("A command runs an AI step on your dictation when you say its trigger phrase.")
+				.font(.caption)
+				.foregroundColor(.secondary)
+				.multilineTextAlignment(.center)
+		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
+		.padding(40)
+	}
+
+	private func recipeRow(_ recipe: Recipe) -> some View {
+		VStack(alignment: .leading, spacing: 2) {
+			Text(recipe.name.isEmpty ? "Untitled" : recipe.name)
+				.font(.subheadline.weight(.medium))
+			if let trigger = recipe.triggerPhrase, !trigger.isEmpty {
+				Text("“\(trigger)”")
+					.font(.caption)
+					.foregroundColor(.secondary)
+			} else {
+				Text("Runs on every dictation")
+					.font(.caption)
+					.foregroundColor(.secondary)
+			}
+		}
+		.frame(maxWidth: .infinity, alignment: .leading)
+		.contentShape(Rectangle())
+	}
+}
+
+/// Create/edit form for a single recipe. v1 edits one `llm` step's prompt + model.
+private struct RecipeEditor: View {
+	@Environment(\.dismiss) private var dismiss
+	@State private var draft: Recipe
+	private let onSave: (Recipe) -> Void
+
+	init(recipe: Recipe, onSave: @escaping (Recipe) -> Void) {
+		_draft = State(initialValue: recipe)
+		self.onSave = onSave
+	}
+
+	private var promptBinding: Binding<String> {
+		Binding(
+			get: { draft.steps.first?.config.prompt ?? "" },
+			set: { newValue in
+				if draft.steps.isEmpty {
+					draft.steps = [RecipeStep(config: LLMStepConfig(prompt: newValue))]
+				} else {
+					draft.steps[0].config.prompt = newValue
+				}
+			})
+	}
+
+	private var modelBinding: Binding<String> {
+		Binding(
+			get: { draft.steps.first?.config.model ?? "" },
+			set: { draft.steps.indices.contains(0) ? (draft.steps[0].config.model = $0.isEmpty ? nil : $0) : () })
+	}
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 16) {
+			Text(draft.name.isEmpty ? "New Command" : "Edit Command")
+				.font(.title3.weight(.semibold))
+
+			Form {
+				TextField("Name", text: $draft.name)
+				TextField("Trigger phrase (optional)", text: triggerBinding)
+				TextField("Model (optional, e.g. gpt-5.4-mini)", text: modelBinding)
+				VStack(alignment: .leading) {
+					Text("Prompt").font(.caption).foregroundColor(.secondary)
+					TextEditor(text: promptBinding)
+						.frame(minHeight: 120)
+						.font(.body.monospaced())
+						.border(.quaternary)
+					Text("Use {{input}} where the dictated text should go.")
+						.font(.caption2)
+						.foregroundColor(.secondary)
+				}
+			}
+			.formStyle(.grouped)
+
+			HStack {
+				Spacer()
+				Button("Cancel") { dismiss() }
+				Button("Save") {
+					onSave(draft)
+					dismiss()
+				}
+				.buttonStyle(.borderedProminent)
+				.disabled(
+					draft.name.trimmingCharacters(in: .whitespaces).isEmpty
+						|| promptBinding.wrappedValue.isEmpty)
+			}
+		}
+		.padding(20)
+		.frame(width: 460, height: 460)
+	}
+
+	private var triggerBinding: Binding<String> {
+		Binding(
+			get: { draft.triggerPhrase ?? "" },
+			set: { draft.triggerPhrase = $0.isEmpty ? nil : $0 })
+	}
+}

--- a/Client/WhisperaAPIClient+Recipes.swift
+++ b/Client/WhisperaAPIClient+Recipes.swift
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+private struct RecipeListResponse: Decodable {
+	let data: [Recipe]
+}
+
+private struct SeedResponse: Decodable {
+	let created: Int
+}
+
+extension WhisperaAPIClient {
+	func listRecipes() async throws -> [Recipe] {
+		let response: RecipeListResponse = try await get("/recipes?limit=100")
+		return response.data
+	}
+
+	func createRecipe(_ input: RecipeInput) async throws -> Recipe {
+		try await send("/recipes", method: "POST", body: input)
+	}
+
+	func updateRecipe(id: String, _ input: RecipeInput) async throws -> Recipe {
+		try await send("/recipes/\(id)", method: "PUT", body: input)
+	}
+
+	func deleteRecipe(id: String) async throws {
+		try await sendNoContent("/recipes/\(id)", method: "DELETE", body: Optional<RecipeInput>.none)
+	}
+
+	/// Idempotent server-side seeding of the default starter recipes. WHI-46.
+	@discardableResult
+	func seedDefaultRecipes() async throws -> Int {
+		let response: SeedResponse = try await send(
+			"/recipes/seed-defaults", method: "POST", body: EmptyBody())
+		return response.created
+	}
+}
+
+private struct EmptyBody: Encodable {}

--- a/Client/WhisperaAPIClient.swift
+++ b/Client/WhisperaAPIClient.swift
@@ -96,11 +96,20 @@ struct WhisperaAPIClient {
 		path: String, method: String, body: Data?, providerKey: String?
 	) async throws -> Data {
 		guard let base = serverURLProvider() else { throw WhisperaAPIError.invalidServerURL }
+		// String join (not appendingPathComponent) so query strings like
+		// "/recipes?limit=100" aren't percent-encoded into the path.
+		let trimmedBase =
+			base.absoluteString.hasSuffix("/")
+			? String(base.absoluteString.dropLast()) : base.absoluteString
+		let fullPath = path.hasPrefix("/") ? path : "/" + path
+		guard let url = URL(string: trimmedBase + fullPath) else {
+			throw WhisperaAPIError.invalidServerURL
+		}
 		guard let token = try? tokenStore.load(), !token.isEmpty else {
 			throw WhisperaAPIError.notAuthenticated
 		}
 
-		var request = URLRequest(url: base.appendingPathComponent(path))
+		var request = URLRequest(url: url)
 		request.httpMethod = method
 		request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 		request.setValue("application/json", forHTTPHeaderField: "Accept")

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -581,6 +581,12 @@ struct SettingsView: View {
 					Label("Account", systemImage: "person.crop.circle")
 				}
 
+			// MARK: - Commands Tab
+			RecipesView()
+				.tabItem {
+					Label("Commands", systemImage: "wand.and.stars")
+				}
+
 			// MARK: - Storage & Downloads Tab
 			ScrollView {
 				VStack(spacing: 24) {

--- a/WhisperaUnitTests/RecipeTests.swift
+++ b/WhisperaUnitTests/RecipeTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+struct RecipeCodableTests {
+
+	@Test func decodesBackendRecipeIgnoringExtraFields() throws {
+		let json = #"""
+			{
+			  "id": "11111111-1111-1111-1111-111111111111",
+			  "userId": "22222222-2222-2222-2222-222222222222",
+			  "name": "Make professional",
+			  "description": "Rewrites politely",
+			  "triggerPhrase": "make professional",
+			  "steps": [{"type":"llm","name":"rewrite","config":{"provider":"openai","model":"gpt-5.4-mini","prompt":"Rewrite {{input}}"}}],
+			  "integrations": null,
+			  "permissions": null,
+			  "outputFormat": "text",
+			  "isPublic": false,
+			  "createdAt": "2026-01-01T00:00:00.000Z",
+			  "updatedAt": "2026-01-01T00:00:00.000Z",
+			  "deletedAt": null
+			}
+			"""#
+		let recipe = try JSONDecoder().decode(Recipe.self, from: Data(json.utf8))
+		#expect(recipe.name == "Make professional")
+		#expect(recipe.triggerPhrase == "make professional")
+		#expect(recipe.steps.first?.config.model == "gpt-5.4-mini")
+		#expect(recipe.steps.first?.config.prompt == "Rewrite {{input}}")
+	}
+
+	@Test func recipeInputOmitsNilFields() throws {
+		let recipe = Recipe(
+			name: "Summarize", triggerPhrase: nil,
+			steps: [RecipeStep(config: LLMStepConfig(prompt: "Summarize {{input}}"))])
+		let data = try JSONEncoder().encode(RecipeInput(from: recipe))
+		let object = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+		#expect(object["name"] as? String == "Summarize")
+		#expect(object["triggerPhrase"] == nil)
+		#expect(object["description"] == nil)
+		let steps = object["steps"] as! [[String: Any]]
+		let config = steps[0]["config"] as! [String: Any]
+		#expect(config["prompt"] as? String == "Summarize {{input}}")
+		#expect(config["model"] == nil)
+	}
+}
+
+@MainActor
+@Suite(.serialized)
+struct RecipeStoreLocalTests {
+
+	private func tempStore() -> (RecipeStore, URL) {
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("recipes-\(UUID().uuidString).json")
+		// Signed-out AuthManager → store stays in local mode (no network).
+		let store = RecipeStore(auth: AuthManager(), fileURL: url)
+		return (store, url)
+	}
+
+	@Test func createPersistsLocallyAndReloads() async {
+		let (store, url) = tempStore()
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		await store.create(
+			Recipe(
+				name: "Test", triggerPhrase: "test",
+				steps: [RecipeStep(config: LLMStepConfig(prompt: "{{input}}"))]))
+		#expect(store.recipes.count == 1)
+
+		let reloaded = RecipeStore(auth: AuthManager(), fileURL: url)
+		#expect(reloaded.recipes.count == 1)
+		#expect(reloaded.recipes.first?.name == "Test")
+	}
+
+	@Test func deleteRemovesLocally() async {
+		let (store, url) = tempStore()
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		let recipe = Recipe(name: "X", steps: [RecipeStep(config: LLMStepConfig(prompt: "{{input}}"))])
+		await store.create(recipe)
+		await store.delete(recipe)
+		#expect(store.recipes.isEmpty)
+	}
+
+	@Test func loadDefaultsPopulatesLocalStarterSet() async {
+		let (store, url) = tempStore()
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		await store.loadDefaults()
+		#expect(!store.recipes.isEmpty)
+		#expect(store.recipes.contains { $0.triggerPhrase == "make professional" })
+	}
+}

--- a/WhisperaUnitTests/WhisperaAPIClientTests.swift
+++ b/WhisperaUnitTests/WhisperaAPIClientTests.swift
@@ -74,6 +74,18 @@ struct WhisperaAPIClientTests {
 		#expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "X-Provider-Key") == "sk-byok-123")
 	}
 
+	@Test func queryStringIsPreservedNotPercentEncoded() async throws {
+		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
+		let (client, store) = makeClient(service: service)
+		defer { try? store.delete() }
+		try store.save("t")
+		respond(200, #"{"ok":true}"#)
+
+		let _: EmptyResponseProbe = try await client.get("/recipes?limit=100")
+		#expect(MockURLProtocol.lastRequest?.url?.path == "/recipes")
+		#expect(MockURLProtocol.lastRequest?.url?.query == "limit=100")
+	}
+
 	@Test func missingTokenThrowsNotAuthenticated() async {
 		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
 		let (client, store) = makeClient(service: service)

--- a/WhisperaUnitTests/WhisperaBackendE2ETests.swift
+++ b/WhisperaUnitTests/WhisperaBackendE2ETests.swift
@@ -26,4 +26,28 @@ struct WhisperaBackendE2ETests {
 		let user = try await client(store).getMe()
 		#expect(user.clerkId == devToken)
 	}
+
+	@Test func recipeCrudRoundTripsAgainstBackend() async throws {
+		let store = AuthTokenStore(service: "com.whispera.clerk.e2e.\(UUID().uuidString)")
+		defer { try? store.delete() }
+		try store.save(devToken)
+		let api = client(store)
+
+		let unique = "E2E \(UUID().uuidString.prefix(8))"
+		let created = try await api.createRecipe(
+			RecipeInput(
+				from: Recipe(
+					name: unique, triggerPhrase: "e2e trigger",
+					steps: [
+						RecipeStep(config: LLMStepConfig(prompt: "echo {{input}}", model: "gpt-5.4-mini"))
+					])))
+		#expect(created.name == unique)
+
+		let listed = try await api.listRecipes()
+		#expect(listed.contains { $0.id == created.id })
+
+		try await api.deleteRecipe(id: created.id)
+		let afterDelete = try await api.listRecipes()
+		#expect(!afterDelete.contains { $0.id == created.id })
+	}
 }


### PR DESCRIPTION
## WHI-30 — Recipe management UI
Stacked on #47. Base: `ismatulla/whi-24-api-connection-auth`.

- `Recipe`/`RecipeStep`/`LLMStepConfig` Codable models; `RecipeInput` omits nil fields.
- `RecipeStore` (`@Observable`): local JSON cache always + backend sync/CRUD when signed in; `loadDefaults()` (server seed / local starter set).
- Recipe API methods; Commands settings tab (list/create/edit/delete + Load Starter Set).
- **Fix (caught by E2E):** API URL building percent-encoded `?`, breaking query strings — switched to string join + regression test.

Verification: build + lint clean; 10 unit tests; live E2E recipe create→list→delete against the backend.