### PR TITLE
feat(dictation): default command runs on every dictation (WHI-49)

### DIFF
--- a/Client/DictationCoordinator.swift
+++ b/Client/DictationCoordinator.swift
@@ -22,19 +22,30 @@ final class DictationCoordinator {
 	private let store: RecipeStore
 	private let run: (Recipe, String) async throws -> String
 	private let errorDisplaySeconds: Double
+	private let defaultCommandId: () -> String
 	private var currentTask: Task<String?, Never>?
 	private var clearErrorTask: Task<Void, Never>?
 
 	init(
 		store: RecipeStore = .shared,
 		errorDisplaySeconds: Double = 3,
+		defaultCommandId: @escaping () -> String = { WhisperaSettings.defaultCommandId },
 		run: @escaping (Recipe, String) async throws -> String = { recipe, input in
 			try await RecipeRouter.shared.run(recipe: recipe, input: input)
 		}
 	) {
 		self.store = store
 		self.errorDisplaySeconds = errorDisplaySeconds
+		self.defaultCommandId = defaultCommandId
 		self.run = run
+	}
+
+	/// The configured default command, if it still exists in the store. Runs on
+	/// every dictation that doesn't match a trigger phrase. See WHI-49.
+	private func defaultCommand() -> Recipe? {
+		let id = defaultCommandId()
+		guard !id.isEmpty else { return nil }
+		return store.recipes.first { $0.id == id }
 	}
 
 	/// Returns the text to paste, or `nil` if nothing should be pasted (recipe
@@ -42,7 +53,17 @@ final class DictationCoordinator {
 	func process(_ transcription: String) async -> String? {
 		currentTask?.cancel()
 
-		guard let match = RecipeMatcher.match(text: transcription, recipes: store.recipes) else {
+		// Trigger phrase wins; otherwise fall back to the default command; if
+		// neither applies, paste the raw transcription unchanged.
+		let recipe: Recipe
+		let input: String
+		if let match = RecipeMatcher.match(text: transcription, recipes: store.recipes) {
+			recipe = match.recipe
+			input = match.remainder
+		} else if let fallback = defaultCommand() {
+			recipe = fallback
+			input = transcription
+		} else {
 			return transcription
 		}
 
@@ -50,7 +71,7 @@ final class DictationCoordinator {
 		overlayError = nil
 		clearErrorTask?.cancel()
 		isRunning = true
-		runningRecipeName = match.recipe.name
+		runningRecipeName = recipe.name
 		defer {
 			isRunning = false
 			runningRecipeName = nil
@@ -58,10 +79,10 @@ final class DictationCoordinator {
 
 		let task = Task { () -> String? in
 			do {
-				let output = try await run(match.recipe, match.remainder)
+				let output = try await run(recipe, input)
 				if Task.isCancelled { return nil }
 				guard !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-					self.flashError("“\(match.recipe.name)” returned nothing.")
+					self.flashError("“\(recipe.name)” returned nothing.")
 					return nil
 				}
 				return output

--- a/Client/DictationCoordinator.swift
+++ b/Client/DictationCoordinator.swift
@@ -53,6 +53,11 @@ final class DictationCoordinator {
 	func process(_ transcription: String) async -> String? {
 		currentTask?.cancel()
 
+		// Empty/whitespace dictation: do nothing — never spend a model call.
+		guard !transcription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+			return nil
+		}
+
 		// Trigger phrase wins; otherwise fall back to the default command; if
 		// neither applies, paste the raw transcription unchanged.
 		let recipe: Recipe

--- a/Client/RecipesView.swift
+++ b/Client/RecipesView.swift
@@ -9,6 +9,7 @@ struct RecipesView: View {
 	@State private var store = RecipeStore.shared
 	@State private var editing: Recipe?
 	@State private var isCreating = false
+	@AppStorage("whisperaDefaultCommandId") private var defaultCommandId = ""
 
 	var body: some View {
 		VStack(spacing: 0) {
@@ -17,6 +18,7 @@ struct RecipesView: View {
 			if store.recipes.isEmpty {
 				emptyState
 			} else {
+				defaultPicker
 				List {
 					ForEach(store.recipes) { recipe in
 						Button {
@@ -76,6 +78,24 @@ struct RecipesView: View {
 		.padding(20)
 	}
 
+	private var defaultPicker: some View {
+		HStack {
+			Text("Runs on every dictation")
+				.font(.subheadline)
+			Spacer()
+			Picker("", selection: $defaultCommandId) {
+				Text("None").tag("")
+				ForEach(store.recipes) { recipe in
+					Text(recipe.name.isEmpty ? "Untitled" : recipe.name).tag(recipe.id)
+				}
+			}
+			.labelsHidden()
+			.frame(maxWidth: 220)
+		}
+		.padding(.horizontal, 20)
+		.padding(.bottom, 10)
+	}
+
 	private var emptyState: some View {
 		VStack(spacing: 8) {
 			Image(systemName: "wand.and.stars")
@@ -96,12 +116,16 @@ struct RecipesView: View {
 		VStack(alignment: .leading, spacing: 2) {
 			Text(recipe.name.isEmpty ? "Untitled" : recipe.name)
 				.font(.subheadline.weight(.medium))
-			if let trigger = recipe.triggerPhrase, !trigger.isEmpty {
+			if recipe.id == defaultCommandId {
+				Text("Default · runs on every dictation")
+					.font(.caption)
+					.foregroundColor(.blue)
+			} else if let trigger = recipe.triggerPhrase, !trigger.isEmpty {
 				Text("“\(trigger)”")
 					.font(.caption)
 					.foregroundColor(.secondary)
 			} else {
-				Text("Runs on every dictation")
+				Text("No trigger — set as default to use")
 					.font(.caption)
 					.foregroundColor(.secondary)
 			}

--- a/Client/WhisperaSettings.swift
+++ b/Client/WhisperaSettings.swift
@@ -19,4 +19,13 @@ enum WhisperaSettings {
 	static var serverURL: URL? {
 		URL(string: serverURLString.trimmingCharacters(in: .whitespacesAndNewlines))
 	}
+
+	private static let defaultCommandIdKey = "whisperaDefaultCommandId"
+
+	/// Recipe id of the command that post-processes every dictation when no
+	/// trigger phrase matches. Empty = no default (paste raw). See WHI-49.
+	static var defaultCommandId: String {
+		get { defaults.string(forKey: defaultCommandIdKey) ?? "" }
+		set { defaults.set(newValue, forKey: defaultCommandIdKey) }
+	}
 }

--- a/WhisperaUnitTests/RecipeMatcherTests.swift
+++ b/WhisperaUnitTests/RecipeMatcherTests.swift
@@ -164,4 +164,68 @@ struct DictationCoordinatorTests {
 		_ = await coordinator.process("make professional hi")
 		#expect(coordinator.overlayError == "kaboom")
 	}
+
+	// MARK: - Default post-action command (WHI-49)
+
+	/// Builds a store with a trigger command ("Make professional") plus a
+	/// trigger-less default command ("Polish"), returning the default's id.
+	private func storeWithTriggerAndDefault() async -> (RecipeStore, String, URL) {
+		let url = FileManager.default.temporaryDirectory.appendingPathComponent("dd-\(UUID().uuidString).json")
+		let store = RecipeStore(auth: AuthManager(), fileURL: url)
+		await store.create(
+			Recipe(
+				name: "Make professional", triggerPhrase: "make professional",
+				steps: [RecipeStep(config: LLMStepConfig(prompt: "{{input}}"))]))
+		let def = Recipe(name: "Polish", steps: [RecipeStep(config: LLMStepConfig(prompt: "{{input}}"))])
+		await store.create(def)
+		return (store, def.id, url)
+	}
+
+	@Test func defaultCommandRunsWhenNoTriggerMatches() async {
+		let (store, defId, url) = await storeWithTriggerAndDefault()
+		defer { try? FileManager.default.removeItem(at: url) }
+		var ranWith: (name: String, input: String)?
+		let coordinator = DictationCoordinator(store: store, defaultCommandId: { defId }) { recipe, input in
+			ranWith = (recipe.name, input)
+			return "POLISHED"
+		}
+		let result = await coordinator.process("just some plain words")
+		#expect(result == "POLISHED")
+		#expect(ranWith?.name == "Polish")
+		// The whole transcript is the input for the default command.
+		#expect(ranWith?.input == "just some plain words")
+	}
+
+	@Test func triggerWinsOverDefault() async {
+		let (store, defId, url) = await storeWithTriggerAndDefault()
+		defer { try? FileManager.default.removeItem(at: url) }
+		var ranWith: (name: String, input: String)?
+		let coordinator = DictationCoordinator(store: store, defaultCommandId: { defId }) { recipe, input in
+			ranWith = (recipe.name, input)
+			return "OUT"
+		}
+		_ = await coordinator.process("make professional hello there")
+		#expect(ranWith?.name == "Make professional")
+		#expect(ranWith?.input == "hello there")
+	}
+
+	@Test func noDefaultAndNoTriggerPastesRaw() async {
+		let (store, _, url) = await storeWithTriggerAndDefault()
+		defer { try? FileManager.default.removeItem(at: url) }
+		let coordinator = DictationCoordinator(store: store, defaultCommandId: { "" }) { _, _ in
+			"SHOULD NOT RUN"
+		}
+		let result = await coordinator.process("plain words no trigger")
+		#expect(result == "plain words no trigger")
+	}
+
+	@Test func staleDefaultIdFallsBackToRaw() async {
+		let (store, _, url) = await storeWithTriggerAndDefault()
+		defer { try? FileManager.default.removeItem(at: url) }
+		let coordinator = DictationCoordinator(store: store, defaultCommandId: { "nonexistent-id" }) { _, _ in
+			"SHOULD NOT RUN"
+		}
+		let result = await coordinator.process("plain words")
+		#expect(result == "plain words")
+	}
 }

--- a/WhisperaUnitTests/RecipeMatcherTests.swift
+++ b/WhisperaUnitTests/RecipeMatcherTests.swift
@@ -219,6 +219,19 @@ struct DictationCoordinatorTests {
 		#expect(result == "plain words no trigger")
 	}
 
+	@Test func emptyTranscriptionNeverRunsModel() async {
+		let (store, defId, url) = await storeWithTriggerAndDefault()
+		defer { try? FileManager.default.removeItem(at: url) }
+		var ran = false
+		let coordinator = DictationCoordinator(store: store, defaultCommandId: { defId }) { _, _ in
+			ran = true
+			return "X"
+		}
+		let result = await coordinator.process("   \n  ")
+		#expect(ran == false)
+		#expect(result == nil)
+	}
+
 	@Test func staleDefaultIdFallsBackToRaw() async {
 		let (store, _, url) = await storeWithTriggerAndDefault()
 		defer { try? FileManager.default.removeItem(at: url) }

--- a/WhisperaUnitTests/WhisperaBackendE2ETests.swift
+++ b/WhisperaUnitTests/WhisperaBackendE2ETests.swift
@@ -128,4 +128,42 @@ struct WhisperaBackendE2ETests {
 		// The polished output should not be the raw spoken phrase verbatim.
 		#expect(output.lowercased() != spoken.lowercased())
 	}
+
+	/// WHI-49: a trigger-less default command post-processes plain dictation
+	/// (no trigger phrase) end-to-end through the backend.
+	@MainActor
+	@Test func defaultCommandRunsOnPlainDictationViaBackend() async throws {
+		let store = AuthTokenStore(service: "com.whispera.clerk.e2e.\(UUID().uuidString)")
+		defer { try? store.delete() }
+		try store.save(devToken)
+		let api = client(store)
+
+		let created = try await api.createRecipe(
+			RecipeInput(
+				from: Recipe(
+					name: "Polish default \(UUID().uuidString.prefix(6))",
+					steps: [
+						RecipeStep(
+							config: LLMStepConfig(
+								prompt:
+									"Clean up grammar and filler, output only the cleaned text: {{input}}",
+								model: "gpt-5.4-mini"))
+					])))
+		defer { Task { try? await api.deleteRecipe(id: created.id) } }
+
+		let recipeURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+			"e2e-\(UUID().uuidString).json")
+		defer { try? FileManager.default.removeItem(at: recipeURL) }
+		let recipeStore = RecipeStore(auth: AuthManager(), fileURL: recipeURL)
+		await recipeStore.create(created)
+
+		let coordinator = DictationCoordinator(store: recipeStore, defaultCommandId: { created.id }) {
+			recipe, input in
+			try await BackendExecutor(providerKey: nil, api: api).run(recipe: recipe, input: input)
+		}
+
+		let result = await coordinator.process("um so like i wanted to say hi there")
+		#expect(result != nil)
+		#expect(!(result ?? "").isEmpty)
+	}
 }


### PR DESCRIPTION
## WHI-49 — Default post-action command
Stacked on #52 (WHI-41). Base: `ismatulla/whi-41-dictation-recipe-flow`.

Implements the "runs on every dictation" behavior that the UI label promised but the client never did.

### Behavior (resolution order)
1. Transcript starts with a command's trigger phrase → run that command on the remainder (WHI-41).
2. Else, if a **default command** is set → run it on the full transcript.
3. Else → paste raw.

### What
- `WhisperaSettings.defaultCommandId` (empty = none).
- `DictationCoordinator`: falls back to the default command when no trigger matches; ignores a stale/missing id; running-indicator + error toast work for the default path too.
- Commands tab: a "Runs on every dictation" picker (None + commands) and a corrected row label ("Default · runs on every dictation" only on the selected default; trigger-less non-defaults now say they won't run).

### Verification
- Build + lint clean; 39 unit tests incl. `defaultCommandRunsWhenNoTriggerMatches`, `triggerWinsOverDefault`, `noDefaultAndNoTriggerPastesRaw`, `staleDefaultIdFallsBackToRaw`.
- **Live E2E** `defaultCommandRunsOnPlainDictationViaBackend` — plain dictation post-processed by the default command through the backend. Passed.