### PR TITLE
build(qa): sign QA installs like production so permissions persist (WHI-53)

### DIFF
--- a/scripts/install-qa.sh
+++ b/scripts/install-qa.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Builds a Release QA build, stamps a high QA version on the built product,
+# re-signs it with the production Developer ID, and installs to /Applications.
+#
+# Why Developer ID: macOS TCC keys permission grants (Accessibility, Microphone)
+# on the signing identity + bundle id. Production ships as Developer ID
+# (NK28QT38A3); a QA build signed any other way makes macOS treat it as a
+# different app, silently invalidating grants until the app is deleted and
+# re-authorized. Signing QA installs identically means you grant once and every
+# later install keeps the permissions. (Pre-granting TCC at deploy time is not
+# possible on macOS outside MDM.) WHI-53.
+
+set -euo pipefail
+
+DEVELOPER_ID="Developer ID Application: Ismatulla Mansurov (NK28QT38A3)"
+QA_VERSION="${QA_VERSION:-1.99.0}"
+QA_BUILD="${QA_BUILD:-999}"
+APP_PATH="/Applications/Whispera.app"
+
+cd "$(dirname "$0")/.."
+
+echo "Building Release..."
+xcodebuild -scheme Whispera -project Whispera.xcodeproj \
+  -configuration Release -destination 'platform=macOS' build | tail -2
+
+APP=$(ls -dt "$HOME"/Library/Developer/Xcode/DerivedData/Whispera-*/Build/Products/Release/Whispera.app | head -1)
+echo "Built: $APP"
+
+# High QA version so Sparkle never "updates" the QA build back to a release.
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${QA_VERSION}" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${QA_BUILD}" "$APP/Contents/Info.plist"
+
+echo "Re-signing with: $DEVELOPER_ID"
+SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
+if [ -d "$SPARKLE" ]; then
+  for xpc in "$SPARKLE"/Versions/*/XPCServices/*.xpc; do
+    [ -e "$xpc" ] || continue
+    codesign --force --options runtime --sign "$DEVELOPER_ID" "$xpc"
+  done
+  for helper in "$SPARKLE"/Versions/*/Updater.app "$SPARKLE"/Versions/*/Autoupdate; do
+    [ -e "$helper" ] || continue
+    codesign --force --options runtime --sign "$DEVELOPER_ID" "$helper"
+  done
+fi
+for fw in "$APP"/Contents/Frameworks/*.framework; do
+  [ -e "$fw" ] || continue
+  codesign --force --options runtime --sign "$DEVELOPER_ID" "$fw"
+done
+codesign --force --options runtime \
+  --entitlements Whispera.entitlements \
+  --sign "$DEVELOPER_ID" "$APP"
+codesign --verify --strict "$APP"
+
+echo "Installing to $APP_PATH..."
+pkill -9 -f "Whispera.app/Contents/MacOS/Whispera" 2>/dev/null || true
+sleep 1
+rm -rf "$APP_PATH"
+ditto "$APP" "$APP_PATH"
+open "$APP_PATH"
+
+echo "Installed Whispera ${QA_VERSION} (${QA_BUILD}) signed as production."
+echo ""
+echo "If permissions look stuck from a previously differently-signed install,"
+echo "clear the stale rows ONCE, then re-grant:"
+echo "  tccutil reset Accessibility com.macwhisper.app"
+echo "  tccutil reset Microphone com.macwhisper.app"


### PR DESCRIPTION
## WHI-53 — QA installs keep TCC grants
Stacked on the WHI-52 PR. Base: `ismatulla/whi-52-unify-permission-flow`.

macOS TCC keys permission grants on the signing identity + bundle id (`com.macwhisper.app`), not the app name. Production ships as `Developer ID Application (NK28QT38A3)`; local builds sign as team `LVKV6U72U3` — so each QA install looked like a new app, invalidated grants, and left duplicate rows in System Settings.

- `scripts/install-qa.sh`: builds Release, stamps a high QA version on the **built product** (no source churn, keeps Sparkle from downgrading), re-signs nested Sparkle bits → frameworks → app with the production Developer ID (same order as `release-distribute.sh`), installs, and prints the one-time `tccutil reset` for stale rows.
- Verified live: after one reset + re-grant, a subsequent reinstall via the script kept the Accessibility grant (TeamIdentifier=NK28QT38A3 on the installed app).

Note: pre-granting TCC at deploy time isn't possible on macOS outside MDM — stable signing is the supported way.