### PR TITLE
build(qa): QA install script with clean derived data and headless-safe signing

### DIFF
--- a/Whispera.xcodeproj/xcshareddata/xcschemes/Whispera.xcscheme
+++ b/Whispera.xcodeproj/xcshareddata/xcschemes/Whispera.xcscheme
@@ -9,7 +9,7 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">

--- a/scripts/install-qa.sh
+++ b/scripts/install-qa.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Builds a Release QA build, stamps a high QA version on the built product,
+# re-signs it with the production Developer ID, and installs to /Applications.
+#
+# Why Developer ID: macOS TCC keys permission grants (Accessibility, Microphone)
+# on the signing identity + bundle id. Production ships as Developer ID
+# (NK28QT38A3); a QA build signed any other way makes macOS treat it as a
+# different app, silently invalidating grants until the app is deleted and
+# re-authorized. Signing QA installs identically means you grant once and every
+# later install keeps the permissions. (Pre-granting TCC at deploy time is not
+# possible on macOS outside MDM.) WHI-53.
+
+set -euo pipefail
+
+DEVELOPER_ID="Developer ID Application: Ismatulla Mansurov (NK28QT38A3)"
+QA_VERSION="${QA_VERSION:-1.99.0}"
+QA_BUILD="${QA_BUILD:-999}"
+APP_PATH="/Applications/Whispera.app"
+
+cd "$(dirname "$0")/.."
+
+echo "Building Release..."
+# Dedicated derived-data path: the shared DerivedData products dir gets XCTest
+# frameworks injected into the app by test builds, which breaks re-signing.
+QA_DERIVED="build/qa-derived"
+rm -rf "$QA_DERIVED/Build/Products"
+# Skip Xcode's own signing: it needs the Apple Development key, which locked
+# keychains (SSH/headless runs) refuse with errSecInternalComponent. The
+# Developer ID re-sign below is the only signature that matters.
+xcodebuild -scheme Whispera -project Whispera.xcodeproj \
+  -configuration Release -destination 'platform=macOS,arch=arm64' \
+  -derivedDataPath "$QA_DERIVED" \
+  CODE_SIGNING_ALLOWED=NO build | tail -2
+
+APP="$QA_DERIVED/Build/Products/Release/Whispera.app"
+echo "Built: $APP"
+
+# High QA version so Sparkle never "updates" the QA build back to a release.
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${QA_VERSION}" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${QA_BUILD}" "$APP/Contents/Info.plist"
+
+echo "Re-signing with: $DEVELOPER_ID"
+SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
+if [ -d "$SPARKLE" ]; then
+  for xpc in "$SPARKLE"/Versions/*/XPCServices/*.xpc; do
+    [ -e "$xpc" ] || continue
+    codesign --force --options runtime --sign "$DEVELOPER_ID" "$xpc"
+  done
+  for helper in "$SPARKLE"/Versions/*/Updater.app "$SPARKLE"/Versions/*/Autoupdate; do
+    [ -e "$helper" ] || continue
+    codesign --force --options runtime --sign "$DEVELOPER_ID" "$helper"
+  done
+fi
+for fw in "$APP"/Contents/Frameworks/*.framework; do
+  [ -e "$fw" ] || continue
+  codesign --force --options runtime --sign "$DEVELOPER_ID" "$fw"
+done
+codesign --force --options runtime \
+  --entitlements Whispera.entitlements \
+  --sign "$DEVELOPER_ID" "$APP"
+codesign --verify --strict "$APP"
+
+echo "Installing to $APP_PATH..."
+pkill -9 -f "Whispera.app/Contents/MacOS/Whispera" 2>/dev/null || true
+sleep 1
+rm -rf "$APP_PATH"
+ditto "$APP" "$APP_PATH"
+open "$APP_PATH"
+
+echo "Installed Whispera ${QA_VERSION} (${QA_BUILD}) signed as production."
+echo ""
+echo "If permissions look stuck from a previously differently-signed install,"
+echo "clear the stale rows ONCE, then re-grant:"
+echo "  tccutil reset Accessibility com.macwhisper.app"
+echo "  tccutil reset Microphone com.macwhisper.app"


### PR DESCRIPTION
Extracts `scripts/install-qa.sh` (WHI-53) from the PR stack so it can merge to main independently, with fixes for unattended runs:

- **Clean derived data** (`build/qa-derived`): the shared DerivedData products dir gets XCTest frameworks injected by test builds, which broke the re-signing pass with contaminated app bundles.
- **Scheme fix**: the autocreated test plan entry had `buildForRunning=YES`, so even plain `xcodebuild build` built the hosted test bundle and injected `XCTest.framework`/`libXCTestBundleInject.dylib` into `Whispera.app`.
- **`CODE_SIGNING_ALLOWED=NO`**: Xcode's own signing needs the Apple Development key, which locked keychains (SSH/headless) refuse with `errSecInternalComponent`. The script's Developer ID re-sign is the only signature that matters for TCC persistence.

Why: macOS keys TCC grants (mic, Accessibility, Documents) to bundle id + signing identity. QA builds signed like production mean permissions are granted once and survive every rebuild — unsigned Debug fallbacks were re-triggering all permission prompts on each build.

Note: PR #56 in the stack carries the original version of this script and will need a trivial rebase once this lands.