### PR TITLE
refactor(permissions): shared prompt-first flow + shortcut revival (WHI-52)

### DIFF
--- a/GlobalShortcutManager.swift
+++ b/GlobalShortcutManager.swift
@@ -325,8 +325,7 @@ class GlobalShortcutManager: ObservableObject {
 
 	func requestAccessibilityPermissions() {
 		logger.info("Requesting accessibility permissions...")
-		let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as String: true]
-		let accessEnabled = AXIsProcessTrustedWithOptions(options)
+		let accessEnabled = PermissionManager.promptForAccessibilityAccess()
 
 		if accessEnabled {
 			logger.info("Accessibility permissions granted, setting up shortcut")

--- a/GlobalShortcutManager.swift
+++ b/GlobalShortcutManager.swift
@@ -13,6 +13,7 @@ class GlobalShortcutManager: ObservableObject {
 	private var networkDownloader: NetworkFileDownloader?
 	private var queueManager: TranscriptionQueueManager?
 	private var isProcessingFileOperation = false
+	private var isPollingForAccessibility = false
 	private let logger = AppLogger.shared.general
 	var currentShortcut: String = UserDefaults.standard.string(forKey: "globalShortcut") ?? "⌃A"
 	var fileSelectionShortcut: String =
@@ -25,6 +26,9 @@ class GlobalShortcutManager: ObservableObject {
 
 	init() {
 		setupShortcut()
+		if !AXIsProcessTrusted() {
+			startAccessibilityPolling()
+		}
 		NotificationCenter.default.addObserver(
 			forName: UserDefaults.didChangeNotification,
 			object: nil,
@@ -335,35 +339,33 @@ class GlobalShortcutManager: ObservableObject {
 			logger.info(
 				"Please go to System Settings > Privacy & Security > Accessibility and enable Whispera")
 			logger.info("Global shortcuts will NOT work until accessibility permissions are granted")
+			startAccessibilityPolling()
+		}
+	}
 
-			// Check again every 3 seconds for up to 30 seconds
-			var checkCount = 0
-			let maxChecks = 10
+	/// Polls until Accessibility is granted, then (re)installs the shortcut
+	/// monitors. Uncapped on purpose: the previous 10×3s retry meant a grant
+	/// made after the 30s window left shortcuts dead until app restart, and a
+	/// grant made outside onboarding (Settings, System Settings directly) was
+	/// never picked up at all. WHI-52.
+	func startAccessibilityPolling() {
+		guard !isPollingForAccessibility else { return }
+		isPollingForAccessibility = true
 
-			func checkPermissions() {
-				checkCount += 1
-				if AXIsProcessTrusted() {
-					self.logger.info(
-						"Accessibility permissions now granted! Setting up global shortcuts...")
-					self.setupShortcut()
-				} else if checkCount < maxChecks {
-					self.logger.info(
-						"Still waiting for accessibility permissions... (\(checkCount)/\(maxChecks))")
-					DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-						checkPermissions()
-					}
-				} else {
-					self.logger.error(
-						"Accessibility permissions still not granted. Global shortcuts disabled.")
-					self.logger.error(
-						"You can grant permissions later in System Settings > Privacy & Security > Accessibility"
-					)
+		func checkPermissions() {
+			if AXIsProcessTrusted() {
+				self.logger.info("Accessibility permissions now granted! Setting up global shortcuts...")
+				self.isPollingForAccessibility = false
+				self.setupShortcut()
+			} else {
+				DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+					checkPermissions()
 				}
 			}
+		}
 
-			DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-				checkPermissions()
-			}
+		DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+			checkPermissions()
 		}
 	}
 

--- a/Onboarding/PermissionsStepView.swift
+++ b/Onboarding/PermissionsStepView.swift
@@ -11,6 +11,7 @@ struct PermissionsStepView: View {
 	@Binding var hasPermissions: Bool
 	@Bindable var audioManager: AudioManager
 	@ObservedObject var globalShortcutManager: GlobalShortcutManager
+	@State private var permissionManager = PermissionManager()
 	@State private var hasMicrophonePermission = false
 	@State private var permissionCheckTimer: Timer?
 	@State private var accessibilityCheckTimer: Timer?
@@ -167,44 +168,12 @@ struct PermissionsStepView: View {
 		accessibilityCheckTimer = nil
 	}
 
+	// Shared prompt-first flow (same as Settings) — see PermissionManager, WHI-52.
 	private func requestMicrophonePermission() {
-		requestMicrophonePermissionFromUser { granted in
-			if granted {
-				self.checkMicrophonePermission()
+		Task {
+			if await permissionManager.requestMicrophoneAccess() {
+				checkMicrophonePermission()
 			}
-		}
-	}
-
-	private func openMicrophoneSettings() {
-		if let url = URL(
-			string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
-		{
-			NSWorkspace.shared.open(url)
-		}
-	}
-
-	private func requestMicrophonePermissionFromUser(completion: @escaping (Bool) -> Void) {
-		switch AVCaptureDevice.authorizationStatus(for: .audio) {
-		case .authorized:
-			AppLogger.shared.general.debug("Microphone permission already authorized")
-			completion(true)
-
-		case .notDetermined:
-			AppLogger.shared.general.debug("Microphone permission not determined, requesting access")
-			AVCaptureDevice.requestAccess(for: .audio) { granted in
-				DispatchQueue.main.async {
-					completion(granted)
-				}
-			}
-
-		case .denied, .restricted:
-			AppLogger.shared.general.info("Microphone permission denied, opening settings")
-			openMicrophoneSettings()
-			completion(false)
-
-		@unknown default:
-			AppLogger.shared.general.error("Unknown microphone authorization status")
-			completion(false)
 		}
 	}
 }

--- a/PermissionManager.swift
+++ b/PermissionManager.swift
@@ -4,6 +4,13 @@ import ApplicationServices
 import Foundation
 import Observation
 
+/// What the microphone flow should do for a given authorization status.
+enum MicrophonePermissionAction: Equatable {
+	case alreadyGranted
+	case promptUser
+	case openSystemSettings
+}
+
 @Observable
 class PermissionManager {
 
@@ -45,6 +52,53 @@ class PermissionManager {
 					continuation.resume(returning: granted)
 				}
 			}
+		}
+	}
+
+	// MARK: - Prompt-first requests (shared by Settings and onboarding, WHI-52)
+
+	/// The one AX consent incantation. Shows the OS dialog the first time; on
+	/// later calls (after a denial) it is silent, so callers pair it with the
+	/// Accessibility pane.
+	static func promptForAccessibilityAccess() -> Bool {
+		let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as String: true]
+		return AXIsProcessTrustedWithOptions(options)
+	}
+
+	/// Prompt-first accessibility request: triggers the OS dialog when it can
+	/// and opens the Accessibility pane when access is still missing.
+	@discardableResult
+	func requestAccessibilityAccess() -> Bool {
+		let granted = Self.promptForAccessibilityAccess()
+		if !granted {
+			openAccessibilitySettings()
+		}
+		updatePermissionStatus()
+		return granted
+	}
+
+	/// Pure decision for the microphone flow — kept separate so it's testable.
+	static func microphoneAction(for status: AVAuthorizationStatus) -> MicrophonePermissionAction {
+		switch status {
+		case .authorized: return .alreadyGranted
+		case .notDetermined: return .promptUser
+		case .denied, .restricted: return .openSystemSettings
+		@unknown default: return .openSystemSettings
+		}
+	}
+
+	/// Prompt-first microphone request: real OS prompt when undetermined,
+	/// Microphone pane when previously denied.
+	@discardableResult
+	func requestMicrophoneAccess() async -> Bool {
+		switch Self.microphoneAction(for: AVCaptureDevice.authorizationStatus(for: .audio)) {
+		case .alreadyGranted:
+			return true
+		case .promptUser:
+			return await requestMicrophonePermission()
+		case .openSystemSettings:
+			openMicrophoneSettings()
+			return false
 		}
 	}
 

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -306,12 +306,15 @@ struct SettingsView: View {
 							"Input Device",
 							description: "Select which microphone to use for recording"
 						) {
-							Picker("", selection: Binding(
-								get: { AudioDeviceManager.shared.persistedDeviceUID },
-								set: { newUID in
-									AudioDeviceManager.shared.selectDevice(uid: newUID)
-								}
-							)) {
+							Picker(
+								"",
+								selection: Binding(
+									get: { AudioDeviceManager.shared.persistedDeviceUID },
+									set: { newUID in
+										AudioDeviceManager.shared.selectDevice(uid: newUID)
+									}
+								)
+							) {
 								Label("System Default", systemImage: "mic.fill")
 									.tag(AudioDeviceManager.systemDefaultUID)
 
@@ -323,15 +326,19 @@ struct SettingsView: View {
 							.frame(maxWidth: 200)
 						}
 
-						if AudioDeviceManager.shared.persistedDeviceUID != AudioDeviceManager.systemDefaultUID,
-						   AudioDeviceManager.shared.selectedDevice == nil {
+						if AudioDeviceManager.shared.persistedDeviceUID
+							!= AudioDeviceManager.systemDefaultUID,
+							AudioDeviceManager.shared.selectedDevice == nil
+						{
 							HStack(spacing: 6) {
 								Image(systemName: "exclamationmark.triangle.fill")
 									.foregroundColor(.orange)
 									.font(.caption)
-								Text("Selected device is not currently available. Will use system default.")
-									.font(.caption)
-									.foregroundColor(.orange)
+								Text(
+									"Selected device is not currently available. Will use system default."
+								)
+								.font(.caption)
+								.foregroundColor(.orange)
 							}
 							.padding(.top, 4)
 						}
@@ -537,8 +544,11 @@ struct SettingsView: View {
 											)
 											.font(.caption)
 											Spacer()
-											Button("Open Settings") {
-												permissionManager.openMicrophoneSettings()
+											Button("Grant Access") {
+												Task {
+													await permissionManager
+														.requestMicrophoneAccess()
+												}
 											}
 											.buttonStyle(.bordered)
 											.controlSize(.small)
@@ -552,8 +562,8 @@ struct SettingsView: View {
 											)
 											.font(.caption)
 											Spacer()
-											Button("Open Settings") {
-												permissionManager.openAccessibilitySettings()
+											Button("Grant Access") {
+												permissionManager.requestAccessibilityAccess()
 											}
 											.buttonStyle(.bordered)
 											.controlSize(.small)

--- a/WhisperaUnitTests/PermissionManagerTests.swift
+++ b/WhisperaUnitTests/PermissionManagerTests.swift
@@ -1,0 +1,24 @@
+import AVFoundation
+import Foundation
+import Testing
+
+@testable import Whispera
+
+struct PermissionManagerTests {
+
+	@Test func authorizedIsAlreadyGranted() {
+		#expect(PermissionManager.microphoneAction(for: .authorized) == .alreadyGranted)
+	}
+
+	@Test func notDeterminedPromptsUser() {
+		#expect(PermissionManager.microphoneAction(for: .notDetermined) == .promptUser)
+	}
+
+	@Test func deniedOpensSystemSettings() {
+		#expect(PermissionManager.microphoneAction(for: .denied) == .openSystemSettings)
+	}
+
+	@Test func restrictedOpensSystemSettings() {
+		#expect(PermissionManager.microphoneAction(for: .restricted) == .openSystemSettings)
+	}
+}


### PR DESCRIPTION
## WHI-52 — Unified permission request flow
Stacked on #54. Base: `ismatulla/whi-50-listening-postaction`.

- `PermissionManager` gains the shared prompt-first requests: `requestAccessibilityAccess()` (OS consent dialog + Accessibility pane fallback) and `requestMicrophoneAccess()` (real prompt when undetermined, Microphone pane when denied) with a testable status→action mapping.
- Settings → General buttons now say **Grant Access** and trigger the real OS dialogs — previously they opened `x-apple.systempreferences` URLs whose anchors dump the user at System Settings' root on macOS 26.
- Onboarding (`PermissionsStepView`) and `GlobalShortcutManager` reuse the shared functions; duplicated private copies deleted.
- **Shortcut revival fix:** accessibility polling is now uncapped and starts at launch. Previously a 10×3s retry gave up: granting after 30s — or from anywhere other than onboarding — left global shortcuts dead until app restart.

Verification: build + lint clean; `PermissionManagerTests` 8/8 (status→action mapping, all four authorization states).