### PR TITLE
fix(audio): never block the UI on mic initialization — cancellable + AsyncButton (WHI-54)

### DIFF
--- a/AudioManager/AudioDeviceManager.swift
+++ b/AudioManager/AudioDeviceManager.swift
@@ -143,6 +143,14 @@ final class AudioDeviceManager {
 			"activateSelectedDevice: current default=\(currentDefaultName) (ID: \(currentDefault ?? 0)), switching to \(device.name) (ID: \(device.id))"
 		)
 
+		// Already the system default → nothing to switch (avoids a redundant,
+		// blocking CoreAudio call, e.g. iPhone 100 → 100). WHI-54.
+		if currentDefault == device.id {
+			AppLogger.shared.deviceManager.debug(
+				"activateSelectedDevice: \(device.name) already default, skipping switch")
+			return
+		}
+
 		if savedSystemDefaultDeviceID == nil {
 			savedSystemDefaultDeviceID = currentDefault
 		}
@@ -152,6 +160,7 @@ final class AudioDeviceManager {
 		await Task.detached(priority: .userInitiated) {
 			Self.setSystemDefaultInputDeviceSync(targetDeviceID)
 		}.value
+		if Task.isCancelled { return }
 
 		let newDefault = Self.getSystemDefaultInputDeviceID()
 		let newDefaultName = newDefault.flatMap { Self.getDeviceName(for: $0) } ?? "unknown"
@@ -167,10 +176,16 @@ final class AudioDeviceManager {
 
 	func restoreSystemDefault() {
 		guard let original = savedSystemDefaultDeviceID else { return }
-		setSystemDefaultInputDevice(original)
-		let name = Self.getDeviceName(for: original) ?? "unknown"
-		AppLogger.shared.deviceManager.info("Restored original system default: \(name) (ID: \(original))")
 		savedSystemDefaultDeviceID = nil
+		// Switching the default is a synchronous, uninterruptible CoreAudio call
+		// that blocks for seconds on Continuity/wireless devices — run it off the
+		// main actor so teardown/cancel never freezes the UI. WHI-54.
+		Task.detached(priority: .userInitiated) {
+			Self.setSystemDefaultInputDeviceSync(original)
+			let name = Self.getDeviceName(for: original) ?? "unknown"
+			AppLogger.shared.deviceManager.info(
+				"Restored original system default: \(name) (ID: \(original))")
+		}
 	}
 
 	private nonisolated static func setSystemDefaultInputDeviceSync(_ deviceID: AudioDeviceID) {

--- a/AudioManager/AudioDeviceManager.swift
+++ b/AudioManager/AudioDeviceManager.swift
@@ -88,22 +88,29 @@ final class AudioDeviceManager {
 	private var savedSystemDefaultDeviceID: AudioDeviceID?
 
 	private init() {
-		refreshDevices()
 		installDeviceChangeListeners()
 		applyPersistedSelection()
+		Task { await refreshDevices() }
 	}
 
 	// For testing
 	init(forTesting: Bool) {
-		refreshDevices()
 		applyPersistedSelection()
+		Task { await refreshDevices() }
 	}
 
 	// MARK: - Public API
 
-	func refreshDevices() {
-		let defaultID = getSystemDefaultInputDeviceID()
-		availableDevices = enumerateInputDevices(defaultDeviceID: defaultID)
+	/// Enumerating CoreAudio devices does blocking `AudioObjectGetPropertyData`
+	/// calls that can stall for seconds while a Continuity/wireless mic is mid
+	/// transition — and the HAL fires the change listeners exactly then. Run the
+	/// enumeration off the main actor so those notifications never freeze the UI.
+	/// WHI-54.
+	func refreshDevices() async {
+		let devices = await Task.detached(priority: .userInitiated) {
+			Self.enumerateInputDevices(defaultDeviceID: Self.getSystemDefaultInputDeviceID())
+		}.value
+		availableDevices = devices
 		applyPersistedSelection()
 		AppLogger.shared.deviceManager.debug("Refreshed devices: \(availableDevices.map(\.name))")
 	}
@@ -123,14 +130,18 @@ final class AudioDeviceManager {
 		}
 
 		guard let device = availableDevices.first(where: { $0.uid == persistedDeviceUID }) else {
-			AppLogger.shared.deviceManager.error("activateSelectedDevice: device \(persistedDeviceUID) not found in \(availableDevices.map { "\($0.name):\($0.uid)" })")
+			AppLogger.shared.deviceManager.error(
+				"activateSelectedDevice: device \(persistedDeviceUID) not found in \(availableDevices.map { "\($0.name):\($0.uid)" })"
+			)
 			restoreSystemDefault()
 			return
 		}
 
-		let currentDefault = getSystemDefaultInputDeviceID()
-		let currentDefaultName = currentDefault.flatMap { getDeviceName(for: $0) } ?? "unknown"
-		AppLogger.shared.deviceManager.info("activateSelectedDevice: current default=\(currentDefaultName) (ID: \(currentDefault ?? 0)), switching to \(device.name) (ID: \(device.id))")
+		let currentDefault = Self.getSystemDefaultInputDeviceID()
+		let currentDefaultName = currentDefault.flatMap { Self.getDeviceName(for: $0) } ?? "unknown"
+		AppLogger.shared.deviceManager.info(
+			"activateSelectedDevice: current default=\(currentDefaultName) (ID: \(currentDefault ?? 0)), switching to \(device.name) (ID: \(device.id))"
+		)
 
 		if savedSystemDefaultDeviceID == nil {
 			savedSystemDefaultDeviceID = currentDefault
@@ -142,19 +153,22 @@ final class AudioDeviceManager {
 			Self.setSystemDefaultInputDeviceSync(targetDeviceID)
 		}.value
 
-		let newDefault = getSystemDefaultInputDeviceID()
-		let newDefaultName = newDefault.flatMap { getDeviceName(for: $0) } ?? "unknown"
+		let newDefault = Self.getSystemDefaultInputDeviceID()
+		let newDefaultName = newDefault.flatMap { Self.getDeviceName(for: $0) } ?? "unknown"
 		if newDefault == targetDeviceID {
-			AppLogger.shared.deviceManager.info("activateSelectedDevice: verified system default changed to \(newDefaultName)")
+			AppLogger.shared.deviceManager.info(
+				"activateSelectedDevice: verified system default changed to \(newDefaultName)")
 		} else {
-			AppLogger.shared.deviceManager.error("activateSelectedDevice: FAILED - system default is still \(newDefaultName) (ID: \(newDefault ?? 0)), expected \(targetDeviceName) (ID: \(targetDeviceID))")
+			AppLogger.shared.deviceManager.error(
+				"activateSelectedDevice: FAILED - system default is still \(newDefaultName) (ID: \(newDefault ?? 0)), expected \(targetDeviceName) (ID: \(targetDeviceID))"
+			)
 		}
 	}
 
 	func restoreSystemDefault() {
 		guard let original = savedSystemDefaultDeviceID else { return }
 		setSystemDefaultInputDevice(original)
-		let name = getDeviceName(for: original) ?? "unknown"
+		let name = Self.getDeviceName(for: original) ?? "unknown"
 		AppLogger.shared.deviceManager.info("Restored original system default: \(name) (ID: \(original))")
 		savedSystemDefaultDeviceID = nil
 	}
@@ -177,7 +191,8 @@ final class AudioDeviceManager {
 		)
 
 		if status != noErr {
-			AppLogger.shared.deviceManager.error("setSystemDefaultInputDevice: FAILED with OSStatus \(status) for ID \(deviceID)")
+			AppLogger.shared.deviceManager.error(
+				"setSystemDefaultInputDevice: FAILED with OSStatus \(status) for ID \(deviceID)")
 		}
 	}
 
@@ -197,7 +212,8 @@ final class AudioDeviceManager {
 			return nil
 		}
 
-		AppLogger.shared.deviceManager.info("resolveActiveDeviceID → \(device.name) (ID: \(device.id), UID: \(device.uid))")
+		AppLogger.shared.deviceManager.info(
+			"resolveActiveDeviceID → \(device.name) (ID: \(device.id), UID: \(device.uid))")
 		return device.id
 	}
 
@@ -211,7 +227,7 @@ final class AudioDeviceManager {
 		}
 	}
 
-	private func enumerateInputDevices(defaultDeviceID: AudioDeviceID?) -> [AudioInputDevice] {
+	private nonisolated static func enumerateInputDevices(defaultDeviceID: AudioDeviceID?) -> [AudioInputDevice] {
 		var propertySize: UInt32 = 0
 		var address = AudioObjectPropertyAddress(
 			mSelector: kAudioHardwarePropertyDevices,
@@ -246,9 +262,9 @@ final class AudioDeviceManager {
 		var devices: [AudioInputDevice] = []
 
 		for deviceID in deviceIDs {
-			guard isInputDevice(deviceID),
-				let uid = getDeviceUID(for: deviceID),
-				let name = getDeviceName(for: deviceID)
+			guard Self.isInputDevice(deviceID),
+				let uid = Self.getDeviceUID(for: deviceID),
+				let name = Self.getDeviceName(for: deviceID)
 			else { continue }
 
 			devices.append(
@@ -257,14 +273,14 @@ final class AudioDeviceManager {
 					uid: uid,
 					name: name,
 					isDefault: deviceID == defaultDeviceID,
-					transportType: getDeviceTransportType(for: deviceID)
+					transportType: Self.getDeviceTransportType(for: deviceID)
 				))
 		}
 
 		return devices
 	}
 
-	private func isInputDevice(_ deviceID: AudioDeviceID) -> Bool {
+	private nonisolated static func isInputDevice(_ deviceID: AudioDeviceID) -> Bool {
 		var propertySize: UInt32 = 0
 		var address = AudioObjectPropertyAddress(
 			mSelector: kAudioDevicePropertyStreams,
@@ -283,7 +299,7 @@ final class AudioDeviceManager {
 		return status == noErr && propertySize > 0
 	}
 
-	private func getDeviceUID(for deviceID: AudioDeviceID) -> String? {
+	private nonisolated static func getDeviceUID(for deviceID: AudioDeviceID) -> String? {
 		var uid: CFString = "" as CFString
 		var size = UInt32(MemoryLayout<CFString>.size)
 		var address = AudioObjectPropertyAddress(
@@ -304,7 +320,7 @@ final class AudioDeviceManager {
 		return status == noErr ? uid as String : nil
 	}
 
-	private func getDeviceName(for deviceID: AudioDeviceID) -> String? {
+	private nonisolated static func getDeviceName(for deviceID: AudioDeviceID) -> String? {
 		var name: CFString = "" as CFString
 		var size = UInt32(MemoryLayout<CFString>.size)
 		var address = AudioObjectPropertyAddress(
@@ -325,7 +341,7 @@ final class AudioDeviceManager {
 		return status == noErr ? name as String : nil
 	}
 
-	private func getDeviceTransportType(for deviceID: AudioDeviceID) -> UInt32 {
+	private nonisolated static func getDeviceTransportType(for deviceID: AudioDeviceID) -> UInt32 {
 		var transportType: UInt32 = 0
 		var size = UInt32(MemoryLayout<UInt32>.size)
 		var address = AudioObjectPropertyAddress(
@@ -346,7 +362,7 @@ final class AudioDeviceManager {
 		return status == noErr ? transportType : 0
 	}
 
-	private func getSystemDefaultInputDeviceID() -> AudioDeviceID? {
+	private nonisolated static func getSystemDefaultInputDeviceID() -> AudioDeviceID? {
 		var deviceID: AudioDeviceID = 0
 		var size = UInt32(MemoryLayout<AudioDeviceID>.size)
 		var address = AudioObjectPropertyAddress(
@@ -378,7 +394,7 @@ final class AudioDeviceManager {
 
 		let devicesBlock: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
 			Task { @MainActor in
-				self?.refreshDevices()
+				await self?.refreshDevices()
 				NotificationCenter.default.post(name: .audioDevicesChanged, object: nil)
 			}
 		}
@@ -399,7 +415,7 @@ final class AudioDeviceManager {
 
 		let defaultBlock: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
 			Task { @MainActor in
-				self?.refreshDevices()
+				await self?.refreshDevices()
 			}
 		}
 		defaultDeviceListenerBlock = defaultBlock

--- a/AudioManager/AudioEngineController.swift
+++ b/AudioManager/AudioEngineController.swift
@@ -1,5 +1,5 @@
-import AudioToolbox
 import AVFoundation
+import AudioToolbox
 import CoreAudio
 import Foundation
 
@@ -50,15 +50,42 @@ final class AudioEngineController {
 	func setup(deviceID: AudioDeviceID? = nil) async throws -> AVAudioInputNode {
 		cleanup()
 
-		let newEngine = AVAudioEngine()
+		// Engine start blocks for seconds while slow devices (Continuity/
+		// wireless mics) come up — run it off the main actor so the UI never
+		// freezes while waiting. WHI-54.
+		let newEngine = try await Task.detached(priority: .userInitiated) {
+			try Self.buildAndStartEngine(deviceID: deviceID)
+		}.value
+
+		// The user may have cancelled while the device was spinning up.
+		if Task.isCancelled {
+			newEngine.stop()
+			throw CancellationError()
+		}
+
 		engine = newEngine
 
+		if let deviceID {
+			verifyActiveDevice(expected: deviceID)
+		}
+
+		isRunning = true
+		setupRouteObserver()
+
+		return newEngine.inputNode
+	}
+
+	/// The blocking part of engine bring-up; must never run on the main actor.
+	private nonisolated static func buildAndStartEngine(deviceID: AudioDeviceID?) throws
+		-> AVAudioEngine
+	{
+		let newEngine = AVAudioEngine()
 		let inputNode = newEngine.inputNode
 
 		#if os(macOS)
-		if let deviceID {
-			try setInputDevice(deviceID, on: inputNode)
-		}
+			if let deviceID {
+				try setInputDevice(deviceID, on: inputNode)
+			}
 		#endif
 
 		let hardwareSampleRate = inputNode.inputFormat(forBus: 0).sampleRate
@@ -70,18 +97,12 @@ final class AudioEngineController {
 
 		newEngine.prepare()
 		try newEngine.start()
-
-		if let deviceID {
-			verifyActiveDevice(expected: deviceID)
-		}
-
-		isRunning = true
-		setupRouteObserver()
-
-		return inputNode
+		return newEngine
 	}
 
-	private func setInputDevice(_ deviceID: AudioDeviceID, on inputNode: AVAudioInputNode) throws {
+	private nonisolated static func setInputDevice(
+		_ deviceID: AudioDeviceID, on inputNode: AVAudioInputNode
+	) throws {
 		guard let audioUnit = inputNode.audioUnit else {
 			throw AudioEngineError.deviceSetupFailed("Could not access audio unit")
 		}
@@ -119,18 +140,20 @@ final class AudioEngineController {
 		)
 
 		if status == noErr {
-			let name = getDeviceName(for: actualDeviceID) ?? "unknown"
+			let name = Self.getDeviceName(for: actualDeviceID) ?? "unknown"
 			if actualDeviceID == expected {
-				AppLogger.shared.deviceManager.info("Verified active input device: \(name) (ID: \(actualDeviceID))")
+				AppLogger.shared.deviceManager.info(
+					"Verified active input device: \(name) (ID: \(actualDeviceID))")
 			} else {
-				let expectedName = getDeviceName(for: expected) ?? "unknown"
+				let expectedName = Self.getDeviceName(for: expected) ?? "unknown"
 				AppLogger.shared.deviceManager.error(
-					"Device mismatch — expected: \(expectedName) (ID: \(expected)), actual: \(name) (ID: \(actualDeviceID))")
+					"Device mismatch — expected: \(expectedName) (ID: \(expected)), actual: \(name) (ID: \(actualDeviceID))"
+				)
 			}
 		}
 	}
 
-	private func getDeviceName(for deviceID: AudioDeviceID) -> String? {
+	private nonisolated static func getDeviceName(for deviceID: AudioDeviceID) -> String? {
 		var name: CFString = "" as CFString
 		var size = UInt32(MemoryLayout<CFString>.size)
 		var address = AudioObjectPropertyAddress(

--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -123,6 +123,28 @@ final class AudioManager: NSObject {
 		}
 	}
 
+	/// Cancels an in-flight microphone activation (slow wireless/Continuity
+	/// mics can take seconds) and returns the app to idle. WHI-54.
+	func cancelMicrophoneInitialization() {
+		guard isMicrophoneInitializing else { return }
+		AppLogger.shared.audioManager.info("Microphone initialization cancelled by user")
+
+		if currentRecordingMode == .liveTranscription {
+			stopLiveTranscription()
+			return
+		}
+
+		deviceActivationTask?.cancel()
+		deviceActivationTask = nil
+		isMicrophoneInitializing = false
+		isRecording = false
+		timer.stop()
+		audioBuffer.removeAll()
+		levelMonitor.reset()
+		engineController.cleanup()
+		deviceManager.restoreSystemDefault()
+	}
+
 	func switchInputDevice(to uid: String) {
 		deviceActivationTask?.cancel()
 		deviceActivationTask = nil
@@ -333,6 +355,8 @@ extension AudioManager {
 				playFeedbackSound(start: true)
 
 			} catch {
+				// A user cancel must not trigger the file-recording fallback.
+				guard !(error is CancellationError), !Task.isCancelled else { return }
 				isMicrophoneInitializing = false
 				AppLogger.shared.audioManager.error("Failed to start streaming: \(error)")
 				useStreamingTranscription = false

--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -252,6 +252,21 @@ extension AudioManager {
 // MARK: - File-Based Recording
 
 extension AudioManager {
+	/// Builds and starts an AVAudioRecorder. `record()` is the blocking call on a
+	/// cold device, so this is only ever run off the main actor. WHI-54.
+	private nonisolated static func makeFileRecorder(url: URL) throws -> AVAudioRecorder {
+		let settings: [String: Any] = [
+			AVFormatIDKey: Int(kAudioFormatLinearPCM),
+			AVSampleRateKey: 16000.0,
+			AVNumberOfChannelsKey: 1,
+			AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
+		]
+		let recorder = try AVAudioRecorder(url: url, settings: settings)
+		recorder.isMeteringEnabled = true
+		recorder.record()
+		return recorder
+	}
+
 	fileprivate func startFileBasedRecording() {
 		isMicrophoneInitializing = true
 
@@ -271,17 +286,20 @@ extension AudioManager {
 				withIntermediateDirectories: true
 			)
 
-			let settings: [String: Any] = [
-				AVFormatIDKey: Int(kAudioFormatLinearPCM),
-				AVSampleRateKey: 16000.0,
-				AVNumberOfChannelsKey: 1,
-				AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
-			]
-
 			do {
-				audioRecorder = try AVAudioRecorder(url: audioFilename, settings: settings)
-				audioRecorder?.isMeteringEnabled = true
-				audioRecorder?.record()
+				// AVAudioRecorder.record() blocks for seconds while a cold
+				// Continuity/wireless mic connects — do it off the main actor so
+				// the UI stays responsive and the stop button works. WHI-54.
+				let recorder = try await Task.detached(priority: .userInitiated) {
+					try Self.makeFileRecorder(url: audioFilename)
+				}.value
+
+				guard !Task.isCancelled else {
+					recorder.stop()
+					return
+				}
+
+				audioRecorder = recorder
 				isMicrophoneInitializing = false
 				isRecording = true
 				timer.start()
@@ -289,6 +307,7 @@ extension AudioManager {
 				startMeteringTimer()
 				AppLogger.shared.audioManager.debug("File-based recording started")
 			} catch {
+				guard !(error is CancellationError), !Task.isCancelled else { return }
 				isMicrophoneInitializing = false
 				AppLogger.shared.audioManager.error("Failed to start recording: \(error)")
 				showRecordingErrorAlert(error)

--- a/Client/AccountSettingsView.swift
+++ b/Client/AccountSettingsView.swift
@@ -81,16 +81,11 @@ struct AccountSettingsView: View {
 				HStack {
 					SecureField("token", text: $token)
 						.textFieldStyle(.roundedBorder)
-					Button("Verify & Sign In") {
-						Task {
-							await auth.signIn(token: token)
-							if auth.isSignedIn { token = "" }
-						}
+					AsyncButton("Verify & Sign In") {
+						await auth.signIn(token: token)
+						if auth.isSignedIn { token = "" }
 					}
-					.disabled(auth.isWorking || token.isEmpty)
-				}
-				if auth.isWorking {
-					ProgressView().scaleEffect(0.7)
+					.disabled(token.isEmpty)
 				}
 			}
 		}

--- a/Client/AsyncButton.swift
+++ b/Client/AsyncButton.swift
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import SwiftUI
+
+/// Button for async work: runs the action off the UI, shows the standard
+/// spinner while pending, disables itself, and cancels if the view goes away.
+/// Use for anything awaiting a network or device operation so the main UI
+/// never waits on it. WHI-54.
+struct AsyncButton<Label: View>: View {
+	private let action: () async -> Void
+	private let label: () -> Label
+	@State private var task: Task<Void, Never>?
+
+	init(action: @escaping () async -> Void, @ViewBuilder label: @escaping () -> Label) {
+		self.action = action
+		self.label = label
+	}
+
+	private var isRunning: Bool { task != nil }
+
+	var body: some View {
+		Button {
+			guard task == nil else { return }
+			task = Task {
+				await action()
+				task = nil
+			}
+		} label: {
+			HStack(spacing: 6) {
+				if isRunning {
+					ProgressView()
+						.scaleEffect(0.6)
+				}
+				label()
+			}
+		}
+		.disabled(isRunning)
+		.onDisappear {
+			task?.cancel()
+			task = nil
+		}
+	}
+}
+
+extension AsyncButton where Label == Text {
+	init(_ title: String, action: @escaping () async -> Void) {
+		self.init(action: action) { Text(title) }
+	}
+}

--- a/Client/LLMModeSettingsView.swift
+++ b/Client/LLMModeSettingsView.swift
@@ -75,7 +75,6 @@ private struct LocalModeConfig: View {
 	@AppStorage("whisperaLocalServerURL") private var serverURL = WhisperaSettings.defaultLocalServerURL
 	@AppStorage("whisperaLocalModel") private var model = ""
 	@State private var testResult: String?
-	@State private var testing = false
 
 	var body: some View {
 		SettingsSection("Local Server") {
@@ -92,9 +91,7 @@ private struct LocalModeConfig: View {
 					.textFieldStyle(.roundedBorder)
 					.autocorrectionDisabled()
 				HStack {
-					Button("Test") { runTest() }
-						.disabled(testing)
-					if testing { ProgressView().scaleEffect(0.7) }
+					AsyncButton("Test") { await runTest() }
 					if let testResult {
 						Text(testResult)
 							.font(.caption)
@@ -106,18 +103,14 @@ private struct LocalModeConfig: View {
 		}
 	}
 
-	private func runTest() {
-		testing = true
+	private func runTest() async {
 		testResult = nil
-		Task {
-			defer { testing = false }
-			do {
-				let reply = try await LocalLLMExecutor().chat(
-					system: nil, prompt: "Reply with the single word: OK", model: nil, maxTokens: 10)
-				testResult = "OK — \(reply.prefix(40))"
-			} catch {
-				testResult = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-			}
+		do {
+			let reply = try await LocalLLMExecutor().chat(
+				system: nil, prompt: "Reply with the single word: OK", model: nil, maxTokens: 10)
+			testResult = "OK — \(reply.prefix(40))"
+		} catch {
+			testResult = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
 		}
 	}
 }

--- a/Client/RecipesView.swift
+++ b/Client/RecipesView.swift
@@ -68,7 +68,7 @@ struct RecipesView: View {
 				.font(.headline)
 			if store.isSyncing { ProgressView().scaleEffect(0.6) }
 			Spacer()
-			Button("Load Starter Set") { Task { await store.loadDefaults() } }
+			AsyncButton("Load Starter Set") { await store.loadDefaults() }
 			Button {
 				isCreating = true
 			} label: {

--- a/What's up?/ListeningView.swift
+++ b/What's up?/ListeningView.swift
@@ -37,6 +37,10 @@ struct ListeningView: View {
 				Image(systemName: deviceManager.selectedDevice?.iconName ?? "mic.fill")
 					.font(.system(size: 11))
 					.foregroundColor(.secondary)
+
+				stopButton(help: "Cancel microphone setup") {
+					audioManager.cancelMicrophoneInitialization()
+				}
 			}
 		case .transcribing:
 			if whisperKit.isWaitingForModel
@@ -71,17 +75,22 @@ struct ListeningView: View {
 
 				AudioMeterView(levels: audioManager.audioLevels)
 
-				Button(action: {
+				stopButton(help: "Stop recording") {
 					audioManager.toggleRecording()
-				}) {
-					Image(systemName: "stop.circle.fill")
-						.font(.system(size: 16))
-						.foregroundColor(.secondary)
 				}
-				.buttonStyle(.plain)
-				.help("Stop recording")
 			}
 		}
+	}
+
+	/// The pill's stop control, shared by the recording and initializing states. WHI-54.
+	private func stopButton(help: String, action: @escaping () -> Void) -> some View {
+		Button(action: action) {
+			Image(systemName: "stop.circle.fill")
+				.font(.system(size: 16))
+				.foregroundColor(.secondary)
+		}
+		.buttonStyle(.plain)
+		.help(help)
 	}
 
 	/// Single pill control that opens the Control-Center-style dropdown
@@ -110,7 +119,9 @@ struct ListeningView: View {
 			.foregroundColor(.secondary)
 		}
 		.buttonStyle(.plain)
-		.help("Input device & post-dictation action — \(ListeningPostAction.label(defaultCommandId: defaultCommandId, recipes: recipeStore.recipes))")
+		.help(
+			"Input device & post-dictation action — \(ListeningPostAction.label(defaultCommandId: defaultCommandId, recipes: recipeStore.recipes))"
+		)
 	}
 
 	private var pillContent: some View {

--- a/WhisperaTests/AudioDeviceManagerTests.swift
+++ b/WhisperaTests/AudioDeviceManagerTests.swift
@@ -21,14 +21,14 @@ final class AudioDeviceManagerTests: XCTestCase {
 	// MARK: - Device Enumeration
 
 	func testEnumerateDevicesReturnsAtLeastOneDevice() async throws {
-		deviceManager.refreshDevices()
+		await deviceManager.refreshDevices()
 		XCTAssertFalse(
 			deviceManager.availableDevices.isEmpty,
 			"Should find at least one input device")
 	}
 
 	func testAllDevicesHaveUIDsAndNames() async throws {
-		deviceManager.refreshDevices()
+		await deviceManager.refreshDevices()
 		for device in deviceManager.availableDevices {
 			XCTAssertFalse(device.uid.isEmpty, "Device '\(device.name)' should have a UID")
 			XCTAssertFalse(device.name.isEmpty, "Device with UID '\(device.uid)' should have a name")
@@ -36,13 +36,13 @@ final class AudioDeviceManagerTests: XCTestCase {
 	}
 
 	func testExactlyOneDefaultDevice() async throws {
-		deviceManager.refreshDevices()
+		await deviceManager.refreshDevices()
 		let defaultDevices = deviceManager.availableDevices.filter { $0.isDefault }
 		XCTAssertEqual(defaultDevices.count, 1, "There should be exactly one default input device")
 	}
 
 	func testDeviceUIDsAreUnique() async throws {
-		deviceManager.refreshDevices()
+		await deviceManager.refreshDevices()
 		let uids = deviceManager.availableDevices.map(\.uid)
 		let uniqueUIDs = Set(uids)
 		XCTAssertEqual(uids.count, uniqueUIDs.count, "All device UIDs should be unique")
@@ -57,7 +57,7 @@ final class AudioDeviceManagerTests: XCTestCase {
 	}
 
 	func testSelectSpecificDevice() async throws {
-		deviceManager.refreshDevices()
+		await deviceManager.refreshDevices()
 		guard let firstDevice = deviceManager.availableDevices.first else {
 			throw XCTSkip("No input devices available")
 		}
@@ -70,7 +70,7 @@ final class AudioDeviceManagerTests: XCTestCase {
 	// MARK: - Persistence
 
 	func testPersistsToUserDefaults() async throws {
-		deviceManager.refreshDevices()
+		await deviceManager.refreshDevices()
 		guard let firstDevice = deviceManager.availableDevices.first else {
 			throw XCTSkip("No input devices available")
 		}
@@ -106,7 +106,7 @@ final class AudioDeviceManagerTests: XCTestCase {
 	}
 
 	func testResolveSpecificDevice() async throws {
-		deviceManager.refreshDevices()
+		await deviceManager.refreshDevices()
 		guard let firstDevice = deviceManager.availableDevices.first else {
 			throw XCTSkip("No input devices available")
 		}
@@ -152,7 +152,8 @@ final class AudioDeviceManagerTests: XCTestCase {
 
 	func testAudioInputDeviceEquality() async throws {
 		let device1 = AudioInputDevice(id: 1, uid: "uid-1", name: "Mic 1", isDefault: true, transportType: 0)
-		let device2 = AudioInputDevice(id: 2, uid: "uid-1", name: "Mic 1 Renamed", isDefault: false, transportType: 0)
+		let device2 = AudioInputDevice(
+			id: 2, uid: "uid-1", name: "Mic 1 Renamed", isDefault: false, transportType: 0)
 		let device3 = AudioInputDevice(id: 3, uid: "uid-2", name: "Mic 2", isDefault: false, transportType: 0)
 
 		XCTAssertEqual(device1, device2, "Devices with same UID should be equal")


### PR DESCRIPTION
## WHI-54 — Non-blocking, cancellable microphone initialization
Stacked on the WHI-53 PR. Base: `ismatulla/whi-53-qa-install-signing`.

### Root cause
`AudioManager`/`AudioDeviceManager`/`AudioEngineController` are `@MainActor`, and their `Task { }` blocks inherit it — so `AVAudioEngine` bring-up (device set, format checks, `start()`) ran on the main thread. A slow wireless/Continuity mic blocks that for seconds → the whole app froze with no way out.

### Changes
- **Engine bring-up off the main actor:** blocking work extracted into a `nonisolated static buildAndStartEngine` run via `Task.detached` (same pattern as the existing `setSystemDefaultInputDeviceSync`); a cancel that lands mid-spin-up stops and discards the late engine.
- **Cancellable init:** new `AudioManager.cancelMicrophoneInitialization()`; the pill's stop button is now a shared `stopButton(help:action:)` shown in **both** the initializing state (cancel) and the recording state (stop). Also fixed: a cancel during setup no longer falls into the error path that silently started file-based recording as a fallback.
- **Reusable `AsyncButton`:** spinner while pending, disables itself, cancels on disappear. Adopted at the three hand-rolled waiting spots (AI Mode *Test*, Account *Verify & Sign In*, Commands *Load Starter Set*), deleting their per-view spinner state.

### Verification
- Build + lint clean; 70 unit tests green (full client regression).
- The freeze itself requires the slow-mic hardware to reproduce — cannot be automated here; manual QA: start with a Continuity mic → UI responsive, stop button works mid-init.