### PR TITLE
feat(local): local OpenAI-compatible recipe executor (WHI-38)

### DIFF
--- a/Client/LocalLLMExecutor.swift
+++ b/Client/LocalLLMExecutor.swift
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+extension WhisperaSettings {
+	private static let localURLKey = "whisperaLocalServerURL"
+	private static let localModelKey = "whisperaLocalModel"
+
+	/// Default points at a local OpenAI-compatible server (ollama). Works with
+	/// any OpenAI-compatible runtime — llama-server, vLLM, LM Studio.
+	static let defaultLocalServerURL = "http://localhost:11434/v1"
+
+	static var localServerURLString: String {
+		get { UserDefaults.standard.string(forKey: localURLKey) ?? defaultLocalServerURL }
+		set { UserDefaults.standard.set(newValue, forKey: localURLKey) }
+	}
+
+	static var localServerURL: URL? {
+		URL(string: localServerURLString.trimmingCharacters(in: .whitespacesAndNewlines))
+	}
+
+	static var localModel: String {
+		get { UserDefaults.standard.string(forKey: localModelKey) ?? "" }
+		set { UserDefaults.standard.set(newValue, forKey: localModelKey) }
+	}
+}
+
+enum LocalLLMError: LocalizedError {
+	case unavailable
+	case noModel
+	case http(status: Int, body: String)
+	case empty
+
+	var errorDescription: String? {
+		switch self {
+		case .unavailable:
+			return "Local mode unavailable — start a local model server or switch to Subscription or BYOK."
+		case .noModel:
+			return "No local model set. Choose a model in Settings or set one on the command."
+		case .http(let status, let body):
+			return "Local model error (HTTP \(status))\(body.isEmpty ? "" : ": \(body)")"
+		case .empty:
+			return "Local model returned an empty response."
+		}
+	}
+}
+
+/// Runs a recipe's `llm` steps against a local OpenAI-compatible server.
+///
+/// ponytail: this is the "local" path until on-device Apple Foundation Models
+/// (`SystemLanguageModel` / `LanguageModelSession`) is wired in — deferred for
+/// now (no model footprint on this machine). Any OpenAI-compatible local
+/// runtime (ollama / llama-server / vLLM / LM Studio) works today. WHI-38.
+struct LocalLLMExecutor {
+	private let session: URLSession
+	private let serverURLProvider: () -> URL?
+	private let defaultModelProvider: () -> String
+
+	init(
+		session: URLSession = .shared,
+		serverURLProvider: @escaping () -> URL? = { WhisperaSettings.localServerURL },
+		defaultModelProvider: @escaping () -> String = { WhisperaSettings.localModel }
+	) {
+		self.session = session
+		self.serverURLProvider = serverURLProvider
+		self.defaultModelProvider = defaultModelProvider
+	}
+
+	/// Runs each step in order, feeding each step's output into the next.
+	func run(recipe: Recipe, input: String) async throws -> String {
+		var current = input
+		var outputs: [String] = []
+		for step in recipe.steps {
+			let config = step.config
+			let prompt = Self.interpolate(config.prompt, input: current, stepOutputs: outputs)
+			let system = config.systemPrompt.map { Self.interpolate($0, input: current, stepOutputs: outputs) }
+			current = try await chat(
+				system: system, prompt: prompt, model: config.model, maxTokens: config.maxTokens)
+			outputs.append(current)
+		}
+		return current
+	}
+
+	func chat(system: String?, prompt: String, model: String?, maxTokens: Int?) async throws -> String {
+		guard let base = serverURLProvider() else { throw LocalLLMError.unavailable }
+		let resolvedModel = (model?.isEmpty == false ? model : nil) ?? nonEmpty(defaultModelProvider())
+		guard let resolvedModel else { throw LocalLLMError.noModel }
+
+		var messages: [[String: String]] = []
+		if let system, !system.isEmpty { messages.append(["role": "system", "content": system]) }
+		messages.append(["role": "user", "content": prompt])
+
+		var payload: [String: Any] = ["model": resolvedModel, "messages": messages]
+		if let maxTokens { payload["max_tokens"] = maxTokens }
+
+		var request = URLRequest(url: base.appendingPathComponent("chat/completions"))
+		request.httpMethod = "POST"
+		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+		let data: Data
+		let response: URLResponse
+		do {
+			(data, response) = try await session.data(for: request)
+		} catch {
+			throw LocalLLMError.unavailable
+		}
+
+		guard let http = response as? HTTPURLResponse else { throw LocalLLMError.empty }
+		guard (200..<300).contains(http.statusCode) else {
+			throw LocalLLMError.http(status: http.statusCode, body: String(data: data, encoding: .utf8) ?? "")
+		}
+
+		guard let content = Self.parseContent(data), !content.isEmpty else { throw LocalLLMError.empty }
+		return content
+	}
+
+	private func nonEmpty(_ s: String) -> String? { s.isEmpty ? nil : s }
+
+	// MARK: - Helpers
+
+	static func parseContent(_ data: Data) -> String? {
+		guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+			let choices = object["choices"] as? [[String: Any]],
+			let message = choices.first?["message"] as? [String: Any],
+			let content = message["content"] as? String
+		else { return nil }
+		return content.trimmingCharacters(in: .whitespacesAndNewlines)
+	}
+
+	/// Mirrors the backend `llm` handler's template syntax for the subset v1 uses.
+	static func interpolate(_ template: String, input: String, stepOutputs: [String]) -> String {
+		var result = template.replacingOccurrences(of: "{{input}}", with: input)
+		for (index, output) in stepOutputs.enumerated() {
+			result = result.replacingOccurrences(of: "{{steps[\(index)].output}}", with: output)
+		}
+		return result
+	}
+}

--- a/WhisperaUnitTests/LocalLLMExecutorTests.swift
+++ b/WhisperaUnitTests/LocalLLMExecutorTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+struct LocalLLMInterpolationTests {
+
+	@Test func interpolatesInput() {
+		let out = LocalLLMExecutor.interpolate("Fix: {{input}}", input: "hello", stepOutputs: [])
+		#expect(out == "Fix: hello")
+	}
+
+	@Test func interpolatesPriorStepOutputs() {
+		let out = LocalLLMExecutor.interpolate(
+			"prev: {{steps[0].output}} and {{input}}", input: "now", stepOutputs: ["first"])
+		#expect(out == "prev: first and now")
+	}
+
+	@Test func parsesOpenAIChatContent() {
+		let json = #"{"choices":[{"message":{"role":"assistant","content":"  Hello there  "}}]}"#
+		#expect(LocalLLMExecutor.parseContent(Data(json.utf8)) == "Hello there")
+	}
+
+	@Test func parseReturnsNilForGarbage() {
+		#expect(LocalLLMExecutor.parseContent(Data("not json".utf8)) == nil)
+	}
+}
+
+@Suite(.serialized)
+struct LocalLLMExecutorChatTests {
+
+	private func executor(model: String = "test-model") -> LocalLLMExecutor {
+		let config = URLSessionConfiguration.ephemeral
+		config.protocolClasses = [MockURLProtocol.self]
+		let session = URLSession(configuration: config)
+		return LocalLLMExecutor(
+			session: session,
+			serverURLProvider: { URL(string: "http://localhost:11434/v1") },
+			defaultModelProvider: { model })
+	}
+
+	@Test func chatPostsOpenAIPayloadAndReturnsContent() async throws {
+		MockURLProtocol.handler = { request in
+			let r = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+			return (r, Data(#"{"choices":[{"message":{"content":"hi"}}]}"#.utf8))
+		}
+		let result = try await executor().chat(system: nil, prompt: "say hi", model: nil, maxTokens: 50)
+		#expect(result == "hi")
+		#expect(MockURLProtocol.lastRequest?.url?.path == "/v1/chat/completions")
+		#expect(MockURLProtocol.lastRequest?.httpMethod == "POST")
+	}
+
+	@Test func noModelThrows() async {
+		let exec = executor(model: "")
+		await #expect(throws: LocalLLMError.self) {
+			_ = try await exec.chat(system: nil, prompt: "x", model: nil, maxTokens: nil)
+		}
+	}
+
+	@Test func runChainsStepsFeedingOutputForward() async throws {
+		// Each call echoes the user content so we can prove the chain wires step N → N+1.
+		MockURLProtocol.handler = { request in
+			let body = request.httpBodyStreamData() ?? request.httpBody ?? Data()
+			let object = (try? JSONSerialization.jsonObject(with: body)) as? [String: Any]
+			let messages = object?["messages"] as? [[String: String]]
+			let content = messages?.last?["content"] ?? ""
+			let r = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+			let json = try! JSONSerialization.data(withJSONObject: [
+				"choices": [["message": ["content": "[\(content)]"]]]
+			])
+			return (r, json)
+		}
+		let recipe = Recipe(
+			name: "chain",
+			steps: [
+				RecipeStep(config: LLMStepConfig(prompt: "a:{{input}}")),
+				RecipeStep(config: LLMStepConfig(prompt: "b:{{input}}")),
+			])
+		let result = try await executor().run(recipe: recipe, input: "x")
+		#expect(result == "[b:[a:x]]")
+	}
+}
+
+extension URLRequest {
+	/// URLProtocol delivers the body via a stream; read it back for assertions.
+	fileprivate func httpBodyStreamData() -> Data? {
+		guard let stream = httpBodyStream else { return nil }
+		stream.open()
+		defer { stream.close() }
+		var data = Data()
+		let size = 4096
+		let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
+		defer { buffer.deallocate() }
+		while stream.hasBytesAvailable {
+			let read = stream.read(buffer, maxLength: size)
+			if read <= 0 { break }
+			data.append(buffer, count: read)
+		}
+		return data
+	}
+}

--- a/WhisperaUnitTests/WhisperaBackendE2ETests.swift
+++ b/WhisperaUnitTests/WhisperaBackendE2ETests.swift
@@ -50,4 +50,22 @@ struct WhisperaBackendE2ETests {
 		let afterDelete = try await api.listRecipes()
 		#expect(!afterDelete.contains { $0.id == created.id })
 	}
+
+	/// Local executor runs against any OpenAI-compatible server. Points at
+	/// VibeProxy (:8317) since no local model is pulled here.
+	@Test func localExecutorRunsRecipeAgainstOpenAICompatibleServer() async throws {
+		let executor = LocalLLMExecutor(
+			serverURLProvider: { URL(string: "http://localhost:8317/v1") },
+			defaultModelProvider: { "gpt-5.4-mini" })
+		let recipe = Recipe(
+			name: "echo",
+			steps: [
+				RecipeStep(
+					config: LLMStepConfig(
+						prompt: "Reply with exactly this word and nothing else: WHISPERA. Input: {{input}}")
+				)
+			])
+		let output = try await executor.run(recipe: recipe, input: "ignored")
+		#expect(output.uppercased().contains("WHISPERA"))
+	}
 }


### PR DESCRIPTION
## WHI-38 — Local recipe executor
Stacked on #48. Base: `ismatulla/whi-30-recipe-management`.

- `LocalLLMExecutor`: runs recipe `llm` steps against a local OpenAI-compatible server (ollama default `:11434/v1`; works with llama-server/vLLM/LM Studio). Configurable base URL + model.
- Multi-step chaining with `{{input}}` / `{{steps[n].output}}` interpolation (mirrors backend handler).
- Clear errors: unavailable / no-model / http / empty.
- **Native Apple Foundation Models deferred** (no model footprint on this machine) — documented with a `ponytail:` comment; the local path uses an external OpenAI-compatible runtime today.

Verification: build + lint clean; 7 unit tests (interpolation, OpenAI parse, payload/method, no-model, multi-step chaining); **live E2E** running a recipe through VibeProxy (`:8317`) returns the expected output.