### PR TITLE
feat(transcribe): Whisper-via-Whispera and BYOK transcription engines (WHI-42)

### DIFF
--- a/Client/LLMModeSettingsView.swift
+++ b/Client/LLMModeSettingsView.swift
@@ -28,10 +28,46 @@ struct LLMModeSettingsView: View {
 				case .subscription: SubscriptionModeConfig(isSignedIn: auth.isSignedIn, name: auth.displayName)
 				case .byok: ByokModeConfig()
 				}
+
+				TranscriptionEngineConfig()
 			}
 			.padding(20)
 		}
 		.task { await auth.refresh() }
+	}
+}
+
+private struct TranscriptionEngineConfig: View {
+	@AppStorage("whisperaTranscriptionEngine") private var engineRaw = TranscriptionEngine.whisperKit.rawValue
+
+	private var engine: TranscriptionEngine { TranscriptionEngine(rawValue: engineRaw) ?? .whisperKit }
+
+	var body: some View {
+		SettingsSection("Transcription Engine") {
+			VStack(alignment: .leading, spacing: 8) {
+				Picker("Speech-to-text", selection: $engineRaw) {
+					ForEach(TranscriptionEngine.allCases, id: \.rawValue) { engine in
+						Text(engine.displayName).tag(engine.rawValue)
+					}
+				}
+				.pickerStyle(.menu)
+
+				Text(note(for: engine))
+					.font(.caption)
+					.foregroundColor(.secondary)
+			}
+		}
+	}
+
+	private func note(for engine: TranscriptionEngine) -> String {
+		switch engine {
+		case .whisperKit:
+			return "On-device, private, no network. Default."
+		case .whisperViaWhispera:
+			return "Audio is uploaded to Whispera and transcribed with OpenAI Whisper. Requires sign-in."
+		case .whisperViaBYOK:
+			return "Audio is uploaded directly to OpenAI using your saved key. Requires a BYOK OpenAI key."
+		}
 	}
 }
 

--- a/Client/RemoteTranscriber.swift
+++ b/Client/RemoteTranscriber.swift
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// Where speech-to-text runs. WhisperKit stays the default (on-device, no
+/// network). See WHI-42.
+enum TranscriptionEngine: String, CaseIterable, Sendable {
+	case whisperKit
+	case whisperViaWhispera
+	case whisperViaBYOK
+
+	var displayName: String {
+		switch self {
+		case .whisperKit: return "WhisperKit (on-device)"
+		case .whisperViaWhispera: return "OpenAI Whisper via Whispera"
+		case .whisperViaBYOK: return "OpenAI Whisper via your key"
+		}
+	}
+}
+
+extension WhisperaSettings {
+	private static let engineKey = "whisperaTranscriptionEngine"
+
+	static var transcriptionEngine: TranscriptionEngine {
+		get { TranscriptionEngine(rawValue: UserDefaults.standard.string(forKey: engineKey) ?? "") ?? .whisperKit }
+		set { UserDefaults.standard.set(newValue.rawValue, forKey: engineKey) }
+	}
+}
+
+enum RemoteTranscriberError: LocalizedError {
+	case notSignedIn
+	case missingOpenAIKey
+	case invalidServerURL
+	case http(status: Int, body: String)
+	case empty
+	case transport(Error)
+
+	var errorDescription: String? {
+		switch self {
+		case .notSignedIn: return "Whisper-via-Whispera needs you to sign in (Account settings)."
+		case .missingOpenAIKey: return "No OpenAI key saved. Add one in BYOK settings."
+		case .invalidServerURL: return "Invalid Whispera server URL"
+		case .http(let status, let body):
+			return "Transcription failed (HTTP \(status))\(body.isEmpty ? "" : ": \(body)")"
+		case .empty: return "Transcription returned no text."
+		case .transport(let err): return "Network error: \(err.localizedDescription)"
+		}
+	}
+}
+
+private struct TranscribeResponse: Decodable {
+	let text: String
+}
+
+private struct OpenAITranscribeResponse: Decodable {
+	let text: String
+}
+
+/// Uploads recorded audio to a remote Whisper endpoint. Used for the two
+/// non-WhisperKit engines. Never silently falls back to WhisperKit — failures
+/// surface to the caller (WHI-42).
+struct RemoteTranscriber {
+	private let session: URLSession
+	private let tokenStore: AuthTokenStore
+	private let keyStore: ByokKeyStore
+	private let serverURLProvider: () -> URL?
+	private let openAITranscribeURL: URL
+
+	init(
+		session: URLSession = .shared,
+		tokenStore: AuthTokenStore = .shared,
+		keyStore: ByokKeyStore = .shared,
+		serverURLProvider: @escaping () -> URL? = { WhisperaSettings.serverURL },
+		openAITranscribeURL: URL = URL(string: "https://api.openai.com/v1/audio/transcriptions")!
+	) {
+		self.session = session
+		self.tokenStore = tokenStore
+		self.keyStore = keyStore
+		self.serverURLProvider = serverURLProvider
+		self.openAITranscribeURL = openAITranscribeURL
+	}
+
+	/// POSTs multipart audio to the Whispera backend `/transcribe` (Bearer auth).
+	func transcribeViaWhispera(audio: Data, filename: String, mimetype: String, language: String?)
+		async throws -> String
+	{
+		guard let base = serverURLProvider() else { throw RemoteTranscriberError.invalidServerURL }
+		guard let token = try? tokenStore.load(), !token.isEmpty else {
+			throw RemoteTranscriberError.notSignedIn
+		}
+
+		var fields: [String: String] = [:]
+		if let language { fields["language"] = language }
+		let (body, contentType) = Self.multipart(
+			fileField: "file", filename: filename, mimetype: mimetype, fileData: audio, fields: fields)
+
+		var request = URLRequest(url: base.appendingPathComponent("transcribe"))
+		request.httpMethod = "POST"
+		request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+		request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+		request.httpBody = body
+
+		let data = try await perform(request)
+		let decoded = try JSONDecoder().decode(TranscribeResponse.self, from: data)
+		guard !decoded.text.isEmpty else { throw RemoteTranscriberError.empty }
+		return decoded.text
+	}
+
+	/// POSTs multipart audio directly to OpenAI using the user's key. The backend
+	/// is never involved, so the key only reaches the user's own provider.
+	func transcribeViaBYOK(audio: Data, filename: String, mimetype: String, language: String?)
+		async throws -> String
+	{
+		guard let key = try keyStore.load(provider: .openai), !key.isEmpty else {
+			throw RemoteTranscriberError.missingOpenAIKey
+		}
+
+		var fields: [String: String] = ["model": "whisper-1"]
+		if let language { fields["language"] = language }
+		let (body, contentType) = Self.multipart(
+			fileField: "file", filename: filename, mimetype: mimetype, fileData: audio, fields: fields)
+
+		var request = URLRequest(url: openAITranscribeURL)
+		request.httpMethod = "POST"
+		request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+		request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+		request.httpBody = body
+
+		let data = try await perform(request)
+		let decoded = try JSONDecoder().decode(OpenAITranscribeResponse.self, from: data)
+		guard !decoded.text.isEmpty else { throw RemoteTranscriberError.empty }
+		return decoded.text
+	}
+
+	private func perform(_ request: URLRequest) async throws -> Data {
+		let data: Data
+		let response: URLResponse
+		do {
+			(data, response) = try await session.data(for: request)
+		} catch {
+			throw RemoteTranscriberError.transport(error)
+		}
+		guard let http = response as? HTTPURLResponse else { throw RemoteTranscriberError.empty }
+		guard (200..<300).contains(http.statusCode) else {
+			throw RemoteTranscriberError.http(
+				status: http.statusCode, body: String(data: data, encoding: .utf8) ?? "")
+		}
+		return data
+	}
+
+	/// Builds a `multipart/form-data` body: one file part plus text fields.
+	static func multipart(
+		fileField: String, filename: String, mimetype: String, fileData: Data, fields: [String: String]
+	) -> (Data, String) {
+		let boundary = "whispera.\(UUID().uuidString)"
+		var body = Data()
+		let crlf = "\r\n"
+
+		for (name, value) in fields {
+			body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+			body.append("Content-Disposition: form-data; name=\"\(name)\"\(crlf)\(crlf)".data(using: .utf8)!)
+			body.append("\(value)\(crlf)".data(using: .utf8)!)
+		}
+
+		body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+		body.append(
+			"Content-Disposition: form-data; name=\"\(fileField)\"; filename=\"\(filename)\"\(crlf)".data(
+				using: .utf8)!)
+		body.append("Content-Type: \(mimetype)\(crlf)\(crlf)".data(using: .utf8)!)
+		body.append(fileData)
+		body.append(crlf.data(using: .utf8)!)
+		body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)
+
+		return (body, "multipart/form-data; boundary=\(boundary)")
+	}
+}

--- a/WhisperaUnitTests/RemoteTranscriberTests.swift
+++ b/WhisperaUnitTests/RemoteTranscriberTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+struct MultipartTests {
+
+	@Test func multipartContainsFilePartAndFields() {
+		let (body, contentType) = RemoteTranscriber.multipart(
+			fileField: "file", filename: "clip.wav", mimetype: "audio/wav",
+			fileData: Data("AUDIOBYTES".utf8), fields: ["language": "en"])
+		let text = String(data: body, encoding: .utf8)!
+
+		#expect(contentType.hasPrefix("multipart/form-data; boundary="))
+		#expect(text.contains("name=\"file\"; filename=\"clip.wav\""))
+		#expect(text.contains("Content-Type: audio/wav"))
+		#expect(text.contains("name=\"language\""))
+		#expect(text.contains("en"))
+		#expect(text.contains("AUDIOBYTES"))
+	}
+}
+
+struct RemoteTranscriberTests {
+
+	@Test func viaWhisperaSendsBearerAndReturnsText() async throws {
+		let mock = MockURLProtocol.make(
+			status: 200,
+			json: #"{"text":"hello world","language":"en","duration":1.0,"provider":"openai-whisper"}"#)
+		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
+		defer { try? store.delete() }
+		try store.save("tok")
+		let transcriber = RemoteTranscriber(
+			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
+
+		let text = try await transcriber.transcribeViaWhispera(
+			audio: Data("x".utf8), filename: "a.wav", mimetype: "audio/wav", language: "en")
+		#expect(text == "hello world")
+		let req = MockURLProtocol.lastRequest(host: mock.host)
+		#expect(req?.url?.path == "/transcribe")
+		#expect(req?.value(forHTTPHeaderField: "Authorization") == "Bearer tok")
+		#expect(req?.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data") == true)
+	}
+
+	@Test func viaWhisperaRequiresSignIn() async {
+		let mock = MockURLProtocol.make(status: 200, json: #"{"text":"x"}"#)
+		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
+		try? store.delete()
+		let transcriber = RemoteTranscriber(
+			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
+		await #expect(throws: RemoteTranscriberError.self) {
+			_ = try await transcriber.transcribeViaWhispera(
+				audio: Data(), filename: "a.wav", mimetype: "audio/wav", language: nil)
+		}
+	}
+
+	@Test func viaBYOKUsesKeyAndOpenAIURL() async throws {
+		let mock = MockURLProtocol.make(status: 200, json: #"{"text":"byok text"}"#)
+		let keyStore = ByokKeyStore(service: "com.whispera.byok.test.\(UUID().uuidString)")
+		defer { try? keyStore.delete(provider: .openai) }
+		try keyStore.save(provider: .openai, key: "sk-user-openai-key-123456")
+		let transcriber = RemoteTranscriber(
+			session: mock.session, keyStore: keyStore,
+			openAITranscribeURL: mock.baseURL.appendingPathComponent("v1/audio/transcriptions"))
+
+		let text = try await transcriber.transcribeViaBYOK(
+			audio: Data("x".utf8), filename: "a.wav", mimetype: "audio/wav", language: nil)
+		#expect(text == "byok text")
+		let req = MockURLProtocol.lastRequest(host: mock.host)
+		#expect(req?.url?.path == "/v1/audio/transcriptions")
+		#expect(req?.value(forHTTPHeaderField: "Authorization") == "Bearer sk-user-openai-key-123456")
+	}
+
+	@Test func viaBYOKRequiresKey() async {
+		let mock = MockURLProtocol.make(status: 200, json: #"{"text":"x"}"#)
+		let keyStore = ByokKeyStore(service: "com.whispera.byok.test.\(UUID().uuidString)")
+		let transcriber = RemoteTranscriber(
+			session: mock.session, keyStore: keyStore,
+			openAITranscribeURL: mock.baseURL.appendingPathComponent("v1/audio/transcriptions"))
+		await #expect(throws: RemoteTranscriberError.self) {
+			_ = try await transcriber.transcribeViaBYOK(
+				audio: Data(), filename: "a.wav", mimetype: "audio/wav", language: nil)
+		}
+	}
+
+	@Test func httpErrorSurfacesNoFallback() async {
+		let mock = MockURLProtocol.make(status: 500, json: #"{"error":"boom"}"#)
+		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
+		defer { try? store.delete() }
+		try? store.save("tok")
+		let transcriber = RemoteTranscriber(
+			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
+		await #expect(throws: RemoteTranscriberError.self) {
+			_ = try await transcriber.transcribeViaWhispera(
+				audio: Data(), filename: "a.wav", mimetype: "audio/wav", language: nil)
+		}
+	}
+}


### PR DESCRIPTION
## WHI-42 — Transcription engine option
Stacked on #50. Base: `ismatulla/whi-39-three-mode-router`.

- `TranscriptionEngine` (WhisperKit on-device default / Whisper-via-Whispera / Whisper-via-BYOK) + setting + picker in the AI Mode tab.
- `RemoteTranscriber`: multipart audio upload to backend `/transcribe` (Bearer) or directly to OpenAI `audio/transcriptions` (BYOK key from Keychain). **No silent fallback** to WhisperKit — failures surface.
- Shared multipart/form-data builder.

### Verification
- Build + lint clean; 6 unit tests (multipart shape, Bearer/key headers, OpenAI URL, response parsing, sign-in/key requirements, HTTP-error-no-fallback).
- ⚠️ Live transcription E2E not run: VibeProxy has no Whisper/audio endpoint (404) and no whisper model, so the backend `/transcribe` path can't be exercised here without a real OpenAI key. Client request construction is fully unit-verified; live run needs a Whisper-capable endpoint.

> Note: wiring the selected engine into the live dictation capture path lands in the WHI-41 PR (where audio actually flows).