### PR TITLE
feat: add recording edge glow

### DIFF
--- a/AudioManager/AudioLevelMonitor.swift
+++ b/AudioManager/AudioLevelMonitor.swift
@@ -11,9 +11,17 @@ final class AudioLevelMonitor {
 
 	private let bandCount: Int
 	private let silenceThreshold: Float = 0.001
-	private var recentPeaks: [Float] = []
-	private let peakHistorySize = 60
-	private var adaptiveGain: Float = 5.0
+	// dB span mapped onto the 0...1 visual range below the adaptive ceiling
+	private let dynamicRangeDb: Float = 40
+	// the ceiling itself maps below 1.0 so ordinary speech, which hovers near
+	// its own recent peak in the log domain, doesn't pin the meters at max
+	private let headroomDb: Float = 8
+	// Rolling estimate of how loud "loud" is for the current mic, in dB.
+	// Mics differ wildly in sensitivity (AirPods report far hotter RMS than
+	// the built-in mic), so a fixed scale either pins the meters or flatlines
+	// them. The ceiling jumps up as soon as it is exceeded and decays slowly,
+	// and is deliberately NOT reset between recordings so calibration sticks.
+	private var ceilingDb: Float = -25
 
 	init(bandCount: Int = 7) {
 		self.bandCount = bandCount
@@ -22,6 +30,12 @@ final class AudioLevelMonitor {
 
 	var hasAudioActivity: Bool {
 		!isSilent && peakLevel > silenceThreshold
+	}
+
+	// normalized 0...1 loudness suitable for driving visuals; the loudest
+	// band tracks speech far better than the average, which dilutes bursts
+	var overallLevel: Float {
+		levels.max() ?? 0
 	}
 
 	var microphoneStatus: MicrophoneStatus {
@@ -42,7 +56,7 @@ final class AudioLevelMonitor {
 
 		let samplesPerBand = max(1, samples.count / bandCount)
 
-		var newLevels: [Float] = []
+		var bandRms: [Float] = []
 		var maxLevel: Float = 0
 		var sum: Float = 0
 
@@ -51,20 +65,18 @@ final class AudioLevelMonitor {
 			let end = min(start + samplesPerBand, samples.count)
 
 			guard start < samples.count else {
-				newLevels.append(0)
+				bandRms.append(0)
 				continue
 			}
 
 			let band = Array(samples[start..<end])
 			let rms = sqrt(band.map { $0 * $0 }.reduce(0, +) / Float(band.count))
-			let normalizedLevel = min(1.0, rms * adaptiveGain)
 
-			newLevels.append(normalizedLevel)
+			bandRms.append(rms)
 			maxLevel = max(maxLevel, rms)
 			sum += rms
 		}
 
-		levels = newLevels
 		peakLevel = maxLevel
 		averageLevel = sum / Float(bandCount)
 
@@ -74,26 +86,30 @@ final class AudioLevelMonitor {
 		} else {
 			consecutiveSilentFrames = 0
 			isSilent = false
-			updateAdaptiveGain(currentPeak: maxLevel)
+			updateCeiling(peakDb: decibels(maxLevel))
+		}
+
+		levels = bandRms.map(normalizedLevel)
+	}
+
+	private func updateCeiling(peakDb: Float) {
+		if peakDb > ceilingDb {
+			ceilingDb = min(0, ceilingDb + (peakDb - ceilingDb) * 0.5)
+		} else {
+			ceilingDb = max(-45, ceilingDb + (peakDb - ceilingDb) * 0.005)
 		}
 	}
 
-	private func updateAdaptiveGain(currentPeak: Float) {
-		recentPeaks.append(currentPeak)
-		if recentPeaks.count > peakHistorySize {
-			recentPeaks.removeFirst()
-		}
+	private func normalizedLevel(_ rms: Float) -> Float {
+		let floorDb = ceilingDb - dynamicRangeDb
+		let linear = min(1, max(0, (decibels(rms) - floorDb) / (dynamicRangeDb + headroomDb)))
+		// squaring expands the top of the range: speech chunks cluster within
+		// a few dB of each other, and without expansion they all read as max
+		return linear * linear
+	}
 
-		guard recentPeaks.count >= 10 else { return }
-
-		let sortedPeaks = recentPeaks.sorted()
-		let percentile90 = sortedPeaks[Int(Float(sortedPeaks.count) * 0.9)]
-
-		if percentile90 > 0.001 {
-			let targetGain = 0.7 / percentile90
-			let clampedGain = max(2.0, min(20.0, targetGain))
-			adaptiveGain = adaptiveGain * 0.95 + clampedGain * 0.05
-		}
+	private func decibels(_ rms: Float) -> Float {
+		20 * log10(max(rms, 1e-7))
 	}
 
 	func reset() {
@@ -102,8 +118,6 @@ final class AudioLevelMonitor {
 		averageLevel = 0
 		isSilent = true
 		consecutiveSilentFrames = 0
-		recentPeaks.removeAll()
-		adaptiveGain = 5.0
 	}
 
 	private func markSilent() {

--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -15,6 +15,20 @@ enum AudioState {
 	case transcribing
 }
 
+// Both recording windows route through this policy so they can never disagree
+// via separate preferences: exactly one surface is eligible per recording mode.
+enum RecordingWindowPolicy {
+	static func shouldShowListeningWindow(state: AudioState, mode: RecordingMode) -> Bool {
+		state != .idle && mode == .text
+	}
+
+	static func shouldShowLiveTranscriptionWindow(
+		mode: RecordingMode, transcriberWantsWindow: Bool
+	) -> Bool {
+		mode == .liveTranscription && transcriberWantsWindow
+	}
+}
+
 @MainActor
 @Observable
 final class AudioManager: NSObject {
@@ -70,7 +84,7 @@ final class AudioManager: NSObject {
 	@ObservationIgnored
 	@AppStorage("useStreamingTranscription") var useStreamingTranscription = true
 	@ObservationIgnored
-	@AppStorage("enableStreaming") var enableStreaming = true
+	@AppStorage("enableStreaming") var enableStreaming = Constants.enableStreamingDefault
 	@ObservationIgnored
 	@AppStorage("autoDetectLanguageFromKeyboard") var autoDetectLanguageFromKeyboard = false
 	@ObservationIgnored
@@ -108,11 +122,12 @@ final class AudioManager: NSObject {
 	// MARK: - Public API
 
 	func toggleRecording() {
-		currentRecordingMode = enableStreaming ? .liveTranscription : .text
-
 		if isRecording {
+			// Keep the mode the session started with: re-reading enableStreaming here
+			// would route stop to the wrong path if the setting changed mid-recording.
 			stopRecording()
 		} else {
+			currentRecordingMode = enableStreaming ? .liveTranscription : .text
 			startRecording()
 		}
 	}

--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -113,6 +113,11 @@ final class AudioManager: NSObject {
 	override init() {
 		super.init()
 		whisperKitTranscriber.startInitialization()
+		whisperKitTranscriber.onLiveAudioSamples = { [weak self] samples in
+			// WhisperKit delivers per-buffer chunks; cap the window so level
+			// math stays cheap even if a large backlog arrives at once
+			self?.levelMonitor.update(from: Array(samples.suffix(4800)))
+		}
 	}
 
 	func setupAudio() {
@@ -458,6 +463,7 @@ extension AudioManager {
 		playFeedbackSound(start: false)
 
 		whisperKitTranscriber.stopLiveStream()
+		levelMonitor.reset()
 		AppLogger.shared.audioManager.info("Live transcription stopped")
 
 		scheduleTimerReset()

--- a/Constants.swift
+++ b/Constants.swift
@@ -150,6 +150,9 @@ struct Constants {
 
 	public static let defaultLanguageCode = "en"
 	public static let defaultLanguageName = "english"
+	// Shared by every @AppStorage("enableStreaming") fallback and the first-launch
+	// defaults: divergent inline copies of this literal caused duplicate recording windows.
+	public static let enableStreamingDefault = true
 
 	// Helper to get sorted language names for UI
 	public static var sortedLanguageNames: [String] {

--- a/LiveTranscription/LiveTranscriptionWindow.swift
+++ b/LiveTranscription/LiveTranscriptionWindow.swift
@@ -51,9 +51,11 @@ class LiveTranscriptionWindow: NSWindow {
 			Task { @MainActor in
 				guard let self = self else { return }
 
-				let shouldShow =
-					self.whisperKit.shouldShowLiveTranscriptionWindow
-					&& (self.whisperKit.isTranscribing || self.whisperKit.isWaitingForModel)
+				let shouldShow = RecordingWindowPolicy.shouldShowLiveTranscriptionWindow(
+					mode: self.audioManager.currentRecordingMode,
+					transcriberWantsWindow: self.whisperKit.shouldShowLiveTranscriptionWindow
+						&& (self.whisperKit.isTranscribing || self.whisperKit.isWaitingForModel)
+				)
 
 				if shouldShow {
 					let newSize = self.calculateDynamicSize()

--- a/MenuBarView.swift
+++ b/MenuBarView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct MenuBarView: View {
 	@Bindable var audioManager: AudioManager
 	var whisperKit = WhisperKitTranscriber.shared
-	@AppStorage("globalShortcut") private var shortcutKey = "⌘⌥D"
+	@AppStorage("globalShortcut") private var shortcutKey = "⌥⌘R"
 	@AppStorage("globalCommandShortcut") private var commandShortcutKey = "⌘⌥C"
 	@AppStorage("enableTranslation") private var enableTranslation = false
 	@AppStorage("materialStyle") private var materialStyleRaw = MaterialStyle.default.rawValue

--- a/OnboardingView.swift
+++ b/OnboardingView.swift
@@ -17,7 +17,7 @@ struct OnboardingView: View {
 	@AppStorage("selectedModel") private var storedModel = ""
 	@AppStorage("launchAtStartup") private var storedLaunchAtLogin = false
 	@AppStorage("enableTranslation") private var enableTranslation = false
-	@AppStorage("enableStreaming") private var enableStreaming = true
+	@AppStorage("enableStreaming") private var enableStreaming = Constants.enableStreamingDefault
 	@AppStorage("selectedLanguage") private var selectedLanguage = Constants.defaultLanguageName
 	@AppStorage("materialStyle") private var materialStyleRaw = MaterialStyle.default.rawValue
 

--- a/RecordingGlow.metal
+++ b/RecordingGlow.metal
@@ -1,0 +1,32 @@
+#include <metal_stdlib>
+#include <SwiftUI/SwiftUI_Metal.h>
+using namespace metal;
+
+constant float glowWidth = 28.0;
+// exp(-4.6) < 1%: past this distance the glow is invisible, skip the math
+constant float glowCutoff = glowWidth * 4.6;
+
+static half3 spectrum(float t) {
+	return half3(0.5 + 0.5 * cos(6.2831853 * (float3(0.0, 0.33, 0.67) + t)));
+}
+
+[[stitchable]] half4 recordingGlow(
+	float2 position, half4 color, float4 bounds, float time, float pulse
+) {
+	float2 size = bounds.zw;
+	float edgeDistance = min(
+		min(position.x, size.x - position.x),
+		min(position.y, size.y - position.y)
+	);
+	if (edgeDistance > glowCutoff) {
+		return half4(0.0);
+	}
+	float intensity = exp(-edgeDistance / glowWidth) * pulse;
+
+	float2 centered = position - size * 0.5;
+	float angle = atan2(centered.y, centered.x) / 6.2831853;
+	half3 rgb = spectrum(angle + time * 0.2);
+
+	// premultiplied alpha, as SwiftUI colorEffect expects
+	return half4(rgb * half(intensity), half(intensity));
+}

--- a/RecordingGlow.metal
+++ b/RecordingGlow.metal
@@ -2,14 +2,16 @@
 #include <SwiftUI/SwiftUI_Metal.h>
 using namespace metal;
 
-constant float glowWidth = 28.0;
+constant float glowWidth = 24.0;
+// widest possible glow at full voice level
+constant float maxGlowWidth = glowWidth * 3.0;
 // exp(-4.6) < 1%: past this distance the glow is invisible, skip the math
-constant float glowCutoff = glowWidth * 4.6;
+constant float glowCutoff = maxGlowWidth * 4.6;
 constant float cornerRadius = 36.0;
-constant float tau = 6.2831853;
 
 [[stitchable]] half4 recordingGlow(
-	float2 position, half4 color, float4 bounds, half4 glowColor, float time, float pulse
+	float2 position, half4 color, float4 bounds, half4 glowColor, float time, float pulse,
+	float level
 ) {
 	float2 halfSize = bounds.zw * 0.5;
 	// signed distance to a rounded rectangle inset to the screen bounds,
@@ -22,11 +24,11 @@ constant float tau = 6.2831853;
 		return half4(0.0);
 	}
 
-	float2 centered = position - halfSize;
-	float angle = atan2(centered.y, centered.x) / tau;
-	// brightness-only wave traveling around the border; hue stays fixed
-	float travel = 0.6 + 0.4 * cos((angle - time * 0.2) * 2.0 * tau);
-	float intensity = exp(-edgeDistance / glowWidth) * pulse * travel;
+	// voice drives both thickness and brightness; at silence only a faint
+	// breathing base remains, so speech reads as a strong uniform bloom
+	float width = mix(glowWidth, maxGlowWidth, level);
+	float energy = mix(pulse * 0.45, 1.0, level);
+	float intensity = exp(-edgeDistance / width) * energy;
 
 	// premultiplied alpha, as SwiftUI colorEffect expects
 	half alpha = half(intensity) * glowColor.a;

--- a/RecordingGlow.metal
+++ b/RecordingGlow.metal
@@ -5,28 +5,30 @@ using namespace metal;
 constant float glowWidth = 28.0;
 // exp(-4.6) < 1%: past this distance the glow is invisible, skip the math
 constant float glowCutoff = glowWidth * 4.6;
-
-static half3 spectrum(float t) {
-	return half3(0.5 + 0.5 * cos(6.2831853 * (float3(0.0, 0.33, 0.67) + t)));
-}
+constant float cornerRadius = 36.0;
+constant float tau = 6.2831853;
 
 [[stitchable]] half4 recordingGlow(
-	float2 position, half4 color, float4 bounds, float time, float pulse
+	float2 position, half4 color, float4 bounds, half4 glowColor, float time, float pulse
 ) {
-	float2 size = bounds.zw;
-	float edgeDistance = min(
-		min(position.x, size.x - position.x),
-		min(position.y, size.y - position.y)
-	);
+	float2 halfSize = bounds.zw * 0.5;
+	// signed distance to a rounded rectangle inset to the screen bounds,
+	// negative inside; the glow hugs its rounded border instead of the
+	// sharp screen corners
+	float2 q = abs(position - halfSize) - (halfSize - cornerRadius);
+	float sdf = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - cornerRadius;
+	float edgeDistance = max(-sdf, 0.0);
 	if (edgeDistance > glowCutoff) {
 		return half4(0.0);
 	}
-	float intensity = exp(-edgeDistance / glowWidth) * pulse;
 
-	float2 centered = position - size * 0.5;
-	float angle = atan2(centered.y, centered.x) / 6.2831853;
-	half3 rgb = spectrum(angle + time * 0.2);
+	float2 centered = position - halfSize;
+	float angle = atan2(centered.y, centered.x) / tau;
+	// brightness-only wave traveling around the border; hue stays fixed
+	float travel = 0.6 + 0.4 * cos((angle - time * 0.2) * 2.0 * tau);
+	float intensity = exp(-edgeDistance / glowWidth) * pulse * travel;
 
 	// premultiplied alpha, as SwiftUI colorEffect expects
-	return half4(rgb * half(intensity), half(intensity));
+	half alpha = half(intensity) * glowColor.a;
+	return half4(glowColor.rgb * alpha, alpha);
 }

--- a/RecordingGlowWindow.swift
+++ b/RecordingGlowWindow.swift
@@ -1,0 +1,98 @@
+import AppKit
+import SwiftUI
+
+private let logger = AppLogger.shared.ui
+
+struct RecordingGlowView: View {
+	private let startDate = Date()
+
+	var body: some View {
+		// 30fps is indistinguishable for this slow ambient sweep and halves
+		// the GPU frame count on ProMotion displays
+		TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
+			let time = Float(context.date.timeIntervalSince(startDate))
+			Rectangle()
+				.colorEffect(
+					ShaderLibrary.recordingGlow(
+						.boundingRect,
+						.float(time),
+						.float(0.8 + 0.2 * sin(time * 2.0))
+					)
+				)
+		}
+		.ignoresSafeArea()
+	}
+}
+
+@MainActor
+final class RecordingGlowController {
+	private let audioManager: AudioManager
+	private var glowPanel: NSPanel?
+	private var screenObserver: NSObjectProtocol?
+
+	init(audioManager: AudioManager) {
+		self.audioManager = audioManager
+
+		screenObserver = NotificationCenter.default.addObserver(
+			forName: NSApplication.didChangeScreenParametersNotification,
+			object: nil,
+			queue: .main
+		) { [weak self] _ in
+			MainActor.assumeIsolated {
+				guard let self, let panel = self.glowPanel, let screen = NSScreen.main else { return }
+				panel.setFrame(screen.frame, display: true)
+			}
+		}
+	}
+
+	deinit {
+		if let observer = screenObserver {
+			NotificationCenter.default.removeObserver(observer)
+		}
+	}
+
+	func updateVisibility() {
+		let enabled = UserDefaults.standard.bool(forKey: "enableRecordingGlow")
+		if enabled && audioManager.currentState == .recording {
+			show()
+		} else {
+			hide()
+		}
+	}
+
+	private func show() {
+		guard glowPanel == nil else { return }
+		guard let screen = NSScreen.main else {
+			logger.error("No main screen available for recording glow")
+			return
+		}
+
+		let panel = NSPanel(
+			contentRect: screen.frame,
+			styleMask: [.borderless, .nonactivatingPanel],
+			backing: .buffered,
+			defer: false
+		)
+		panel.level = .screenSaver
+		panel.isOpaque = false
+		panel.backgroundColor = .clear
+		panel.hasShadow = false
+		panel.ignoresMouseEvents = true
+		panel.hidesOnDeactivate = false
+		panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
+		panel.contentView = NSHostingView(rootView: RecordingGlowView())
+		panel.orderFrontRegardless()
+
+		glowPanel = panel
+		logger.debug("Recording glow shown on screen \(screen.frame.debugDescription)")
+	}
+
+	private func hide() {
+		guard let panel = glowPanel else { return }
+		panel.orderOut(nil)
+		// dropping the panel tears down the TimelineView render loop so
+		// nothing animates while idle
+		glowPanel = nil
+		logger.debug("Recording glow hidden")
+	}
+}

--- a/RecordingGlowWindow.swift
+++ b/RecordingGlowWindow.swift
@@ -31,22 +31,41 @@ enum RecordingGlowColor {
 	}
 }
 
+// fast attack so the glow jumps with speech onset, slow release so it
+// decays smoothly instead of flickering between words
+private final class GlowLevelSmoother {
+	private var value: Float = 0
+	private var lastTime: Float?
+
+	func step(toward target: Float, at time: Float) -> Float {
+		let dt = lastTime.map { max(0, time - $0) } ?? 0
+		lastTime = time
+		let timeConstant: Float = target > value ? 0.03 : 0.2
+		value += (target - value) * (1 - exp(-dt / timeConstant))
+		return value
+	}
+}
+
 struct RecordingGlowView: View {
 	@AppStorage(RecordingGlowColor.key) private var glowColorHex = RecordingGlowColor.defaultHex
+	let levelMonitor: AudioLevelMonitor
 	private let startDate = Date()
+	private let smoother = GlowLevelSmoother()
 
 	var body: some View {
 		// 30fps is indistinguishable for this slow ambient sweep and halves
 		// the GPU frame count on ProMotion displays
 		TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
 			let time = Float(context.date.timeIntervalSince(startDate))
+			let level = smoother.step(toward: levelMonitor.overallLevel, at: time)
 			Rectangle()
 				.colorEffect(
 					ShaderLibrary.recordingGlow(
 						.boundingRect,
 						.color(RecordingGlowColor.color(fromHex: glowColorHex)),
 						.float(time),
-						.float(0.8 + 0.2 * sin(time * 2.0))
+						.float(0.8 + 0.2 * sin(time * 2.0)),
+						.float(level)
 					)
 				)
 		}
@@ -110,7 +129,8 @@ final class RecordingGlowController {
 		panel.ignoresMouseEvents = true
 		panel.hidesOnDeactivate = false
 		panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
-		panel.contentView = NSHostingView(rootView: RecordingGlowView())
+		panel.contentView = NSHostingView(
+			rootView: RecordingGlowView(levelMonitor: audioManager.levelMonitor))
 		panel.orderFrontRegardless()
 
 		glowPanel = panel

--- a/RecordingGlowWindow.swift
+++ b/RecordingGlowWindow.swift
@@ -3,7 +3,36 @@ import SwiftUI
 
 private let logger = AppLogger.shared.ui
 
+enum RecordingGlowColor {
+	static let key = "recordingGlowColor"
+	static let defaultHex = "0A84FF"
+
+	static func color(fromHex hex: String) -> Color {
+		var value: UInt64 = 0
+		let scanner = Scanner(string: hex)
+		guard hex.count == 6, scanner.scanHexInt64(&value), scanner.isAtEnd else {
+			return Color(red: 0x0A / 255.0, green: 0x84 / 255.0, blue: 1.0)
+		}
+		return Color(
+			red: Double((value >> 16) & 0xFF) / 255.0,
+			green: Double((value >> 8) & 0xFF) / 255.0,
+			blue: Double(value & 0xFF) / 255.0
+		)
+	}
+
+	static func hex(from color: Color) -> String {
+		guard let srgb = NSColor(color).usingColorSpace(.sRGB) else { return defaultHex }
+		return String(
+			format: "%02X%02X%02X",
+			Int(round(srgb.redComponent * 255)),
+			Int(round(srgb.greenComponent * 255)),
+			Int(round(srgb.blueComponent * 255))
+		)
+	}
+}
+
 struct RecordingGlowView: View {
+	@AppStorage(RecordingGlowColor.key) private var glowColorHex = RecordingGlowColor.defaultHex
 	private let startDate = Date()
 
 	var body: some View {
@@ -15,6 +44,7 @@ struct RecordingGlowView: View {
 				.colorEffect(
 					ShaderLibrary.recordingGlow(
 						.boundingRect,
+						.color(RecordingGlowColor.color(fromHex: glowColorHex)),
 						.float(time),
 						.float(0.8 + 0.2 * sin(time * 2.0))
 					)

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -55,7 +55,7 @@ struct SettingRow<Content: View>: View {
 	}
 
 	var body: some View {
-		HStack {
+		HStack(spacing: 12) {
 			VStack(alignment: .leading, spacing: 2) {
 				Text(label)
 					.font(.subheadline)
@@ -63,10 +63,12 @@ struct SettingRow<Content: View>: View {
 					Text(description)
 						.font(.caption)
 						.foregroundColor(.secondary)
+						.fixedSize(horizontal: false, vertical: true)
 				}
 			}
-			Spacer()
+			.frame(maxWidth: .infinity, alignment: .leading)
 			content
+				.layoutPriority(1)
 		}
 	}
 }
@@ -108,6 +110,7 @@ struct InfoBox<Content: View>: View {
 				.foregroundColor(style.color)
 				.imageScale(.medium)
 			content
+				.fixedSize(horizontal: false, vertical: true)
 				.frame(maxWidth: .infinity, alignment: .leading)
 		}
 		.padding(12)
@@ -123,7 +126,7 @@ struct InfoBox<Content: View>: View {
 }
 
 struct SettingsView: View {
-	@AppStorage("globalShortcut") private var globalShortcut = "⌘⌥D"
+	@AppStorage("globalShortcut") private var globalShortcut = "⌥⌘R"
 	@AppStorage("selectedModel") private var selectedModel = ""
 	@AppStorage("autoDownloadModel") private var autoDownloadModel = true
 	@AppStorage("soundFeedback") private var soundFeedback = true
@@ -131,7 +134,7 @@ struct SettingsView: View {
 	@AppStorage("stopSound") private var stopSound = "Pop"
 	@AppStorage("launchAtStartup") private var launchAtStartup = false
 	@AppStorage("enableTranslation") private var enableTranslation = false
-	@AppStorage("enableStreaming") private var enableStreaming = false
+	@AppStorage("enableStreaming") private var enableStreaming = Constants.enableStreamingDefault
 	@AppStorage("selectedLanguage") private var selectedLanguage = Constants.defaultLanguageName
 	@AppStorage("autoDetectLanguageFromKeyboard") private var autoDetectLanguageFromKeyboard = true
 	@AppStorage("autoExecuteCommands") private var autoExecuteCommands = false
@@ -501,14 +504,16 @@ struct SettingsView: View {
 					Divider()
 
 					SettingsSection("Performance") {
-						VStack(alignment: .leading, spacing: 8) {
-							Text("Optimized Compute Configuration")
-								.font(.subheadline)
-							Text(
-								"Audio processing uses CPU + GPU, text decoding uses CPU + Neural Engine for optimal performance on Apple Silicon."
-							)
-							.font(.caption)
-							.foregroundColor(.secondary)
+						InfoBox(style: .info) {
+							VStack(alignment: .leading, spacing: 4) {
+								Text("Optimized Compute Configuration")
+									.font(.subheadline)
+								Text(
+									"Audio processing uses CPU + GPU, text decoding uses CPU + Neural Engine for optimal performance on Apple Silicon."
+								)
+								.font(.caption)
+								.foregroundColor(.secondary)
+							}
 						}
 					}
 

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -138,6 +138,9 @@ struct SettingsView: View {
 	@AppStorage("globalCommandShortcut") private var globalCommandShortcut = "⌘⌥C"
 	@AppStorage("useStreamingTranscription") private var useStreamingTranscription = true
 	@AppStorage("shortcutHapticFeedback") private var shortcutHapticFeedback = false
+	@AppStorage("enableRecordingGlow") private var enableRecordingGlow = true
+	@AppStorage(RecordingGlowColor.key) private var recordingGlowColorHex = RecordingGlowColor
+		.defaultHex
 	@AppStorage("materialStyle") private var materialStyleRaw = MaterialStyle.default.rawValue
 
 	private var materialStyle: MaterialStyle {
@@ -297,6 +300,31 @@ struct SettingsView: View {
 							description: "Trackpad vibration when shortcut is triggered"
 						) {
 							Toggle("", isOn: $shortcutHapticFeedback)
+						}
+
+						SettingRow(
+							"Recording Glow",
+							description: "Glow around the screen edges while recording"
+						) {
+							Toggle("", isOn: $enableRecordingGlow)
+						}
+
+						if enableRecordingGlow {
+							SettingRow("Glow Color") {
+								ColorPicker(
+									"",
+									selection: Binding(
+										get: {
+											RecordingGlowColor.color(fromHex: recordingGlowColorHex)
+										},
+										set: {
+											recordingGlowColorHex = RecordingGlowColor.hex(from: $0)
+										}
+									),
+									supportsOpacity: false
+								)
+								.labelsHidden()
+							}
 						}
 					}
 					Divider()

--- a/What's up?/ListeningWindow.swift
+++ b/What's up?/ListeningWindow.swift
@@ -10,7 +10,6 @@ class ListeningWindow: NSWindow {
 	private var pickerWindow: NSWindow?
 	private var pickerToggleObserver: NSObjectProtocol?
 	private var pickerDismissObserver: NSObjectProtocol?
-	@AppStorage("enableStreaming") private var enableStreaming = false
 
 	init(audioManager: AudioManager) {
 		self.audioManager = audioManager
@@ -53,9 +52,10 @@ class ListeningWindow: NSWindow {
 	}
 
 	private func updateVisibility() {
-		let state = audioManager.currentState
-		let shouldShow = state == .initializing
-			|| (state != .idle && !enableStreaming)
+		let shouldShow = RecordingWindowPolicy.shouldShowListeningWindow(
+			state: audioManager.currentState,
+			mode: audioManager.currentRecordingMode
+		)
 
 		if shouldShow && !isVisible {
 			positionAtBottomCenter()

--- a/WhisperKitTranscriber.swift
+++ b/WhisperKitTranscriber.swift
@@ -21,6 +21,7 @@ import WhisperKit
 	var currentModel: String?
 	var downloadedModels: Set<String> = []
 	var onConfirmedTextChange: ((String) -> Void)?
+	@ObservationIgnored var onLiveAudioSamples: (@MainActor ([Float]) -> Void)?
 	var shouldShowLiveTranscriptionWindow: Bool = false
 	var isTranscribing: Bool = false
 	var decodingOptions: DecodingOptions?
@@ -571,9 +572,10 @@ import WhisperKit
 
 				await AudioDeviceManager.shared.activateSelectedDevice()
 				let selectedDeviceID = AudioDeviceManager.shared.resolveActiveDeviceID()
-				try? whisperKit.audioProcessor.startRecordingLive(inputDeviceID: selectedDeviceID) { [weak self] _ in
+				try? whisperKit.audioProcessor.startRecordingLive(inputDeviceID: selectedDeviceID) { [weak self] samples in
 					Task { @MainActor in
 						self?.shouldShowLiveTranscriptionWindow = true
+						self?.onLiveAudioSamples?(samples)
 					}
 				}
 				realtimeLoop()
@@ -600,7 +602,11 @@ import WhisperKit
 		whisperKit.audioProcessor.pauseRecording()
 
 		do {
-			try whisperKit.audioProcessor.resumeRecordingLive(inputDeviceID: newDeviceID, callback: nil)
+			try whisperKit.audioProcessor.resumeRecordingLive(inputDeviceID: newDeviceID) { [weak self] samples in
+				Task { @MainActor in
+					self?.onLiveAudioSamples?(samples)
+				}
+			}
 			let deviceName = newDeviceID.flatMap { id -> String? in
 				AudioDeviceManager.shared.availableDevices.first(where: { $0.id == id })?.name
 			} ?? "System Default"

--- a/Whispera.xcodeproj/project.pbxproj
+++ b/Whispera.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		D69B300D2DFA0E020024A2DA /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = D69B300C2DFA0E020024A2DA /* MarkdownUI */; };
 		D6B81FB42DEFF5CC00D32F2A /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = D6B81FB32DEFF5CC00D32F2A /* WhisperKit */; };
 		D6B81FB62DEFFE4000D32F2A /* RecordingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B81FB52DEFFE4000D32F2A /* RecordingIndicator.swift */; };
+		D6C10A012F20000000000002 /* RecordingGlowWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C10A012F20000000000001 /* RecordingGlowWindow.swift */; };
+		D6C10A022F20000000000002 /* RecordingGlow.metal in Sources */ = {isa = PBXBuildFile; fileRef = D6C10A022F20000000000001 /* RecordingGlow.metal */; };
 		D6BENCH012F0000000000001 /* BenchmarkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BENCH022F0000000000001 /* BenchmarkResult.swift */; };
 		D6BENCH012F0000000000002 /* BenchmarkRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BENCH022F0000000000002 /* BenchmarkRunner.swift */; };
 		D6BENCH012F0000000000003 /* BenchmarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BENCH022F0000000000003 /* BenchmarkView.swift */; };
@@ -158,6 +160,8 @@
 		D698B9062E18EC70008FE0CF /* VersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
 		D698B91C2E18F3DD008FE0CF /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
 		D6B81FB52DEFFE4000D32F2A /* RecordingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingIndicator.swift; sourceTree = "<group>"; };
+		D6C10A012F20000000000001 /* RecordingGlowWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingGlowWindow.swift; sourceTree = "<group>"; };
+		D6C10A022F20000000000001 /* RecordingGlow.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = RecordingGlow.metal; sourceTree = "<group>"; };
 		D6BENCH022F0000000000001 /* BenchmarkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkResult.swift; sourceTree = "<group>"; };
 		D6BENCH022F0000000000002 /* BenchmarkRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkRunner.swift; sourceTree = "<group>"; };
 		D6BENCH022F0000000000003 /* BenchmarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkView.swift; sourceTree = "<group>"; };
@@ -227,6 +231,8 @@
 				8A8A8A8A8A8A8A8A8A8A8A8A /* Products */,
 				2A2A2A2A2A2A2A2A2A2A2A2A /* WhisperaApp.swift */,
 				D6B81FB52DEFFE4000D32F2A /* RecordingIndicator.swift */,
+				D6C10A012F20000000000001 /* RecordingGlowWindow.swift */,
+				D6C10A022F20000000000001 /* RecordingGlow.metal */,
 				2A2A2A2A2A2A2A2A2A2A2A2B /* MenuBarView.swift */,
 				2A2A2A2A2A2A2A2A2A2A2A2C /* SettingsView.swift */,
 				B91EF5D0CAB5432B90AFFF23 /* KeyboardInputSourceManager.swift */,
@@ -554,6 +560,8 @@
 				1A1A1A1A1A1A1A1A1A1A1A1D /* AudioManager.swift in Sources */,
 				FDB1B0A903214623AADB4048 /* KeyboardInputSourceManager.swift in Sources */,
 				D6B81FB62DEFFE4000D32F2A /* RecordingIndicator.swift in Sources */,
+				D6C10A012F20000000000002 /* RecordingGlowWindow.swift in Sources */,
+				D6C10A022F20000000000002 /* RecordingGlow.metal in Sources */,
 				D698B91D2E18F3DD008FE0CF /* PermissionManager.swift in Sources */,
 				D63900D62E3D77EF005B5623 /* FileTranscriptionProtocols.swift in Sources */,
 				D63900D72E3D77EF005B5623 /* YouTubeTranscriptionManager.swift in Sources */,

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -109,7 +109,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 			return
 		}
 
-		setupDefaultsIfNeeded()
+		AppDelegate.registerInitialDefaults(in: .standard)
 
 		Task { @MainActor in
 			audioManager = AudioManager()
@@ -177,43 +177,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 		}
 	}
 
-	private func setupDefaultsIfNeeded() {
-		// Set default values if they don't exist
-		if UserDefaults.standard.object(forKey: "selectedModel") == nil {
-			UserDefaults.standard.set("openai_whisper-small.en", forKey: "selectedModel")
-		}
-
-		if UserDefaults.standard.object(forKey: "globalShortcut") == nil {
-			UserDefaults.standard.set("⌥⌘R", forKey: "globalShortcut")
-		}
-
-		if UserDefaults.standard.object(forKey: "startSound") == nil {
-			UserDefaults.standard.set("Tink", forKey: "startSound")
-		}
-
-		if UserDefaults.standard.object(forKey: "stopSound") == nil {
-			UserDefaults.standard.set("Pop", forKey: "stopSound")
-		}
-
-		if UserDefaults.standard.object(forKey: "launchAtStartup") == nil {
-			UserDefaults.standard.set(false, forKey: "launchAtStartup")
-		}
-
-		if UserDefaults.standard.object(forKey: "soundFeedback") == nil {
-			UserDefaults.standard.set(true, forKey: "soundFeedback")
-		}
-
-		if UserDefaults.standard.object(forKey: "enableRecordingGlow") == nil {
-			UserDefaults.standard.set(true, forKey: "enableRecordingGlow")
-		}
-
-		if UserDefaults.standard.object(forKey: "materialStyle") == nil {
-			UserDefaults.standard.set(MaterialStyle.default.rawValue, forKey: "materialStyle")
-		}
-
-		AppLogger.shared.general.info(
-			"Setup defaults - Model: \(UserDefaults.standard.string(forKey: "selectedModel") ?? "none")"
-		)
+	nonisolated static func registerInitialDefaults(in defaults: UserDefaults) {
+		defaults.register(defaults: [
+			"selectedModel": "openai_whisper-small.en",
+			"globalShortcut": "⌥⌘R",
+			"startSound": "Tink",
+			"stopSound": "Pop",
+			"launchAtStartup": false,
+			"soundFeedback": true,
+			"enableRecordingGlow": true,
+			"enableStreaming": Constants.enableStreamingDefault,
+			"materialStyle": MaterialStyle.default.rawValue,
+		])
 	}
 
 	func setupMenuBar() {

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -96,6 +96,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 	private var onboardingWindow: NSWindow?
 	private var liveTranscriptionWindow: LiveTranscriptionWindow?
 	private var listeningWindow: ListeningWindow?
+	private var recordingGlowController: RecordingGlowController?
 	private var popoverFrame: NSRect?
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
@@ -135,6 +136,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
 			liveTranscriptionWindow = LiveTranscriptionWindow(audioManager: audioManager)
 			listeningWindow = ListeningWindow(audioManager: audioManager)
+			recordingGlowController = RecordingGlowController(audioManager: audioManager)
 			if !hasCompletedOnboarding {
 				showOnboarding()
 			}
@@ -199,6 +201,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
 		if UserDefaults.standard.object(forKey: "soundFeedback") == nil {
 			UserDefaults.standard.set(true, forKey: "soundFeedback")
+		}
+
+		if UserDefaults.standard.object(forKey: "enableRecordingGlow") == nil {
+			UserDefaults.standard.set(true, forKey: "enableRecordingGlow")
 		}
 
 		if UserDefaults.standard.object(forKey: "materialStyle") == nil {
@@ -352,6 +358,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 		) { [weak self] _ in
 			Task { @MainActor in
 				self?.updateStatusIcon()
+				self?.recordingGlowController?.updateVisibility()
 			}
 		}
 

--- a/WhisperaUnitTests/RecordingGlowColorTests.swift
+++ b/WhisperaUnitTests/RecordingGlowColorTests.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import Testing
+
+@testable import Whispera
+
+struct RecordingGlowColorTests {
+
+	@Test func hexRoundTripsThroughColor() {
+		let hex = "3AF2C8"
+		#expect(RecordingGlowColor.hex(from: RecordingGlowColor.color(fromHex: hex)) == hex)
+	}
+
+	@Test func defaultHexRoundTrips() {
+		let color = RecordingGlowColor.color(fromHex: RecordingGlowColor.defaultHex)
+		#expect(RecordingGlowColor.hex(from: color) == RecordingGlowColor.defaultHex)
+	}
+
+	@Test(arguments: ["", "nope", "12345", "GGGGGG"])
+	func invalidHexFallsBackToDefault(invalid: String) {
+		let color = RecordingGlowColor.color(fromHex: invalid)
+		#expect(RecordingGlowColor.hex(from: color) == RecordingGlowColor.defaultHex)
+	}
+}

--- a/WhisperaUnitTests/RecordingWindowPolicyTests.swift
+++ b/WhisperaUnitTests/RecordingWindowPolicyTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+struct RecordingWindowPolicyTests {
+
+	@Test(arguments: [AudioState.initializing, .recording, .transcribing])
+	func liveModeNeverShowsLegacyListeningWindow(state: AudioState) {
+		#expect(
+			!RecordingWindowPolicy.shouldShowListeningWindow(state: state, mode: .liveTranscription),
+			"Live mode renders its own listening surface inside the live transcription window; showing the legacy window too duplicates it"
+		)
+	}
+
+	@Test(arguments: [AudioState.initializing, .recording, .transcribing])
+	func textModeShowsLegacyListeningWindow(state: AudioState) {
+		#expect(RecordingWindowPolicy.shouldShowListeningWindow(state: state, mode: .text))
+	}
+
+	@Test(arguments: [RecordingMode.text, .liveTranscription])
+	func idleHidesLegacyListeningWindow(mode: RecordingMode) {
+		#expect(!RecordingWindowPolicy.shouldShowListeningWindow(state: .idle, mode: mode))
+	}
+
+	@Test func textModeNeverShowsLiveTranscriptionWindow() {
+		#expect(
+			!RecordingWindowPolicy.shouldShowLiveTranscriptionWindow(
+				mode: .text, transcriberWantsWindow: true),
+			"Text mode renders the legacy listening window; the live window showing too duplicates it"
+		)
+	}
+
+	@Test func liveModeShowsLiveTranscriptionWindowOnlyWhenTranscriberWantsIt() {
+		#expect(
+			RecordingWindowPolicy.shouldShowLiveTranscriptionWindow(
+				mode: .liveTranscription, transcriberWantsWindow: true))
+		#expect(
+			!RecordingWindowPolicy.shouldShowLiveTranscriptionWindow(
+				mode: .liveTranscription, transcriberWantsWindow: false))
+	}
+}
+
+struct InitialDefaultsTests {
+
+	private func isolatedDefaults(_ label: String) -> (UserDefaults, String) {
+		let suiteName = "InitialDefaultsTests-\(label)-\(UUID().uuidString)"
+		return (UserDefaults(suiteName: suiteName)!, suiteName)
+	}
+
+	@Test func freshInstallRegistersEnableStreamingMatchingAudioManagerDefault() {
+		let (defaults, suiteName) = isolatedDefaults("fresh")
+		defer { defaults.removePersistentDomain(forName: suiteName) }
+
+		AppDelegate.registerInitialDefaults(in: defaults)
+
+		#expect(
+			defaults.object(forKey: "enableStreaming") != nil,
+			"Fresh installs must resolve enableStreaming so every window reads the same mode"
+		)
+		#expect(defaults.bool(forKey: "enableStreaming") == Constants.enableStreamingDefault)
+	}
+
+	@Test func existingEnableStreamingChoiceIsPreserved() {
+		let (defaults, suiteName) = isolatedDefaults("existing")
+		defer { defaults.removePersistentDomain(forName: suiteName) }
+
+		defaults.set(false, forKey: "enableStreaming")
+		AppDelegate.registerInitialDefaults(in: defaults)
+
+		#expect(defaults.bool(forKey: "enableStreaming") == false)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a Metal-backed animated multicolor edge glow while dictation is actively recording
- Shows the glow in a borderless, click-through, non-activating overlay panel on the main screen
- Hides and tears down the overlay when recording stops

## Verification
- xcodebuild -scheme Whispera CODE_SIGNING_ALLOWED=NO -configuration Debug -derivedDataPath build -destination "platform=macOS,arch=arm64" build: BUILD SUCCEEDED
- xcodebuild test runs hung in the SSH runner before reporting test cases, including -only-testing:WhisperaUnitTests; no test failures were emitted before timeout

## QA
- Signed QA install and recording demo pending
