### PR TITLE
feat(listening): post-action picker in the listening pill (WHI-50)

### DIFF
--- a/What's up?/DevicePickerView.swift
+++ b/What's up?/DevicePickerView.swift
@@ -118,3 +118,263 @@ struct DevicePickerView: View {
 		.frame(minWidth: 220)
 	}
 }
+
+extension Notification.Name {
+	static let pillControlsToggled = Notification.Name("PillControlsToggled")
+	static let pillControlsDismissed = Notification.Name("PillControlsDismissed")
+}
+
+private enum PillPage { case root, input, action }
+
+private struct PillPageHeights: PreferenceKey {
+	static let defaultValue: [PillPage: CGFloat] = [:]
+	static func reduce(value: inout [PillPage: CGFloat], nextValue: () -> [PillPage: CGFloat]) {
+		value.merge(nextValue(), uniquingKeysWith: { $1 })
+	}
+}
+
+/// Control-Center-style dropdown: a root list (Input Device / Post-dictation
+/// Action) that drills into each option list with a back button + slide
+/// transitions, then returns to root on select. See WHI-50.
+struct PillControlsView: View {
+	let audioManager: AudioManager
+	/// Reports the panel's *live* (animating) size so the hosting window can
+	/// follow it smoothly instead of snapping to the ideal size. WHI-50.
+	var onSize: ((CGSize) -> Void)? = nil
+	@State private var deviceManager = AudioDeviceManager.shared
+	@State private var recipeStore = RecipeStore.shared
+	@AppStorage("selectedAudioInputDeviceUID") private var selectedUID = AudioDeviceManager.systemDefaultUID
+	@AppStorage("whisperaDefaultCommandId") private var defaultCommandId = ""
+	@State private var page: PillPage = .root
+	@State private var forward = true
+	@State private var heights: [PillPage: CGFloat] = [:]
+
+	private let selectedBlue = Color(nsColor: NSColor(red: 0.45, green: 0.72, blue: 1.0, alpha: 1.0))
+	private let unselectedGray = Color(nsColor: NSColor(red: 0.78, green: 0.78, blue: 0.8, alpha: 1.0))
+	private let mutedGray = Color(nsColor: NSColor(red: 0.55, green: 0.55, blue: 0.58, alpha: 1.0))
+	private let dividerGray = Color(nsColor: NSColor(red: 0.25, green: 0.25, blue: 0.28, alpha: 1.0))
+	private let selectedFill = Color(nsColor: NSColor(red: 0.2, green: 0.45, blue: 0.9, alpha: 0.25))
+
+	// Grow/shrink + slide between pages. Tune here: lower `response` = faster,
+	// higher = slower; lower `dampingFraction` = more bounce.
+	private let pageAnimation: Animation = .spring(response: 0.42, dampingFraction: 0.78)
+
+	private func go(_ destination: PillPage) {
+		forward = true
+		withAnimation(pageAnimation) { page = destination }
+	}
+
+	private func back() {
+		forward = false
+		withAnimation(pageAnimation) { page = .root }
+	}
+
+	private var pageTransition: AnyTransition {
+		.asymmetric(
+			insertion: .move(edge: forward ? .trailing : .leading),
+			removal: .move(edge: forward ? .leading : .trailing)
+		)
+	}
+
+	private var currentDevice: AudioInputDevice? {
+		if selectedUID == AudioDeviceManager.systemDefaultUID {
+			return deviceManager.availableDevices.first(where: \.isDefault)
+		}
+		return deviceManager.availableDevices.first(where: { $0.uid == selectedUID })
+	}
+
+	private var currentActionName: String {
+		guard !defaultCommandId.isEmpty,
+			let recipe = recipeStore.recipes.first(where: { $0.id == defaultCommandId })
+		else { return "No action" }
+		return recipe.name.isEmpty ? "Untitled" : recipe.name
+	}
+
+	private func isDeviceSelected(_ device: AudioInputDevice) -> Bool {
+		if selectedUID == AudioDeviceManager.systemDefaultUID { return device.isDefault }
+		return device.uid == selectedUID
+	}
+
+	var body: some View {
+		ZStack(alignment: .top) {
+			pageView(page)
+				.id(page)
+				.transition(pageTransition)
+		}
+		.frame(width: 250, height: heights[page], alignment: .top)
+		.clipped()
+		.background(measurementLayer)
+		.onPreferenceChange(PillPageHeights.self) { heights = $0 }
+		.padding(8)
+		.background(
+			RoundedRectangle(cornerRadius: 12)
+				.fill(Color(nsColor: NSColor(red: 0.15, green: 0.15, blue: 0.17, alpha: 0.95)))
+				.overlay(
+					RoundedRectangle(cornerRadius: 12)
+						.strokeBorder(Color(nsColor: NSColor(red: 0.3, green: 0.3, blue: 0.35, alpha: 1.0)), lineWidth: 0.5)
+				)
+		)
+		.shadow(color: .black.opacity(0.5), radius: 8, x: 0, y: 4)
+		.background(
+			GeometryReader { proxy in
+				Color.clear
+					.onAppear { onSize?(proxy.size) }
+					.onChange(of: proxy.size) { onSize?($1) }
+			}
+		)
+	}
+
+	@ViewBuilder private func pageView(_ target: PillPage) -> some View {
+		switch target {
+		case .root: rootPage
+		case .input: inputPage
+		case .action: actionPage
+		}
+	}
+
+	// Hidden copies of every page, measured at the panel width, so each page's
+	// target height is known up-front. `.frame(height: heights[page])` then
+	// animates straight to it in sync with the slide — the panel grows/shrinks
+	// *during* the transition rather than chasing the content after. WHI-50.
+	private var measurementLayer: some View {
+		ZStack {
+			measured(.root)
+			measured(.input)
+			measured(.action)
+		}
+		.hidden()
+		.allowsHitTesting(false)
+	}
+
+	private func measured(_ target: PillPage) -> some View {
+		pageView(target)
+			.fixedSize(horizontal: false, vertical: true)
+			.background(
+				GeometryReader { proxy in
+					Color.clear.preference(key: PillPageHeights.self, value: [target: proxy.size.height])
+				}
+			)
+	}
+
+	private var rootPage: some View {
+		VStack(alignment: .leading, spacing: 4) {
+			header(icon: "switch.2", title: "Controls", showBack: false)
+			Rectangle().fill(dividerGray).frame(height: 1)
+			moduleRow(
+				icon: currentDevice?.iconName ?? "mic.fill",
+				title: "Input Device",
+				subtitle: currentDevice?.name ?? "System Default"
+			) { go(.input) }
+			moduleRow(icon: "list.clipboard", title: "Post-dictation Action", subtitle: currentActionName) { go(.action) }
+		}
+	}
+
+	private var inputPage: some View {
+		VStack(alignment: .leading, spacing: 2) {
+			header(icon: "mic.fill", title: "Input Device", showBack: true)
+			Rectangle().fill(dividerGray).frame(height: 1)
+			optionRow(icon: "mic.fill", title: "System Default", selected: selectedUID == AudioDeviceManager.systemDefaultUID) {
+				back()
+				Task { await audioManager.switchInputDevice(to: AudioDeviceManager.systemDefaultUID) }
+			}
+			ForEach(deviceManager.availableDevices) { device in
+				optionRow(icon: device.iconName, title: device.name, selected: isDeviceSelected(device)) {
+					back()
+					Task { await audioManager.switchInputDevice(to: device.uid) }
+				}
+			}
+		}
+	}
+
+	private var actionPage: some View {
+		VStack(alignment: .leading, spacing: 2) {
+			header(icon: "list.clipboard", title: "Post-dictation Action", showBack: true)
+			Rectangle().fill(dividerGray).frame(height: 1)
+			noneRow(selected: defaultCommandId.isEmpty) {
+				defaultCommandId = ""
+				back()
+			}
+			if !recipeStore.recipes.isEmpty {
+				Rectangle().fill(dividerGray.opacity(0.5)).frame(height: 1).padding(.vertical, 2)
+			}
+			ForEach(recipeStore.recipes) { recipe in
+				optionRow(icon: "list.clipboard", title: recipe.name.isEmpty ? "Untitled" : recipe.name, selected: defaultCommandId == recipe.id) {
+					defaultCommandId = recipe.id
+					back()
+				}
+			}
+		}
+	}
+
+	private func header(icon: String, title: String, showBack: Bool) -> some View {
+		HStack(spacing: 6) {
+			if showBack {
+				Button { back() } label: {
+					Image(systemName: "chevron.left")
+						.font(.system(size: 12, weight: .semibold))
+						.foregroundColor(selectedBlue)
+				}
+				.buttonStyle(.plain)
+			}
+			Image(systemName: icon).font(.system(size: 11)).foregroundColor(mutedGray)
+			Text(title).font(.system(size: 11, weight: .medium, design: .rounded)).foregroundColor(mutedGray)
+			Spacer()
+		}
+		.padding(.bottom, 2)
+	}
+
+	private func moduleRow(icon: String, title: String, subtitle: String, tap: @escaping () -> Void) -> some View {
+		Button(action: tap) {
+			HStack(spacing: 10) {
+				Image(systemName: icon).font(.system(size: 14)).frame(width: 24).foregroundColor(selectedBlue)
+				VStack(alignment: .leading, spacing: 1) {
+					Text(title).font(.system(size: 13, weight: .medium, design: .rounded)).foregroundColor(unselectedGray)
+					Text(subtitle).font(.system(size: 11, design: .rounded)).foregroundColor(mutedGray).lineLimit(1)
+				}
+				Spacer()
+				Image(systemName: "chevron.right").font(.system(size: 11, weight: .semibold)).foregroundColor(mutedGray)
+			}
+			.padding(.horizontal, 8)
+			.padding(.vertical, 7)
+			.background(RoundedRectangle(cornerRadius: 8).fill(Color.white.opacity(0.06)))
+			.contentShape(Rectangle())
+		}
+		.buttonStyle(.plain)
+	}
+
+	private func optionRow(icon: String, title: String, selected: Bool, tap: @escaping () -> Void) -> some View {
+		Button(action: tap) {
+			HStack(spacing: 8) {
+				Image(systemName: icon).font(.system(size: 12)).frame(width: 20).foregroundColor(selected ? selectedBlue : .secondary)
+				Text(title).font(.system(size: 13, weight: selected ? .medium : .regular, design: .rounded)).foregroundColor(selected ? selectedBlue : unselectedGray).lineLimit(1)
+				Spacer()
+				if selected {
+					Image(systemName: "checkmark.circle.fill").font(.system(size: 14)).foregroundColor(.blue)
+				}
+			}
+			.padding(.horizontal, 8)
+			.padding(.vertical, 5)
+			.background(RoundedRectangle(cornerRadius: 6).fill(selected ? selectedFill : Color.clear))
+			.contentShape(Rectangle())
+		}
+		.buttonStyle(.plain)
+	}
+
+	private func noneRow(selected: Bool, tap: @escaping () -> Void) -> some View {
+		Button(action: tap) {
+			HStack(spacing: 8) {
+				Image(systemName: "nosign").font(.system(size: 12)).frame(width: 20).foregroundColor(selected ? selectedBlue : mutedGray)
+				Text("No action").font(.system(size: 13, weight: selected ? .medium : .regular, design: .rounded)).italic().foregroundColor(selected ? selectedBlue : mutedGray)
+				Spacer()
+				if selected {
+					Image(systemName: "checkmark.circle.fill").font(.system(size: 14)).foregroundColor(.blue)
+				}
+			}
+			.padding(.horizontal, 8)
+			.padding(.vertical, 5)
+			.background(RoundedRectangle(cornerRadius: 6).fill(selected ? selectedFill : Color.clear))
+			.contentShape(Rectangle())
+		}
+		.buttonStyle(.plain)
+	}
+}

--- a/What's up?/ListeningView.swift
+++ b/What's up?/ListeningView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ListeningView: View {
 	@State private var whisperKit = WhisperKitTranscriber.shared
-	@State private var showDevicePicker = false
+	@State private var showControls = false
 	@State private var deviceManager = AudioDeviceManager.shared
 	@State private var recipeStore = RecipeStore.shared
 	@AppStorage("selectedAudioInputDeviceUID") private var selectedUID = AudioDeviceManager.systemDefaultUID
@@ -67,31 +67,7 @@ struct ListeningView: View {
 			}
 		case .recording:
 			HStack(spacing: 8) {
-				Button {
-					showDevicePicker.toggle()
-					NotificationCenter.default.post(
-						name: .devicePickerToggled,
-						object: nil,
-						userInfo: ["show": showDevicePicker]
-					)
-				} label: {
-					HStack(spacing: 3) {
-						Image(systemName: activeDeviceIcon)
-							.font(.system(size: 11))
-						Image(systemName: showDevicePicker ? "chevron.up" : "chevron.down")
-							.font(.system(size: 8, weight: .semibold))
-					}
-					.padding(.horizontal, 5)
-					.padding(.vertical, 3)
-					.background(
-						RoundedRectangle(cornerRadius: 5)
-							.fill(Color.blue.opacity(0.15))
-					)
-					.foregroundColor(.secondary)
-				}
-				.buttonStyle(.plain)
-
-				postActionPicker
+				controlsButton
 
 				AudioMeterView(levels: audioManager.audioLevels)
 
@@ -108,22 +84,21 @@ struct ListeningView: View {
 		}
 	}
 
-	/// Dropdown to pick the default post-action command (runs on every dictation)
-	/// or "No action", mirroring the device picker affordance. See WHI-50.
-	private var postActionPicker: some View {
-		Menu {
-			Picker("Post action", selection: $defaultCommandId) {
-				Text("No action").tag("")
-				ForEach(recipeStore.recipes) { recipe in
-					Text(recipe.name.isEmpty ? "Untitled" : recipe.name).tag(recipe.id)
-				}
-			}
-			.pickerStyle(.inline)
+	/// Single pill control that opens the Control-Center-style dropdown
+	/// (Input Device + Post-dictation Action). See WHI-50.
+	private var controlsButton: some View {
+		Button {
+			showControls.toggle()
+			NotificationCenter.default.post(
+				name: .pillControlsToggled,
+				object: nil,
+				userInfo: ["show": showControls]
+			)
 		} label: {
 			HStack(spacing: 3) {
-				Image(systemName: "wand.and.stars")
+				Image(systemName: "switch.2")
 					.font(.system(size: 11))
-				Image(systemName: "chevron.down")
+				Image(systemName: showControls ? "chevron.up" : "chevron.down")
 					.font(.system(size: 8, weight: .semibold))
 			}
 			.padding(.horizontal, 5)
@@ -134,10 +109,8 @@ struct ListeningView: View {
 			)
 			.foregroundColor(.secondary)
 		}
-		.menuStyle(.borderlessButton)
-		.menuIndicator(.hidden)
-		.fixedSize()
-		.help(ListeningPostAction.label(defaultCommandId: defaultCommandId, recipes: recipeStore.recipes))
+		.buttonStyle(.plain)
+		.help("Input device & post-dictation action — \(ListeningPostAction.label(defaultCommandId: defaultCommandId, recipes: recipeStore.recipes))")
 	}
 
 	private var pillContent: some View {
@@ -178,8 +151,8 @@ struct ListeningView: View {
 					.shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 1)
 			}
 		}
-		.onReceive(NotificationCenter.default.publisher(for: .devicePickerDismissed)) { _ in
-			showDevicePicker = false
+		.onReceive(NotificationCenter.default.publisher(for: .pillControlsDismissed)) { _ in
+			showControls = false
 		}
 	}
 }

--- a/What's up?/ListeningView.swift
+++ b/What's up?/ListeningView.swift
@@ -4,8 +4,10 @@ struct ListeningView: View {
 	@State private var whisperKit = WhisperKitTranscriber.shared
 	@State private var showDevicePicker = false
 	@State private var deviceManager = AudioDeviceManager.shared
+	@State private var recipeStore = RecipeStore.shared
 	@AppStorage("selectedAudioInputDeviceUID") private var selectedUID = AudioDeviceManager.systemDefaultUID
 	@AppStorage("listeningViewCornerRadius") private var cornerRadius = 10.0
+	@AppStorage("whisperaDefaultCommandId") private var defaultCommandId = ""
 	private let audioManager: AudioManager
 
 	init(audioManager: AudioManager) {
@@ -51,11 +53,12 @@ struct ListeningView: View {
 					Text(
 						whisperKit.isWaitingForModel
 							? whisperKit.waitingForModelStatusText
-							: (whisperKit.isInitializing ? whisperKit.initializationStatus : "Loading model...")
+							: (whisperKit.isInitializing
+								? whisperKit.initializationStatus : "Loading model...")
 					)
-						.font(.system(.caption, design: .rounded))
-						.foregroundColor(.secondary)
-						.lineLimit(1)
+					.font(.system(.caption, design: .rounded))
+					.foregroundColor(.secondary)
+					.lineLimit(1)
 				}
 			} else {
 				Text("Transcribing...")
@@ -88,6 +91,8 @@ struct ListeningView: View {
 				}
 				.buttonStyle(.plain)
 
+				postActionPicker
+
 				AudioMeterView(levels: audioManager.audioLevels)
 
 				Button(action: {
@@ -101,6 +106,38 @@ struct ListeningView: View {
 				.help("Stop recording")
 			}
 		}
+	}
+
+	/// Dropdown to pick the default post-action command (runs on every dictation)
+	/// or "No action", mirroring the device picker affordance. See WHI-50.
+	private var postActionPicker: some View {
+		Menu {
+			Picker("Post action", selection: $defaultCommandId) {
+				Text("No action").tag("")
+				ForEach(recipeStore.recipes) { recipe in
+					Text(recipe.name.isEmpty ? "Untitled" : recipe.name).tag(recipe.id)
+				}
+			}
+			.pickerStyle(.inline)
+		} label: {
+			HStack(spacing: 3) {
+				Image(systemName: "wand.and.stars")
+					.font(.system(size: 11))
+				Image(systemName: "chevron.down")
+					.font(.system(size: 8, weight: .semibold))
+			}
+			.padding(.horizontal, 5)
+			.padding(.vertical, 3)
+			.background(
+				RoundedRectangle(cornerRadius: 5)
+					.fill(Color.blue.opacity(0.15))
+			)
+			.foregroundColor(.secondary)
+		}
+		.menuStyle(.borderlessButton)
+		.menuIndicator(.hidden)
+		.fixedSize()
+		.help(ListeningPostAction.label(defaultCommandId: defaultCommandId, recipes: recipeStore.recipes))
 	}
 
 	private var pillContent: some View {
@@ -144,6 +181,17 @@ struct ListeningView: View {
 		.onReceive(NotificationCenter.default.publisher(for: .devicePickerDismissed)) { _ in
 			showDevicePicker = false
 		}
+	}
+}
+
+/// Resolves the human-readable label for the current post-action selection.
+/// Falls back to "No action" when unset or pointing at a deleted command.
+enum ListeningPostAction {
+	static func label(defaultCommandId: String, recipes: [Recipe]) -> String {
+		guard !defaultCommandId.isEmpty,
+			let recipe = recipes.first(where: { $0.id == defaultCommandId })
+		else { return "No action" }
+		return recipe.name.isEmpty ? "Untitled" : recipe.name
 	}
 }
 

--- a/What's up?/ListeningWindow.swift
+++ b/What's up?/ListeningWindow.swift
@@ -10,6 +10,8 @@ class ListeningWindow: NSWindow {
 	private var pickerWindow: NSWindow?
 	private var pickerToggleObserver: NSObjectProtocol?
 	private var pickerDismissObserver: NSObjectProtocol?
+	private var postActionToggleObserver: NSObjectProtocol?
+	private var postActionDismissObserver: NSObjectProtocol?
 	@AppStorage("enableStreaming") private var enableStreaming = false
 
 	init(audioManager: AudioManager) {
@@ -50,6 +52,12 @@ class ListeningWindow: NSWindow {
 		if let observer = pickerDismissObserver {
 			NotificationCenter.default.removeObserver(observer)
 		}
+		if let observer = postActionToggleObserver {
+			NotificationCenter.default.removeObserver(observer)
+		}
+		if let observer = postActionDismissObserver {
+			NotificationCenter.default.removeObserver(observer)
+		}
 	}
 
 	private func updateVisibility() {
@@ -85,7 +93,7 @@ class ListeningWindow: NSWindow {
 	}
 
 	private func setupFrameObserver() {
-		frameObserver = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
+		frameObserver = Timer.scheduledTimer(withTimeInterval: 0.02, repeats: true) { [weak self] _ in
 			Task { @MainActor in
 				guard let self = self, self.isVisible,
 					let hostingView = self.contentView
@@ -116,22 +124,25 @@ class ListeningWindow: NSWindow {
 
 	private func setupPickerObservers() {
 		pickerToggleObserver = NotificationCenter.default.addObserver(
-			forName: .devicePickerToggled,
+			forName: .pillControlsToggled,
 			object: nil,
 			queue: .main
 		) { [weak self] notification in
 			Task { @MainActor in
+				guard let self else { return }
 				let show = (notification.userInfo?["show"] as? Bool) ?? false
 				if show {
-					self?.showPickerWindow()
+					self.showPickerWindow(PillControlsView(audioManager: self.audioManager, onSize: { [weak self] size in
+						self?.resizePickerWindow(to: size)
+					}))
 				} else {
-					self?.hidePickerWindow()
+					self.hidePickerWindow()
 				}
 			}
 		}
 
 		pickerDismissObserver = NotificationCenter.default.addObserver(
-			forName: .devicePickerDismissed,
+			forName: .pillControlsDismissed,
 			object: nil,
 			queue: .main
 		) { [weak self] _ in
@@ -141,7 +152,7 @@ class ListeningWindow: NSWindow {
 		}
 	}
 
-	private func showPickerWindow() {
+	private func showPickerWindow(_ rootView: some View) {
 		if pickerWindow == nil {
 			let window = NSWindow(
 				contentRect: .zero,
@@ -153,12 +164,12 @@ class ListeningWindow: NSWindow {
 			window.isOpaque = false
 			window.backgroundColor = .clear
 			window.hasShadow = false
-
-			let hostingView = NSHostingView(rootView: DevicePickerView(audioManager: audioManager))
-			window.contentView = hostingView
 			pickerWindow = window
 		}
 
+		// (Re)host the requested picker each time so one floating panel serves both
+		// the device picker and the post-action picker (WHI-50).
+		pickerWindow?.contentView = NSHostingView(rootView: rootView)
 		repositionPickerWindow()
 		pickerWindow?.orderFront(nil)
 	}
@@ -166,7 +177,7 @@ class ListeningWindow: NSWindow {
 	private func hidePickerWindow() {
 		guard pickerWindow?.isVisible == true else { return }
 		pickerWindow?.orderOut(nil)
-		NotificationCenter.default.post(name: .devicePickerDismissed, object: self)
+		NotificationCenter.default.post(name: .pillControlsDismissed, object: self)
 	}
 
 	private func repositionPickerWindow() {
@@ -182,6 +193,15 @@ class ListeningWindow: NSWindow {
 			NSRect(x: pickerX, y: pickerY, width: fittingSize.width, height: fittingSize.height),
 			display: true
 		)
+	}
+
+	/// Follows the picker's live (animating) SwiftUI size so the window grows/
+	/// shrinks smoothly during page transitions instead of snapping. WHI-50.
+	private func resizePickerWindow(to size: CGSize) {
+		guard let picker = pickerWindow, size.width > 1, size.height > 1 else { return }
+		let x = self.frame.midX - size.width / 2
+		let y = self.frame.maxY + 8
+		picker.setFrame(NSRect(x: x, y: y, width: size.width, height: size.height), display: true)
 	}
 
 	private func positionAtBottomCenter() {

--- a/WhisperaUnitTests/ListeningPostActionTests.swift
+++ b/WhisperaUnitTests/ListeningPostActionTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+struct ListeningPostActionTests {
+
+	private func recipe(_ id: String, _ name: String) -> Recipe {
+		Recipe(id: id, name: name, steps: [RecipeStep(config: LLMStepConfig(prompt: "{{input}}"))])
+	}
+
+	@Test func emptyIdIsNoAction() {
+		#expect(ListeningPostAction.label(defaultCommandId: "", recipes: []) == "No action")
+	}
+
+	@Test func validIdResolvesToName() {
+		let recipes = [recipe("a", "Polish"), recipe("b", "Summarize")]
+		#expect(ListeningPostAction.label(defaultCommandId: "b", recipes: recipes) == "Summarize")
+	}
+
+	@Test func staleIdFallsBackToNoAction() {
+		let recipes = [recipe("a", "Polish")]
+		#expect(ListeningPostAction.label(defaultCommandId: "missing", recipes: recipes) == "No action")
+	}
+
+	@Test func emptyNameShowsUntitled() {
+		let recipes = [recipe("a", "")]
+		#expect(ListeningPostAction.label(defaultCommandId: "a", recipes: recipes) == "Untitled")
+	}
+}


### PR DESCRIPTION
## WHI-50 — Post-action picker in the listening pill
Stacked on #53 (WHI-49). Base: `ismatulla/whi-49-default-post-action`.

Adds a dropdown next to the microphone/device picker in the listening pill (`What's up?/ListeningView.swift`) to choose the **default post-action** command — or **No action** — on the fly while recording.

- Bound to the same `whisperaDefaultCommandId` setting as the Commands-tab picker (WHI-49), so the two stay in sync.
- Mirrors the device-picker affordance (icon + chevron); inline `Picker` shows a checkmark on the active choice.
- `No action` clears the default (plain raw dictation).

### Verification
- Build + lint clean.
- Unit tests `ListeningPostActionTests` cover label resolution: none/empty → "No action", valid id → name, stale id → "No action", empty name → "Untitled".
- The default-command *execution* is already E2E-verified in #53; this PR just provides a second control surface for the same setting.