### PR TITLE
feat(auth): add Clerk sign-in flow (WHI-45)

### DIFF
--- a/Client/AccountSettingsView.swift
+++ b/Client/AccountSettingsView.swift
@@ -3,6 +3,11 @@
 
 import SwiftUI
 
+#if canImport(ClerkKit)
+import ClerkKit
+import ClerkKitUI
+#endif
+
 /// Settings tab for connecting the Mac client to the Whispera backend and
 /// signing in for Subscription mode. See WHI-24 / WHI-45.
 struct AccountSettingsView: View {
@@ -11,7 +16,7 @@ struct AccountSettingsView: View {
 	@State private var token = ""
 
 	var body: some View {
-		ScrollView {
+		let content = ScrollView {
 			VStack(spacing: 24) {
 				SettingsSection("Whispera Server") {
 					VStack(alignment: .leading, spacing: 8) {
@@ -44,6 +49,19 @@ struct AccountSettingsView: View {
 			.padding(20)
 		}
 		.task { await auth.refresh() }
+		.sheet(isPresented: $auth.isClerkSheetPresented) {
+			ClerkSignInSheet(auth: auth)
+		}
+
+		#if canImport(ClerkKit)
+		if ClerkBridge.shared.isConfigured {
+			content.environment(Clerk.shared)
+		} else {
+			content
+		}
+		#else
+		content
+		#endif
 	}
 
 	private var signedInView: some View {
@@ -62,13 +80,10 @@ struct AccountSettingsView: View {
 
 	private var signedOutView: some View {
 		VStack(alignment: .leading, spacing: 12) {
-			Button {
-				Task { await auth.signInWithClerk() }
-			} label: {
-				Label("Sign in with Clerk", systemImage: "person.crop.circle")
+			AsyncButton("Sign in with Clerk") {
+				await auth.signInWithClerk()
 			}
 			.buttonStyle(.borderedProminent)
-			.disabled(auth.isWorking)
 
 			Divider()
 
@@ -91,3 +106,39 @@ struct AccountSettingsView: View {
 		}
 	}
 }
+
+private struct ClerkSignInSheet: View {
+	let auth: AuthManager
+
+	var body: some View {
+		#if canImport(ClerkKit)
+		ClerkAuthView(auth: auth)
+		#else
+		Text("Clerk SDK is unavailable in this build.")
+			.padding(24)
+		#endif
+	}
+}
+
+#if canImport(ClerkKit)
+private struct ClerkAuthView: View {
+	@Environment(Clerk.self) private var clerk
+	let auth: AuthManager
+
+	var body: some View {
+		AuthView(mode: .signIn)
+			.task {
+				for await event in clerk.auth.events {
+					switch event {
+					case .sessionChanged(_, let newValue) where newValue?.status == .active:
+						await auth.completeClerkSignIn()
+					case .signInCompleted:
+						await auth.completeClerkSignIn()
+					default:
+						break
+					}
+				}
+			}
+	}
+}
+#endif

--- a/Client/AuthManager.swift
+++ b/Client/AuthManager.swift
@@ -15,21 +15,28 @@ final class AuthManager {
 	private(set) var isSignedIn = false
 	private(set) var user: WhisperaUser?
 	var lastError: String?
+	var isClerkSheetPresented = false
 
 	private let api: WhisperaAPIClient
 	private let tokenStore: AuthTokenStore
+	private let clerk: ClerkSessionProviding
 
-	init(api: WhisperaAPIClient = .shared, tokenStore: AuthTokenStore = .shared) {
+	init(
+		api: WhisperaAPIClient = .shared,
+		tokenStore: AuthTokenStore = .shared,
+		clerk: ClerkSessionProviding = ClerkBridge.shared
+	) {
 		self.api = api
 		self.tokenStore = tokenStore
+		self.clerk = clerk
 	}
 
 	var displayName: String {
-		user?.email ?? user?.name ?? user?.clerkId ?? "Signed in"
+		user?.email ?? user?.name ?? clerk.userEmail ?? clerk.userName ?? clerk.userId ?? user?.clerkId ?? "Signed in"
 	}
 
-	/// Saves a token (Clerk JWT or dev token) and verifies it against /auth/me.
-	/// Reverts the stored token if verification fails so we never persist a bad one.
+	/// Saves a dev token and verifies it against /auth/me. This hidden shortcut
+	/// keeps WHI-41/42 development unblocked while the real Clerk app is wired.
 	func signIn(token: String) async {
 		let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
 		guard !trimmed.isEmpty else {
@@ -37,19 +44,37 @@ final class AuthManager {
 			return
 		}
 
+		await verifyAndPersist(token: trimmed)
+	}
+
+	func signInWithClerk() async {
 		isWorking = true
 		lastError = nil
 		defer { isWorking = false }
 
 		do {
-			try tokenStore.save(trimmed)
-			let me = try await api.getMe()
-			user = me
-			isSignedIn = true
+			try await clerk.load()
+			if clerk.hasActiveSession {
+				try await persistCurrentClerkToken()
+			} else {
+				isClerkSheetPresented = true
+			}
 		} catch {
-			try? tokenStore.delete()
-			isSignedIn = false
-			user = nil
+			lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+		}
+	}
+
+	/// Called by the Clerk sheet/auth event listener after a native Clerk flow
+	/// creates or recovers an active session.
+	func completeClerkSignIn() async {
+		isWorking = true
+		lastError = nil
+		defer { isWorking = false }
+
+		do {
+			try await persistCurrentClerkToken()
+			isClerkSheetPresented = false
+		} catch {
 			lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
 		}
 	}
@@ -74,16 +99,33 @@ final class AuthManager {
 	}
 
 	func signOut() {
+		Task { try? await clerk.signOut() }
 		try? tokenStore.delete()
 		isSignedIn = false
 		user = nil
 		lastError = nil
+		isClerkSheetPresented = false
 	}
 
-	// ponytail: native Clerk sign-in (Clerk Swift SDK / hosted WebView) is deferred
-	// until a Clerk app + publishable key exist to test against. The dev-token path
-	// above covers Subscription-mode development today (backend NODE_ENV=test). WHI-45.
-	func signInWithClerk() async {
-		lastError = "Clerk sign-in isn't wired yet — use a token for now."
+	private func persistCurrentClerkToken() async throws {
+		guard let token = try await clerk.sessionToken(), !token.isEmpty else {
+			throw ClerkBridgeError.noActiveSession
+		}
+		await verifyAndPersist(token: token)
+	}
+
+	private func verifyAndPersist(token: String) async {
+		lastError = nil
+		do {
+			try tokenStore.save(token)
+			let me = try await api.getMe()
+			user = me
+			isSignedIn = true
+		} catch {
+			try? tokenStore.delete()
+			isSignedIn = false
+			user = nil
+			lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+		}
 	}
 }

--- a/Client/ClerkBridge.swift
+++ b/Client/ClerkBridge.swift
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+#if canImport(ClerkKit)
+import ClerkKit
+#endif
+
+/// Small adapter around Clerk's Swift SDK so the rest of the client can be
+/// tested without importing ClerkKit directly. Clerk's package supports native
+/// macOS targets, so WHI-45 uses the native SDK path rather than a WebView.
+@MainActor
+protocol ClerkSessionProviding: AnyObject {
+	var userEmail: String? { get }
+	var userName: String? { get }
+	var userId: String? { get }
+	var hasActiveSession: Bool { get }
+
+	func load() async throws
+	func sessionToken() async throws -> String?
+	func signOut() async throws
+}
+
+@MainActor
+final class ClerkBridge: ClerkSessionProviding {
+	static let shared = ClerkBridge()
+
+	private(set) var isConfigured = false
+
+	var userEmail: String? {
+		#if canImport(ClerkKit)
+		return Clerk.shared.user?.primaryEmailAddress?.emailAddress
+		#else
+		return nil
+		#endif
+	}
+
+	var userName: String? {
+		#if canImport(ClerkKit)
+		let user = Clerk.shared.user
+		return [user?.firstName, user?.lastName]
+			.compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+			.filter { !$0.isEmpty }
+			.joined(separator: " ")
+		#else
+		return nil
+		#endif
+	}
+
+	var userId: String? {
+		#if canImport(ClerkKit)
+		return Clerk.shared.user?.id
+		#else
+		return nil
+		#endif
+	}
+
+	var hasActiveSession: Bool {
+		#if canImport(ClerkKit)
+		return Clerk.shared.session != nil
+		#else
+		return false
+		#endif
+	}
+
+	func configureIfPossible() {
+		guard !isConfigured else { return }
+		guard let publishableKey = WhisperaSettings.clerkPublishableKey, !publishableKey.isEmpty else {
+			return
+		}
+
+		#if canImport(ClerkKit)
+		Clerk.configure(publishableKey: publishableKey)
+		isConfigured = true
+		#endif
+	}
+
+	func load() async throws {
+		#if canImport(ClerkKit)
+		configureIfPossible()
+		guard isConfigured else { throw ClerkBridgeError.missingPublishableKey }
+		_ = try await Clerk.shared.refreshEnvironment()
+		_ = try await Clerk.shared.refreshClient()
+		#endif
+	}
+
+	func handle(_ url: URL) async throws {
+		#if canImport(ClerkKit)
+		configureIfPossible()
+		guard isConfigured else { throw ClerkBridgeError.missingPublishableKey }
+		try await Clerk.shared.handle(url)
+		#endif
+	}
+
+	func sessionToken() async throws -> String? {
+		#if canImport(ClerkKit)
+		try await load()
+		return try await Clerk.shared.auth.getToken()
+		#else
+		return nil
+		#endif
+	}
+
+	func signOut() async throws {
+		#if canImport(ClerkKit)
+		configureIfPossible()
+		guard isConfigured else { return }
+		try await Clerk.shared.auth.signOut()
+		#endif
+	}
+}
+
+enum ClerkBridgeError: LocalizedError {
+	case missingPublishableKey
+	case noActiveSession
+
+	var errorDescription: String? {
+		switch self {
+		case .missingPublishableKey:
+			return "Set CLERK_PUBLISHABLE_KEY in the app environment before using Clerk sign-in."
+		case .noActiveSession:
+			return "No active Clerk session"
+		}
+	}
+}

--- a/Client/WhisperaSettings.swift
+++ b/Client/WhisperaSettings.swift
@@ -20,6 +20,14 @@ enum WhisperaSettings {
 		URL(string: serverURLString.trimmingCharacters(in: .whitespacesAndNewlines))
 	}
 
+	/// Clerk publishable key is deployment config, not a secret. For now this is
+	/// read from the app process environment so local/test builds can point at the
+	/// developer's Clerk instance without committing project-specific values.
+	static var clerkPublishableKey: String? {
+		ProcessInfo.processInfo.environment["CLERK_PUBLISHABLE_KEY"]?
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+	}
+
 	private static let defaultCommandIdKey = "whisperaDefaultCommandId"
 
 	/// Recipe id of the command that post-processes every dictation when no

--- a/Whispera.xcodeproj/project.pbxproj
+++ b/Whispera.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		D6LMTEST12F0000000000001 /* LargeModelTranscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6LMTEST22F0000000000001 /* LargeModelTranscriptionTests.swift */; };
 		D6SOFTUPD2ED700000000005 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6SOFTUPD2ED700000000004 /* SoftwareUpdater.swift */; };
 		D6SPARKLE2ED700000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = D6SPARKLE2ED700000000002 /* Sparkle */; };
+		D6CLERKBUILD000000000001 /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = D6CLERKPROD000000000001 /* ClerkKit */; };
+		D6CLERKBUILD000000000002 /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = D6CLERKPROD000000000002 /* ClerkKitUI */; };
 		FDB1B0A903214623AADB4048 /* KeyboardInputSourceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91EF5D0CAB5432B90AFFF23 /* KeyboardInputSourceManager.swift */; };
 		D6DEVMGR12F0000000000001 /* AudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEVMGR22F0000000000001 /* AudioDeviceManager.swift */; };
 		D6DEVMGR12F0000000000002 /* AudioDeviceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEVMGR22F0000000000002 /* AudioDeviceManagerTests.swift */; };
@@ -190,6 +192,8 @@
 				D6B81FB42DEFF5CC00D32F2A /* WhisperKit in Frameworks */,
 				D63900CF2E3D77B4005B5623 /* YouTubeKit in Frameworks */,
 				D6SPARKLE2ED700000000003 /* Sparkle in Frameworks */,
+				D6CLERKBUILD000000000001 /* ClerkKit in Frameworks */,
+				D6CLERKBUILD000000000002 /* ClerkKitUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -392,6 +396,10 @@
 				D6CLIENTSYNCGRP000000001 /* Client */,
 			);
 			name = Whispera;
+			packageProductDependencies = (
+				D6CLERKPROD000000000001 /* ClerkKit */,
+				D6CLERKPROD000000000002 /* ClerkKitUI */,
+			);
 			productName = MacWhisper;
 			productReference = 3A3A3A3A3A3A3A3A3A3A3A3A /* Whispera.app */;
 			productType = "com.apple.product-type.application";
@@ -479,6 +487,7 @@
 				D63900CD2E3D77B4005B5623 /* XCRemoteSwiftPackageReference "YouTubeKit" */,
 				D6D486302EA49C1F00C1D5FA /* XCRemoteSwiftPackageReference "WhisperKit" */,
 				D6SPARKLE2ED700000000001 /* XCRemoteSwiftPackageReference "Sparkle" */,
+				D6CLERKPKG000000000001 /* XCRemoteSwiftPackageReference "clerk-ios" */,
 			);
 			productRefGroup = 8A8A8A8A8A8A8A8A8A8A8A8A /* Products */;
 			projectDirPath = "";
@@ -992,6 +1001,14 @@
 				minimumVersion = 2.6.0;
 			};
 		};
+		D6CLERKPKG000000000001 /* XCRemoteSwiftPackageReference "clerk-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/clerk/clerk-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1024,6 +1041,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D6SPARKLE2ED700000000001 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		D6CLERKPROD000000000001 /* ClerkKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D6CLERKPKG000000000001 /* XCRemoteSwiftPackageReference "clerk-ios" */;
+			productName = ClerkKit;
+		};
+		D6CLERKPROD000000000002 /* ClerkKitUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D6CLERKPKG000000000001 /* XCRemoteSwiftPackageReference "clerk-ios" */;
+			productName = ClerkKitUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Whispera.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Whispera.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "df523d0548936977a9c633016a0e15bdd5a1f471c7b4d5de85d6193e889a2264",
+  "originHash" : "e5a7f607f1356b4f8d0e4a4e7ec156d798c58bcbb3f1660e76e1deedcd912e6a",
   "pins" : [
+    {
+      "identity" : "clerk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/clerk/clerk-ios",
+      "state" : {
+        "revision" : "0f7b836629e26e77787b6c9371f86a524d2debbd",
+        "version" : "1.3.0"
+      }
+    },
     {
       "identity" : "networkimage",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,24 @@
       "state" : {
         "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
         "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke.git",
+      "state" : {
+        "revision" : "63a8fcbd6621340a2410bc3e9575ac97058615f4",
+        "version" : "13.0.6"
+      }
+    },
+    {
+      "identity" : "phonenumberkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PhoneNumberKit/PhoneNumberKit",
+      "state" : {
+        "revision" : "ab06a8333394f4a4fb6eecca447dae0aa06c1eca",
+        "version" : "5.0.4"
       }
     },
     {

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -2,8 +2,17 @@ import AppKit
 import Sparkle
 import SwiftUI
 
+#if canImport(ClerkKit)
+import ClerkKit
+import ClerkKitUI
+#endif
+
 @main
 struct WhisperaApp: App {
+	init() {
+		ClerkBridge.shared.configureIfPossible()
+	}
+
 	@NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 	private let softwareUpdater = SoftwareUpdater()
 

--- a/WhisperaUnitTests/WhisperaAPIClientTests.swift
+++ b/WhisperaUnitTests/WhisperaAPIClientTests.swift
@@ -72,16 +72,38 @@ struct EmptyResponseProbe: Decodable {
 }
 
 @MainActor
+private final class MockClerkProvider: ClerkSessionProviding {
+	var userEmail: String? = "clerk@example.com"
+	var userName: String? = nil
+	var userId: String? = "clerk_user"
+	var hasActiveSession = false
+	var token: String?
+	var signOutCalled = false
+
+	func load() async throws {}
+	func sessionToken() async throws -> String? { token }
+	func signOut() async throws { signOutCalled = true }
+}
+
+@MainActor
 struct AuthManagerTests {
+
+	private func makeAuth(
+		mock: MockURLProtocol.Mock,
+		clerk: ClerkSessionProviding
+	) -> (AuthManager, AuthTokenStore) {
+		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
+		let client = WhisperaAPIClient(
+			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
+		let auth = AuthManager(api: client, tokenStore: store, clerk: clerk)
+		return (auth, store)
+	}
 
 	@Test func signInSuccessStoresUser() async {
 		let mock = MockURLProtocol.make(
 			status: 200, json: #"{"id":"u1","clerkId":"tok","email":"x@y.z","name":null}"#)
-		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
+		let (auth, store) = makeAuth(mock: mock, clerk: MockClerkProvider())
 		defer { try? store.delete() }
-		let client = WhisperaAPIClient(
-			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
-		let auth = AuthManager(api: client, tokenStore: store)
 
 		await auth.signIn(token: "tok")
 		#expect(auth.isSignedIn)
@@ -91,15 +113,57 @@ struct AuthManagerTests {
 
 	@Test func signInFailureRevertsToken() async {
 		let mock = MockURLProtocol.make(status: 401, json: #"{"error":"Unauthorized"}"#)
-		let store = AuthTokenStore(service: "com.whispera.clerk.test.\(UUID().uuidString)")
+		let (auth, store) = makeAuth(mock: mock, clerk: MockClerkProvider())
 		defer { try? store.delete() }
-		let client = WhisperaAPIClient(
-			session: mock.session, tokenStore: store, serverURLProvider: { mock.baseURL })
-		let auth = AuthManager(api: client, tokenStore: store)
 
 		await auth.signIn(token: "bad")
 		#expect(!auth.isSignedIn)
 		#expect((try? store.load()) == nil)
 		#expect(auth.lastError != nil)
+	}
+
+	@Test func clerkSignInPersistsSessionTokenAndUser() async {
+		let clerk = MockClerkProvider()
+		clerk.hasActiveSession = true
+		clerk.token = "clerk-jwt"
+		let mock = MockURLProtocol.make { request in
+			#expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer clerk-jwt")
+			let r = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+			return (r, Data(#"{"id":"u1","clerkId":"clerk_user","email":"clerk@example.com","name":null}"#.utf8))
+		}
+		let (auth, store) = makeAuth(mock: mock, clerk: clerk)
+		defer { try? store.delete() }
+
+		await auth.signInWithClerk()
+		#expect(auth.isSignedIn)
+		#expect(auth.user?.email == "clerk@example.com")
+		#expect((try? store.load()) == "clerk-jwt")
+		#expect(!auth.isClerkSheetPresented)
+	}
+
+	@Test func clerkSignInShowsSheetWhenNoActiveSession() async {
+		let clerk = MockClerkProvider()
+		clerk.hasActiveSession = false
+		let mock = MockURLProtocol.make(status: 200, json: #"{"ok":true}"#)
+		let (auth, store) = makeAuth(mock: mock, clerk: clerk)
+		defer { try? store.delete() }
+
+		await auth.signInWithClerk()
+		#expect(!auth.isSignedIn)
+		#expect(auth.isClerkSheetPresented)
+		#expect((try? store.load()) == nil)
+	}
+
+	@Test func signOutClearsTokenAndClerkSession() async {
+		let clerk = MockClerkProvider()
+		let mock = MockURLProtocol.make(status: 200, json: #"{"ok":true}"#)
+		let (auth, store) = makeAuth(mock: mock, clerk: clerk)
+		try? store.save("persisted")
+
+		auth.signOut()
+		try? await Task.sleep(for: .milliseconds(20))
+		#expect((try? store.load()) == nil)
+		#expect(!auth.isSignedIn)
+		#expect(clerk.signOutCalled)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds Clerk's native Swift SDK for macOS (`ClerkKit` / `ClerkKitUI`) and wires the Settings “Sign in with Clerk” sheet.
- Persists the resulting Clerk session JWT in Keychain service `com.whispera.clerk`, account `session`; API requests continue to read it at request time and send `Authorization: Bearer ...`.
- Keeps the hidden dev-token path for test backends and clears Keychain on sign-out.
- Adds auth manager/client tests for dev-token auth, Clerk-token persistence, sheet presentation, and sign-out clearing.

## Verification
- `xcodebuild -resolvePackageDependencies -scheme Whispera -destination "platform=macOS,arch=arm64"` ✅
- `xcodebuild -scheme Whispera -destination "platform=macOS,arch=arm64" CODE_SIGNING_ALLOWED=NO build` ✅
- Targeted `WhisperaAPIClientTests` compiled and the API client test cases passed, but the xcodebuild test runner still exits with the existing app bootstrap issue (`test runner exited with code 0 before establishing connection`).

## Notes
- Uses `CLERK_PUBLISHABLE_KEY` from the app process environment for now so we don't commit a Clerk project key.
- Based on the latest stacked PR branch `ismatulla/whi-54-nonblocking-mic-init`.