### PR TITLE
feat(router): three-mode LLM routing — local/subscription/BYOK (WHI-39)

### DIFF
--- a/Client/LLMModeSettingsView.swift
+++ b/Client/LLMModeSettingsView.swift
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import SwiftUI
+
+/// Settings tab to pick where recipe LLM steps run (Local / Subscription / BYOK)
+/// and configure each mode. See WHI-39.
+struct LLMModeSettingsView: View {
+	@AppStorage("whisperaLLMMode") private var modeRaw = LLMMode.local.rawValue
+	@State private var auth = AuthManager.shared
+
+	private var mode: LLMMode { LLMMode(rawValue: modeRaw) ?? .local }
+
+	var body: some View {
+		ScrollView {
+			VStack(spacing: 24) {
+				SettingsSection("AI Mode") {
+					Picker("Run recipe steps using", selection: $modeRaw) {
+						ForEach(LLMMode.allCases, id: \.rawValue) { mode in
+							Text(mode.displayName).tag(mode.rawValue)
+						}
+					}
+					.pickerStyle(.segmented)
+				}
+
+				switch mode {
+				case .local: LocalModeConfig()
+				case .subscription: SubscriptionModeConfig(isSignedIn: auth.isSignedIn, name: auth.displayName)
+				case .byok: ByokModeConfig()
+				}
+			}
+			.padding(20)
+		}
+		.task { await auth.refresh() }
+	}
+}
+
+private struct LocalModeConfig: View {
+	@AppStorage("whisperaLocalServerURL") private var serverURL = WhisperaSettings.defaultLocalServerURL
+	@AppStorage("whisperaLocalModel") private var model = ""
+	@State private var testResult: String?
+	@State private var testing = false
+
+	var body: some View {
+		SettingsSection("Local Server") {
+			VStack(alignment: .leading, spacing: 10) {
+				Text(
+					"On-device / local OpenAI-compatible server (ollama, llama-server, vLLM, LM Studio). No account, no network beyond your machine."
+				)
+				.font(.caption)
+				.foregroundColor(.secondary)
+				TextField("http://localhost:11434/v1", text: $serverURL)
+					.textFieldStyle(.roundedBorder)
+					.autocorrectionDisabled()
+				TextField("Model (e.g. llama3.2)", text: $model)
+					.textFieldStyle(.roundedBorder)
+					.autocorrectionDisabled()
+				HStack {
+					Button("Test") { runTest() }
+						.disabled(testing)
+					if testing { ProgressView().scaleEffect(0.7) }
+					if let testResult {
+						Text(testResult)
+							.font(.caption)
+							.foregroundColor(testResult.hasPrefix("OK") ? .green : .red)
+							.lineLimit(2)
+					}
+				}
+			}
+		}
+	}
+
+	private func runTest() {
+		testing = true
+		testResult = nil
+		Task {
+			defer { testing = false }
+			do {
+				let reply = try await LocalLLMExecutor().chat(
+					system: nil, prompt: "Reply with the single word: OK", model: nil, maxTokens: 10)
+				testResult = "OK — \(reply.prefix(40))"
+			} catch {
+				testResult = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+			}
+		}
+	}
+}
+
+private struct SubscriptionModeConfig: View {
+	let isSignedIn: Bool
+	let name: String
+
+	var body: some View {
+		SettingsSection("Subscription") {
+			VStack(alignment: .leading, spacing: 6) {
+				if isSignedIn {
+					Label("Signed in as \(name)", systemImage: "checkmark.seal.fill")
+						.foregroundColor(.green)
+				} else {
+					Label("Not signed in", systemImage: "exclamationmark.triangle.fill")
+						.foregroundColor(.orange)
+					Text("Sign in from the Account tab to use Subscription mode.")
+						.font(.caption)
+						.foregroundColor(.secondary)
+				}
+				Text("Recipe steps run on Whispera's servers using our provider keys.")
+					.font(.caption)
+					.foregroundColor(.secondary)
+			}
+		}
+	}
+}
+
+private struct ByokModeConfig: View {
+	@State private var openaiKey = ""
+	@State private var anthropicKey = ""
+	@State private var savedProviders: Set<ProviderId> = []
+	@State private var status: String?
+
+	var body: some View {
+		SettingsSection("Bring Your Own Key") {
+			VStack(alignment: .leading, spacing: 12) {
+				Text(
+					"Your provider keys stay in the macOS Keychain and are sent only as the X-Provider-Key header on recipe execution. Requires a (free) signed-in account for the backend pass-through."
+				)
+				.font(.caption)
+				.foregroundColor(.secondary)
+
+				keyRow(provider: .openai, placeholder: "sk-...", text: $openaiKey)
+				keyRow(provider: .anthropic, placeholder: "sk-ant-...", text: $anthropicKey)
+
+				if let status {
+					Text(status).font(.caption).foregroundColor(.secondary)
+				}
+			}
+		}
+		.onAppear { savedProviders = (try? Set(ByokKeyStore.shared.providers())) ?? [] }
+	}
+
+	private func keyRow(provider: ProviderId, placeholder: String, text: Binding<String>) -> some View {
+		HStack {
+			Text(provider.displayName).frame(width: 80, alignment: .leading)
+			if savedProviders.contains(provider) {
+				Text("Saved").foregroundColor(.green).font(.caption)
+				Spacer()
+				Button("Remove") {
+					try? ByokKeyStore.shared.delete(provider: provider)
+					savedProviders.remove(provider)
+					status = "\(provider.displayName) key removed."
+				}
+			} else {
+				SecureField(placeholder, text: text)
+					.textFieldStyle(.roundedBorder)
+				Button("Save") {
+					let value = text.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines)
+					guard !value.isEmpty else { return }
+					do {
+						try ByokKeyStore.shared.save(provider: provider, key: value)
+						savedProviders.insert(provider)
+						text.wrappedValue = ""
+						status = "\(provider.displayName) key saved to Keychain."
+					} catch {
+						status = error.localizedDescription
+					}
+				}
+				.disabled(text.wrappedValue.isEmpty)
+			}
+		}
+	}
+}

--- a/Client/RecipeRouter.swift
+++ b/Client/RecipeRouter.swift
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// Where recipe LLM steps run. Mutually exclusive at the app-global level. WHI-39.
+enum LLMMode: String, CaseIterable, Sendable {
+	case local
+	case subscription
+	case byok
+
+	var displayName: String {
+		switch self {
+		case .local: return "Local"
+		case .subscription: return "Subscription"
+		case .byok: return "Bring Your Own Key"
+		}
+	}
+}
+
+extension WhisperaSettings {
+	private static let llmModeKey = "whisperaLLMMode"
+
+	static var llmMode: LLMMode {
+		get { LLMMode(rawValue: UserDefaults.standard.string(forKey: llmModeKey) ?? "") ?? .local }
+		set { UserDefaults.standard.set(newValue.rawValue, forKey: llmModeKey) }
+	}
+}
+
+enum RecipeRouterError: LocalizedError {
+	case notSignedIn
+	case missingProviderKey(ProviderId)
+	case executionFailed(String)
+
+	var errorDescription: String? {
+		switch self {
+		case .notSignedIn:
+			return "Subscription mode needs you to sign in (Account settings)."
+		case .missingProviderKey(let provider):
+			return "No \(provider.displayName) key saved. Add one in BYOK settings."
+		case .executionFailed(let message):
+			return message
+		}
+	}
+}
+
+protocol RecipeExecuting: Sendable {
+	func run(recipe: Recipe, input: String) async throws -> String
+}
+
+extension LocalLLMExecutor: RecipeExecuting {}
+
+/// Runs a recipe through the backend execute endpoint. Used for both
+/// Subscription (Bearer only) and BYOK (Bearer + X-Provider-Key) modes.
+struct BackendExecutor: RecipeExecuting {
+	let providerKey: String?
+	private let api: WhisperaAPIClient
+
+	init(providerKey: String?, api: WhisperaAPIClient = .shared) {
+		self.providerKey = providerKey
+		self.api = api
+	}
+
+	func run(recipe: Recipe, input: String) async throws -> String {
+		let result = try await api.executeRecipe(id: recipe.id, input: input, providerKey: providerKey)
+		guard result.status == "completed", let output = result.output, !output.isEmpty else {
+			throw RecipeRouterError.executionFailed(result.error ?? "Recipe execution failed")
+		}
+		return output
+	}
+}
+
+/// Resolves the active mode and runs a recipe through the right executor.
+@MainActor
+struct RecipeRouter {
+	static let shared = RecipeRouter()
+
+	private let auth: AuthManager
+	private let keyStore: ByokKeyStore
+	private let modeProvider: () -> LLMMode
+
+	init(
+		auth: AuthManager = .shared,
+		keyStore: ByokKeyStore = .shared,
+		modeProvider: @escaping () -> LLMMode = { WhisperaSettings.llmMode }
+	) {
+		self.auth = auth
+		self.keyStore = keyStore
+		self.modeProvider = modeProvider
+	}
+
+	func run(recipe: Recipe, input: String) async throws -> String {
+		try await executor(for: recipe).run(recipe: recipe, input: input)
+	}
+
+	/// Builds the executor for the current mode. BYOK keys are read from the
+	/// Keychain here, at request time, and dropped after the call returns.
+	func executor(for recipe: Recipe) throws -> RecipeExecuting {
+		switch modeProvider() {
+		case .local:
+			return LocalLLMExecutor()
+		case .subscription:
+			guard auth.isSignedIn else { throw RecipeRouterError.notSignedIn }
+			return BackendExecutor(providerKey: nil)
+		case .byok:
+			// BYOK still routes through the backend execute endpoint (pass-through),
+			// which requires Bearer auth — the user's key just replaces platform
+			// credits via X-Provider-Key. So a signed-in account is still needed.
+			guard auth.isSignedIn else { throw RecipeRouterError.notSignedIn }
+			let provider = Self.provider(for: recipe)
+			guard let key = try keyStore.load(provider: provider), !key.isEmpty else {
+				throw RecipeRouterError.missingProviderKey(provider)
+			}
+			return BackendExecutor(providerKey: key)
+		}
+	}
+
+	static func provider(for recipe: Recipe) -> ProviderId {
+		let raw = recipe.steps.first?.config.provider?.lowercased()
+		return raw == "claude" || raw == "anthropic" ? .anthropic : .openai
+	}
+}

--- a/Client/WhisperaAPIClient+Execute.swift
+++ b/Client/WhisperaAPIClient+Execute.swift
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+struct RecipeExecutionResult: Decodable, Sendable {
+	let status: String
+	let output: String?
+	let error: String?
+}
+
+private struct ExecuteBody: Encodable {
+	let input: String
+}
+
+extension WhisperaAPIClient {
+	/// Executes a recipe server-side. Pass `providerKey` for BYOK (sent as
+	/// `X-Provider-Key`); omit for Subscription (platform keys via Bearer auth).
+	func executeRecipe(id: String, input: String, providerKey: String? = nil) async throws
+		-> RecipeExecutionResult
+	{
+		try await send(
+			"/recipes/\(id)/execute", method: "POST", body: ExecuteBody(input: input),
+			providerKey: providerKey)
+	}
+}

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -581,6 +581,12 @@ struct SettingsView: View {
 					Label("Account", systemImage: "person.crop.circle")
 				}
 
+			// MARK: - AI Mode Tab
+			LLMModeSettingsView()
+				.tabItem {
+					Label("AI Mode", systemImage: "brain")
+				}
+
 			// MARK: - Commands Tab
 			RecipesView()
 				.tabItem {

--- a/WhisperaUnitTests/LocalLLMExecutorTests.swift
+++ b/WhisperaUnitTests/LocalLLMExecutorTests.swift
@@ -26,32 +26,27 @@ struct LocalLLMInterpolationTests {
 	}
 }
 
-@Suite(.serialized)
 struct LocalLLMExecutorChatTests {
 
-	private func executor(model: String = "test-model") -> LocalLLMExecutor {
-		let config = URLSessionConfiguration.ephemeral
-		config.protocolClasses = [MockURLProtocol.self]
-		let session = URLSession(configuration: config)
-		return LocalLLMExecutor(
-			session: session,
-			serverURLProvider: { URL(string: "http://localhost:11434/v1") },
+	private func executor(mock: MockURLProtocol.Mock, model: String = "test-model") -> LocalLLMExecutor {
+		LocalLLMExecutor(
+			session: mock.session,
+			serverURLProvider: { mock.baseURL.appendingPathComponent("v1") },
 			defaultModelProvider: { model })
 	}
 
 	@Test func chatPostsOpenAIPayloadAndReturnsContent() async throws {
-		MockURLProtocol.handler = { request in
-			let r = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-			return (r, Data(#"{"choices":[{"message":{"content":"hi"}}]}"#.utf8))
-		}
-		let result = try await executor().chat(system: nil, prompt: "say hi", model: nil, maxTokens: 50)
+		let mock = MockURLProtocol.make(status: 200, json: #"{"choices":[{"message":{"content":"hi"}}]}"#)
+		let result = try await executor(mock: mock).chat(
+			system: nil, prompt: "say hi", model: nil, maxTokens: 50)
 		#expect(result == "hi")
-		#expect(MockURLProtocol.lastRequest?.url?.path == "/v1/chat/completions")
-		#expect(MockURLProtocol.lastRequest?.httpMethod == "POST")
+		#expect(MockURLProtocol.lastRequest(host: mock.host)?.url?.path == "/v1/chat/completions")
+		#expect(MockURLProtocol.lastRequest(host: mock.host)?.httpMethod == "POST")
 	}
 
 	@Test func noModelThrows() async {
-		let exec = executor(model: "")
+		let mock = MockURLProtocol.make(status: 200, json: #"{}"#)
+		let exec = executor(mock: mock, model: "")
 		await #expect(throws: LocalLLMError.self) {
 			_ = try await exec.chat(system: nil, prompt: "x", model: nil, maxTokens: nil)
 		}
@@ -59,7 +54,7 @@ struct LocalLLMExecutorChatTests {
 
 	@Test func runChainsStepsFeedingOutputForward() async throws {
 		// Each call echoes the user content so we can prove the chain wires step N → N+1.
-		MockURLProtocol.handler = { request in
+		let mock = MockURLProtocol.make { request in
 			let body = request.httpBodyStreamData() ?? request.httpBody ?? Data()
 			let object = (try? JSONSerialization.jsonObject(with: body)) as? [String: Any]
 			let messages = object?["messages"] as? [[String: String]]
@@ -76,7 +71,7 @@ struct LocalLLMExecutorChatTests {
 				RecipeStep(config: LLMStepConfig(prompt: "a:{{input}}")),
 				RecipeStep(config: LLMStepConfig(prompt: "b:{{input}}")),
 			])
-		let result = try await executor().run(recipe: recipe, input: "x")
+		let result = try await executor(mock: mock).run(recipe: recipe, input: "x")
 		#expect(result == "[b:[a:x]]")
 	}
 }

--- a/WhisperaUnitTests/MockURLProtocol.swift
+++ b/WhisperaUnitTests/MockURLProtocol.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Race-free URLProtocol mock. Each `make` call returns a session bound to a
+/// unique base URL (host = a UUID), and the handler is keyed by that host, so
+/// tests running in parallel never clobber each other's responses.
+final class MockURLProtocol: URLProtocol {
+	private static let lock = NSLock()
+	nonisolated(unsafe) private static var handlers: [String: @Sendable (URLRequest) -> (HTTPURLResponse, Data)] = [:]
+	nonisolated(unsafe) private static var lastRequests: [String: URLRequest] = [:]
+
+	struct Mock {
+		let session: URLSession
+		let baseURL: URL
+		let host: String
+	}
+
+	static func make(handler: @escaping @Sendable (URLRequest) -> (HTTPURLResponse, Data)) -> Mock {
+		let host = "m\(UUID().uuidString.replacingOccurrences(of: "-", with: "")).test"
+		lock.lock()
+		handlers[host] = handler
+		lock.unlock()
+
+		let config = URLSessionConfiguration.ephemeral
+		config.protocolClasses = [MockURLProtocol.self]
+		let session = URLSession(configuration: config)
+		return Mock(session: session, baseURL: URL(string: "http://\(host)")!, host: host)
+	}
+
+	/// Convenience for a single status + JSON body response.
+	static func make(status: Int, json: String) -> Mock {
+		make { request in
+			let response = HTTPURLResponse(
+				url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+			return (response, Data(json.utf8))
+		}
+	}
+
+	static func lastRequest(host: String) -> URLRequest? {
+		lock.lock()
+		defer { lock.unlock() }
+		return lastRequests[host]
+	}
+
+	override class func canInit(with request: URLRequest) -> Bool { true }
+	override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+	override func startLoading() {
+		let host = request.url?.host ?? ""
+		Self.lock.lock()
+		let handler = Self.handlers[host]
+		Self.lastRequests[host] = request
+		Self.lock.unlock()
+
+		guard let handler else {
+			client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+			return
+		}
+		let (response, data) = handler(request)
+		client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+		client?.urlProtocol(self, didLoad: data)
+		client?.urlProtocolDidFinishLoading(self)
+	}
+
+	override func stopLoading() {}
+}

--- a/WhisperaUnitTests/RecipeRouterTests.swift
+++ b/WhisperaUnitTests/RecipeRouterTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+@MainActor
+@Suite(.serialized)
+struct RecipeRouterTests {
+
+	private func recipe(provider: String? = nil) -> Recipe {
+		Recipe(
+			name: "r",
+			steps: [RecipeStep(config: LLMStepConfig(prompt: "{{input}}", provider: provider))])
+	}
+
+	@Test func localModeReturnsLocalExecutor() throws {
+		let router = RecipeRouter(auth: AuthManager(), modeProvider: { .local })
+		#expect(try router.executor(for: recipe()) is LocalLLMExecutor)
+	}
+
+	@Test func subscriptionModeRequiresSignIn() {
+		let router = RecipeRouter(auth: AuthManager(), modeProvider: { .subscription })
+		#expect(throws: RecipeRouterError.self) { _ = try router.executor(for: recipe()) }
+	}
+
+	@Test func byokModeRequiresSignIn() {
+		let router = RecipeRouter(auth: AuthManager(), modeProvider: { .byok })
+		#expect(throws: RecipeRouterError.self) { _ = try router.executor(for: recipe()) }
+	}
+
+	@Test func providerSelectionFromStepConfig() {
+		#expect(RecipeRouter.provider(for: recipe(provider: "claude")) == .anthropic)
+		#expect(RecipeRouter.provider(for: recipe(provider: "anthropic")) == .anthropic)
+		#expect(RecipeRouter.provider(for: recipe(provider: "openai")) == .openai)
+		#expect(RecipeRouter.provider(for: recipe(provider: nil)) == .openai)
+	}
+}
+
+struct BackendExecutorTests {
+
+	private func api(mock: MockURLProtocol.Mock) -> (WhisperaAPIClient, AuthTokenStore) {
+		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
+		try? store.save("t")
+		let api = WhisperaAPIClient(
+			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
+		return (api, store)
+	}
+
+	private func recipe() -> Recipe {
+		Recipe(id: "rid", name: "r", steps: [RecipeStep(config: LLMStepConfig(prompt: "{{input}}"))])
+	}
+
+	@Test func completedStatusReturnsOutput() async throws {
+		let mock = MockURLProtocol.make(status: 200, json: #"{"status":"completed","output":"done","error":null}"#)
+		let (client, store) = api(mock: mock)
+		defer { try? store.delete() }
+		let executor = BackendExecutor(providerKey: nil, api: client)
+		#expect(try await executor.run(recipe: recipe(), input: "x") == "done")
+	}
+
+	@Test func failedStatusThrows() async throws {
+		let mock = MockURLProtocol.make(status: 200, json: #"{"status":"failed","output":null,"error":"boom"}"#)
+		let (client, store) = api(mock: mock)
+		defer { try? store.delete() }
+		let executor = BackendExecutor(providerKey: nil, api: client)
+		await #expect(throws: RecipeRouterError.self) { _ = try await executor.run(recipe: recipe(), input: "x") }
+	}
+}

--- a/WhisperaUnitTests/WhisperaAPIClientTests.swift
+++ b/WhisperaUnitTests/WhisperaAPIClientTests.swift
@@ -3,135 +3,85 @@ import Testing
 
 @testable import Whispera
 
-/// Intercepts URLSession traffic so client tests never hit the network.
-final class MockURLProtocol: URLProtocol {
-	nonisolated(unsafe) static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
-	nonisolated(unsafe) static var lastRequest: URLRequest?
-
-	override class func canInit(with request: URLRequest) -> Bool { true }
-	override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-	override func startLoading() {
-		MockURLProtocol.lastRequest = request
-		guard let handler = MockURLProtocol.handler else {
-			client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-			return
-		}
-		let (response, data) = handler(request)
-		client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-		client?.urlProtocol(self, didLoad: data)
-		client?.urlProtocolDidFinishLoading(self)
-	}
-
-	override func stopLoading() {}
-}
-
-@Suite(.serialized)
 struct WhisperaAPIClientTests {
 
-	private func makeClient(service: String) -> (WhisperaAPIClient, AuthTokenStore) {
-		let config = URLSessionConfiguration.ephemeral
-		config.protocolClasses = [MockURLProtocol.self]
-		let session = URLSession(configuration: config)
-		let store = AuthTokenStore(service: service)
+	private func makeClient(mock: MockURLProtocol.Mock) -> (WhisperaAPIClient, AuthTokenStore) {
+		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
 		let client = WhisperaAPIClient(
-			session: session,
-			tokenStore: store,
-			serverURLProvider: { URL(string: "http://localhost:3000") })
+			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
 		return (client, store)
 	}
 
-	private func respond(_ status: Int, _ json: String) {
-		MockURLProtocol.handler = { request in
-			let response = HTTPURLResponse(
-				url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
-			return (response, Data(json.utf8))
-		}
-	}
-
 	@Test func getMeSendsBearerAndDecodes() async throws {
-		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
-		let (client, store) = makeClient(service: service)
+		let mock = MockURLProtocol.make(
+			status: 200, json: #"{"id":"u1","clerkId":"devtoken123","email":"a@b.co","name":null}"#)
+		let (client, store) = makeClient(mock: mock)
 		defer { try? store.delete() }
 		try store.save("devtoken123")
-		respond(200, #"{"id":"u1","clerkId":"devtoken123","email":"a@b.co","name":null}"#)
 
 		let user = try await client.getMe()
 		#expect(user.id == "u1")
 		#expect(user.email == "a@b.co")
-		#expect(MockURLProtocol.lastRequest?.url?.path == "/auth/me")
-		#expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer devtoken123")
+		#expect(MockURLProtocol.lastRequest(host: mock.host)?.url?.path == "/auth/me")
+		#expect(
+			MockURLProtocol.lastRequest(host: mock.host)?.value(forHTTPHeaderField: "Authorization")
+				== "Bearer devtoken123")
 	}
 
 	@Test func providerKeyHeaderIsSetWhenProvided() async throws {
-		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
-		let (client, store) = makeClient(service: service)
+		let mock = MockURLProtocol.make(status: 200, json: #"{"ok":true}"#)
+		let (client, store) = makeClient(mock: mock)
 		defer { try? store.delete() }
 		try store.save("t")
-		respond(200, #"{"ok":true}"#)
 
 		let _: EmptyResponseProbe = try await client.get("/x", providerKey: "sk-byok-123")
-		#expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "X-Provider-Key") == "sk-byok-123")
+		#expect(
+			MockURLProtocol.lastRequest(host: mock.host)?.value(forHTTPHeaderField: "X-Provider-Key")
+				== "sk-byok-123")
 	}
 
 	@Test func queryStringIsPreservedNotPercentEncoded() async throws {
-		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
-		let (client, store) = makeClient(service: service)
+		let mock = MockURLProtocol.make(status: 200, json: #"{"ok":true}"#)
+		let (client, store) = makeClient(mock: mock)
 		defer { try? store.delete() }
 		try store.save("t")
-		respond(200, #"{"ok":true}"#)
 
 		let _: EmptyResponseProbe = try await client.get("/recipes?limit=100")
-		#expect(MockURLProtocol.lastRequest?.url?.path == "/recipes")
-		#expect(MockURLProtocol.lastRequest?.url?.query == "limit=100")
+		#expect(MockURLProtocol.lastRequest(host: mock.host)?.url?.path == "/recipes")
+		#expect(MockURLProtocol.lastRequest(host: mock.host)?.url?.query == "limit=100")
 	}
 
 	@Test func missingTokenThrowsNotAuthenticated() async {
-		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
-		let (client, store) = makeClient(service: service)
+		let mock = MockURLProtocol.make(status: 200, json: #"{"ok":true}"#)
+		let (client, store) = makeClient(mock: mock)
 		try? store.delete()
 		await #expect(throws: WhisperaAPIError.self) { _ = try await client.getMe() }
 	}
 
 	@Test func httpErrorIsMapped() async throws {
-		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
-		let (client, store) = makeClient(service: service)
+		let mock = MockURLProtocol.make(status: 401, json: #"{"error":"Unauthorized"}"#)
+		let (client, store) = makeClient(mock: mock)
 		defer { try? store.delete() }
 		try store.save("t")
-		respond(401, #"{"error":"Unauthorized"}"#)
-
 		await #expect(throws: WhisperaAPIError.self) { _ = try await client.getMe() }
 	}
 }
 
-private struct EmptyResponseProbe: Decodable {
+struct EmptyResponseProbe: Decodable {
 	let ok: Bool
 }
 
 @MainActor
-@Suite(.serialized)
 struct AuthManagerTests {
 
-	private func makeAuth(service: String) -> (AuthManager, AuthTokenStore) {
-		let config = URLSessionConfiguration.ephemeral
-		config.protocolClasses = [MockURLProtocol.self]
-		let session = URLSession(configuration: config)
-		let store = AuthTokenStore(service: service)
-		let client = WhisperaAPIClient(
-			session: session,
-			tokenStore: store,
-			serverURLProvider: { URL(string: "http://localhost:3000") })
-		return (AuthManager(api: client, tokenStore: store), store)
-	}
-
 	@Test func signInSuccessStoresUser() async {
-		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
-		let (auth, store) = makeAuth(service: service)
+		let mock = MockURLProtocol.make(
+			status: 200, json: #"{"id":"u1","clerkId":"tok","email":"x@y.z","name":null}"#)
+		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
 		defer { try? store.delete() }
-		MockURLProtocol.handler = { request in
-			let r = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-			return (r, Data(#"{"id":"u1","clerkId":"tok","email":"x@y.z","name":null}"#.utf8))
-		}
+		let client = WhisperaAPIClient(
+			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
+		let auth = AuthManager(api: client, tokenStore: store)
 
 		await auth.signIn(token: "tok")
 		#expect(auth.isSignedIn)
@@ -140,13 +90,12 @@ struct AuthManagerTests {
 	}
 
 	@Test func signInFailureRevertsToken() async {
-		let service = "com.whispera.clerk.test.\(UUID().uuidString)"
-		let (auth, store) = makeAuth(service: service)
+		let mock = MockURLProtocol.make(status: 401, json: #"{"error":"Unauthorized"}"#)
+		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
 		defer { try? store.delete() }
-		MockURLProtocol.handler = { request in
-			let r = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
-			return (r, Data(#"{"error":"Unauthorized"}"#.utf8))
-		}
+		let client = WhisperaAPIClient(
+			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
+		let auth = AuthManager(api: client, tokenStore: store)
 
 		await auth.signIn(token: "bad")
 		#expect(!auth.isSignedIn)

--- a/WhisperaUnitTests/WhisperaBackendE2ETests.swift
+++ b/WhisperaUnitTests/WhisperaBackendE2ETests.swift
@@ -68,4 +68,30 @@ struct WhisperaBackendE2ETests {
 		let output = try await executor.run(recipe: recipe, input: "ignored")
 		#expect(output.uppercased().contains("WHISPERA"))
 	}
+
+	/// Subscription mode: create a recipe, execute it server-side via the backend
+	/// (LLM through VibeProxy), assert the polished output, then clean up.
+	@Test func subscriptionExecuteRoundTripsAgainstBackend() async throws {
+		let store = AuthTokenStore(service: "com.whispera.clerk.e2e.\(UUID().uuidString)")
+		defer { try? store.delete() }
+		try store.save(devToken)
+		let api = client(store)
+
+		let created = try await api.createRecipe(
+			RecipeInput(
+				from: Recipe(
+					name: "E2E professional \(UUID().uuidString.prefix(6))",
+					steps: [
+						RecipeStep(
+							config: LLMStepConfig(
+								prompt: "Rewrite politely, output only the message: {{input}}",
+								model: "gpt-5.4-mini"))
+					])))
+		defer { Task { try? await api.deleteRecipe(id: created.id) } }
+
+		let executor = BackendExecutor(providerKey: nil, api: api)
+		let output = try await executor.run(
+			recipe: created, input: "hey send me the file by tomorrow")
+		#expect(!output.isEmpty)
+	}
 }


### PR DESCRIPTION
## WHI-39 — Three-mode LLM routing
Stacked on #49. Base: `ismatulla/whi-38-local-llm-executor`.

- `LLMMode` (local/subscription/byok) + `RecipeRouter` resolving the active mode and building the right executor.
- `BackendExecutor`: runs a recipe via `/recipes/:id/execute` (Subscription = Bearer; BYOK = Bearer + `X-Provider-Key`). BYOK keys read from Keychain at request time, dropped after.
- `executeRecipe` API method.
- AI Mode settings tab: mode picker + per-mode config (local server URL/model + Test button; subscription sign-in status; BYOK key fields).
- **Test infra fix:** made the `URLProtocol` mock race-free (per-host keyed handlers) — it previously shared a global handler and flaked under parallel suites.

Note: BYOK still routes through the backend execute endpoint (pass-through), which requires Bearer auth — so BYOK also needs a signed-in account (guarded in the router).

Verification: build + lint clean; unit tests (router mode resolution, provider selection, BackendExecutor success/failure) — 40 mocked tests run together with 0 flake; **live E2E** subscription execute (create→execute via backend→output→cleanup).