### PR TITLE
feat(scripts): QA worktree and screen-record helpers

### DIFF
--- a/scripts/qa-record.sh
+++ b/scripts/qa-record.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Screen-records a QA run as a start/stop pair so the driver can act in
+# between. stop remuxes with faststart so the file is streamable/attachable.
+# Requires the invoking terminal to have the Screen Recording TCC grant.
+set -euo pipefail
+
+OUT_DIR="${WHISPERA_QA_DIR:-$HOME/qa-artifacts/whispera}"
+PID_FILE="/tmp/whispera-qa-record.pid"
+RAW="$OUT_DIR/raw.mov"
+
+case "${1:-}" in
+  start)
+    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      echo "already recording (pid $(cat "$PID_FILE"))" >&2
+      exit 1
+    fi
+    mkdir -p "$OUT_DIR"
+    rm -f "$RAW"
+    screencapture -v "$RAW" &
+    echo $! > "$PID_FILE"
+    echo "recording pid $(cat "$PID_FILE") -> $RAW"
+    ;;
+  stop)
+    SLUG="${2:-demo}"
+    [ -f "$PID_FILE" ] || { echo "no recording in progress" >&2; exit 1; }
+    PID="$(cat "$PID_FILE")"
+    # screencapture sometimes ignores a single SIGINT, which leaves a
+    # moov-less unplayable file — re-signal until the process exits.
+    for _ in 1 2 3 4 5; do
+      kill -0 "$PID" 2>/dev/null || break
+      kill -INT "$PID" 2>/dev/null || true
+      sleep 1
+    done
+    rm -f "$PID_FILE"
+    if kill -0 "$PID" 2>/dev/null; then
+      echo "recorder did not exit; recording not finalized" >&2
+      exit 1
+    fi
+    if [ ! -s "$RAW" ]; then
+      echo "no recording produced — is Screen Recording granted to this terminal?" >&2
+      exit 1
+    fi
+    OUT="$OUT_DIR/$SLUG.mp4"
+    ffmpeg -y -loglevel error -i "$RAW" \
+      -vf 'scale=trunc(iw/2)*2:trunc(ih/2)*2' -pix_fmt yuv420p \
+      -movflags +faststart "$OUT"
+    rm -f "$RAW"
+    SECS="$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$OUT" | cut -d. -f1)"
+    echo "saved ${SECS}s -> $OUT"
+    ;;
+  *)
+    echo "usage: $(basename "$0") start | stop [slug]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/qa-worktree.sh
+++ b/scripts/qa-worktree.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Creates an isolated worktree + branch for a QA run so the main checkout's
+# branch is never touched. Worktrees live outside the repo so Xcode and SPM
+# never index them from the main checkout.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WT_BASE="${WHISPERA_WT_BASE:-$HOME/Developer/whispera-worktrees}"
+
+usage() {
+  echo "usage: $(basename "$0") <slug> | --rm <slug> | --list" >&2
+  exit 1
+}
+
+case "${1:-}" in
+  --list)
+    git -C "$ROOT" worktree list
+    exit 0
+    ;;
+  --rm)
+    [ -n "${2:-}" ] || usage
+    git -C "$ROOT" worktree remove --force "$WT_BASE/$2"
+    git -C "$ROOT" worktree prune
+    exit 0
+    ;;
+  "" | -*)
+    usage
+    ;;
+esac
+
+SLUG="$1"
+BRANCH="${QA_BRANCH:-sapoepsilon/autoship-$SLUG}"
+WT="$WT_BASE/$SLUG"
+
+if [ -d "$WT" ]; then
+  echo "$WT"
+  exit 0
+fi
+
+git -C "$ROOT" fetch origin main
+mkdir -p "$WT_BASE"
+if git -C "$ROOT" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git -C "$ROOT" worktree add "$WT" "$BRANCH"
+else
+  git -C "$ROOT" worktree add -b "$BRANCH" "$WT" origin/main
+fi
+echo "$WT"


### PR DESCRIPTION
Adds two small helpers for automated QA runs:

- **`scripts/qa-worktree.sh <slug>`** — creates an isolated git worktree at `~/Developer/whispera-worktrees/<slug>` on a fresh branch from `origin/main`, so QA builds never touch the main checkout's branch. `--rm <slug>` removes it, `--list` shows all worktrees. Override the base dir with `WHISPERA_WT_BASE` or the branch with `QA_BRANCH`.
- **`scripts/qa-record.sh start|stop [slug]`** — screen-records a QA session via `screencapture -v`, then remuxes with ffmpeg (`+faststart`, even dimensions) to `~/qa-artifacts/whispera/<slug>.mp4`. Guards against the recorder ignoring a single SIGINT (which leaves an unplayable moov-less file) and reports if the Screen Recording permission is missing.

Both are macOS-only, dependency-light (git, screencapture, ffmpeg), and complement the existing `scripts/install-qa.sh` flow.