### PR TITLE
fix(transcription): make timestamps the working default for file transcription

### DIFF
--- a/FileTranscription/FileTranscriptionManager.swift
+++ b/FileTranscription/FileTranscriptionManager.swift
@@ -32,7 +32,16 @@ class FileTranscriptionManager: FileTranscriptionCapable {
 	// MARK: - FileTranscriptionCapable Methods
 
 	func transcribeFile(at url: URL) async throws -> String {
-		logger.info("Starting file transcription for: \(url.lastPathComponent)")
+		let includeTimestamps = Self.resolveIncludeTimestamps(from: .standard)
+		logger.info("Resolved includeTimestamps: \(includeTimestamps)")
+		return try await transcribeFile(at: url, withTimestamps: includeTimestamps)
+	}
+
+	func transcribeFile(at url: URL, withTimestamps: Bool, timestampFormat: String? = nil)
+		async throws -> String
+	{
+		logger.info(
+			"Starting file transcription for: \(url.lastPathComponent) (timestamps: \(withTimestamps))")
 
 		guard supportsFileType(url) else {
 			throw FileTranscriptionError.unsupportedFormat(url.pathExtension)
@@ -43,20 +52,23 @@ class FileTranscriptionManager: FileTranscriptionCapable {
 		}
 		defer { url.stopAccessingSecurityScopedResource() }
 
-		// Check user setting for timestamps
-		let showTimestamps = UserDefaults.standard.bool(forKey: "showTimestamps")
-		logger.info("User setting showTimestamps: \(showTimestamps)")
-
-		if showTimestamps {
-			// Return timestamped transcription formatted as string
+		if withTimestamps {
 			let segments =
 				try await performSingleTranscription(url: url, withTimestamps: true)
 				as! [TranscriptionSegment]
-			return formatSegmentsAsString(segments)
+			return formatSegmentsAsString(segments, format: timestampFormat)
 		} else {
-			// Return plain text
 			return try await performSingleTranscription(url: url, withTimestamps: false) as! String
 		}
+	}
+
+	// Timestamps are on unless the user turned them off. Reads via object(forKey:)
+	// because bool(forKey:) returns false for absent keys, which silently disabled
+	// timestamps for anyone who never touched the Settings toggle.
+	nonisolated static func resolveIncludeTimestamps(from defaults: UserDefaults) -> Bool {
+		let mode = defaults.string(forKey: "defaultTranscriptionMode") ?? "timestamps"
+		let showTimestamps = defaults.object(forKey: "showTimestamps") as? Bool ?? true
+		return mode == "timestamps" && showTimestamps
 	}
 
 	func transcribeFiles(at urls: [URL]) async throws -> [String] {
@@ -149,8 +161,9 @@ class FileTranscriptionManager: FileTranscriptionCapable {
 
 	// MARK: - Private Helpers
 
-	private func formatSegmentsAsString(_ segments: [TranscriptionSegment]) -> String {
-		let timestampFormat = UserDefaults.standard.string(forKey: "timestampFormat") ?? "MM:SS"
+	func formatSegmentsAsString(_ segments: [TranscriptionSegment], format: String? = nil) -> String {
+		let timestampFormat =
+			format ?? UserDefaults.standard.string(forKey: "timestampFormat") ?? "MM:SS"
 		logger.info("Formatting \(segments.count) segments with timestamp format: \(timestampFormat)")
 
 		let formattedString = segments.map { segment in

--- a/FileTranscription/FileTranscriptionViewModel.swift
+++ b/FileTranscription/FileTranscriptionViewModel.swift
@@ -18,7 +18,7 @@ class FileTranscriptionViewModel {
 	// MARK: - Settings
 	@ObservationIgnored @AppStorage("showTimestamps") private var showTimestamps: Bool = true
 	@ObservationIgnored @AppStorage("timestampFormat") private var timestampFormat: String = "MM:SS"
-	@ObservationIgnored @AppStorage("defaultTranscriptionMode") private var defaultTranscriptionMode: String = "plain"
+	@ObservationIgnored @AppStorage("defaultTranscriptionMode") private var defaultTranscriptionMode: String = "timestamps"
 	@ObservationIgnored @AppStorage("maxFileSizeMB") private var maxFileSizeMB: Int = 100
 
 	// MARK: - Dependencies
@@ -222,7 +222,10 @@ class FileTranscriptionViewModel {
 					let transcriptionSegments =
 						try await fileTranscriptionManager.transcribeFileWithTimestamps(at: fileURL)
 					segments = transcriptionSegments
-					transcriptionText = transcriptionSegments.map { $0.text }.joined(separator: " ")
+					// The text representation keeps the timestamps; joining bare
+					// segment text silently dropped them from copy/save output.
+					transcriptionText = fileTranscriptionManager.formatSegmentsAsString(
+						transcriptionSegments)
 				} else {
 					transcriptionText = try await fileTranscriptionManager.transcribeFile(at: fileURL)
 					segments = nil

--- a/FileTranscription/YouTubeTranscriptionViewModel.swift
+++ b/FileTranscription/YouTubeTranscriptionViewModel.swift
@@ -30,7 +30,7 @@ class YouTubeTranscriptionViewModel {
 		var autoDeleteDownloadedFiles: Bool = true
 	@ObservationIgnored @AppStorage("showTimestamps") var showTimestamps: Bool = true
 	@ObservationIgnored @AppStorage("timestampFormat") private var timestampFormat: String = "MM:SS"
-	@ObservationIgnored @AppStorage("defaultTranscriptionMode") private var defaultTranscriptionMode: String = "plain"
+	@ObservationIgnored @AppStorage("defaultTranscriptionMode") private var defaultTranscriptionMode: String = "timestamps"
 
 	// MARK: - Dependencies
 	private let youtubeTranscriptionManager: YouTubeTranscriptionManager

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -168,7 +168,7 @@ struct SettingsView: View {
 	@AppStorage("youtubeQuality") private var youtubeQuality = "medium"
 	@AppStorage("showTimestamps") private var showTimestamps = true
 	@AppStorage("timestampFormat") private var timestampFormat = "MM:SS"
-	@AppStorage("defaultTranscriptionMode") private var defaultTranscriptionMode = "plain"
+	@AppStorage("defaultTranscriptionMode") private var defaultTranscriptionMode = "timestamps"
 	@AppStorage("maxFileSizeMB") private var maxFileSizeMB = 100
 
 	// MARK: - Injected Dependencies

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -187,6 +187,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 			"soundFeedback": true,
 			"enableRecordingGlow": true,
 			"enableStreaming": Constants.enableStreamingDefault,
+			"defaultTranscriptionMode": "timestamps",
+			"showTimestamps": true,
+			"timestampFormat": "MM:SS",
 			"materialStyle": MaterialStyle.default.rawValue,
 		])
 	}

--- a/WhisperaUnitTests/FileTranscriptionTimestampTests.swift
+++ b/WhisperaUnitTests/FileTranscriptionTimestampTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+
+@testable import Whispera
+
+// MARK: - Timestamp formatting (pure logic)
+
+@MainActor
+struct TimestampFormattingTests {
+
+	private func makeSegments() -> [TranscriptionSegment] {
+		[
+			TranscriptionSegment(text: "Hello world.", startTime: 0.0, endTime: 2.4),
+			TranscriptionSegment(text: "Second segment.", startTime: 65.2, endTime: 68.9),
+			TranscriptionSegment(text: "One hour in.", startTime: 3661.0, endTime: 3665.0),
+		]
+	}
+
+	@Test func formatsMinutesSeconds() {
+		let manager = FileTranscriptionManager()
+		let output = manager.formatSegmentsAsString(makeSegments(), format: "MM:SS")
+		let lines = output.components(separatedBy: "\n")
+
+		#expect(lines[0] == "[00:00] Hello world.")
+		#expect(lines[1] == "[01:05] Second segment.")
+		#expect(lines[2] == "[01:01] One hour in.")
+	}
+
+	@Test func formatsHoursMinutesSeconds() {
+		let manager = FileTranscriptionManager()
+		let output = manager.formatSegmentsAsString(makeSegments(), format: "HH:MM:SS")
+		let lines = output.components(separatedBy: "\n")
+
+		#expect(lines[0] == "[00:00:00] Hello world.")
+		#expect(lines[1] == "[00:01:05] Second segment.")
+		#expect(lines[2] == "[01:01:01] One hour in.")
+	}
+
+	@Test func formatsRawSeconds() {
+		let manager = FileTranscriptionManager()
+		let output = manager.formatSegmentsAsString(makeSegments(), format: "Seconds")
+
+		#expect(output.hasPrefix("[0.0s] Hello world."))
+		#expect(output.contains("[65.2s] Second segment."))
+	}
+
+	@Test func everyLineCarriesATimestampPrefix() {
+		let manager = FileTranscriptionManager()
+		let output = manager.formatSegmentsAsString(makeSegments(), format: "MM:SS")
+
+		for line in output.components(separatedBy: "\n") {
+			#expect(line.range(of: #"^\[\d{2}:\d{2}\] "#, options: .regularExpression) != nil)
+		}
+	}
+}
+
+// MARK: - Default resolution
+
+struct TimestampDefaultResolutionTests {
+
+	private func isolatedDefaults(_ name: String) -> UserDefaults {
+		let suite = "TimestampDefaultResolutionTests.\(name).\(UUID().uuidString)"
+		let defaults = UserDefaults(suiteName: suite)!
+		defaults.removePersistentDomain(forName: suite)
+		return defaults
+	}
+
+	@Test func timestampsAreOnByDefaultWhenNothingWasEverSet() {
+		let defaults = isolatedDefaults("untouched")
+		#expect(FileTranscriptionManager.resolveIncludeTimestamps(from: defaults) == true)
+	}
+
+	@Test func plainModeDisablesTimestamps() {
+		let defaults = isolatedDefaults("plain")
+		defaults.set("plain", forKey: "defaultTranscriptionMode")
+		#expect(FileTranscriptionManager.resolveIncludeTimestamps(from: defaults) == false)
+	}
+
+	@Test func explicitToggleOffDisablesTimestamps() {
+		let defaults = isolatedDefaults("toggledOff")
+		defaults.set("timestamps", forKey: "defaultTranscriptionMode")
+		defaults.set(false, forKey: "showTimestamps")
+		#expect(FileTranscriptionManager.resolveIncludeTimestamps(from: defaults) == false)
+	}
+
+	@Test func timestampsModeWithToggleOnEnablesTimestamps() {
+		let defaults = isolatedDefaults("bothOn")
+		defaults.set("timestamps", forKey: "defaultTranscriptionMode")
+		defaults.set(true, forKey: "showTimestamps")
+		#expect(FileTranscriptionManager.resolveIncludeTimestamps(from: defaults) == true)
+	}
+
+	@Test func registeredDefaultsEnableTimestampsOnFreshInstall() {
+		let defaults = isolatedDefaults("registered")
+		AppDelegate.registerInitialDefaults(in: defaults)
+		#expect(FileTranscriptionManager.resolveIncludeTimestamps(from: defaults) == true)
+		#expect(defaults.string(forKey: "timestampFormat") == "MM:SS")
+	}
+}
+
+// MARK: - End-to-end (real WhisperKit)
+
+// Renders a known phrase to an audio file with the system voice, transcribes it
+// through the real file-transcription pipeline, and asserts the timestamped and
+// plain outputs. Requires a downloaded Whisper model on the test machine.
+@MainActor
+struct FileTranscriptionTimestampE2ETests {
+
+	private func synthesizeFixture() throws -> URL {
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("timestamp-e2e-\(UUID().uuidString).aiff")
+		let say = Process()
+		say.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+		say.arguments = ["-o", url.path, "The quick brown fox jumps over the lazy dog"]
+		try say.run()
+		say.waitUntilExit()
+		try #require(say.terminationStatus == 0)
+		try #require(FileManager.default.fileExists(atPath: url.path))
+		return url
+	}
+
+	@Test(.timeLimit(.minutes(10)))
+	func timestampedTranscriptionCarriesTimestampsInEveryLine() async throws {
+		let fixture = try synthesizeFixture()
+		defer { try? FileManager.default.removeItem(at: fixture) }
+
+		let manager = FileTranscriptionManager()
+		let output = try await manager.transcribeFile(
+			at: fixture, withTimestamps: true, timestampFormat: "MM:SS")
+
+		try #require(!output.isEmpty)
+		#expect(output.lowercased().contains("fox"))
+
+		let lines = output.components(separatedBy: "\n").filter { !$0.isEmpty }
+		try #require(!lines.isEmpty)
+		for line in lines {
+			#expect(
+				line.range(of: #"^\[\d{2}:\d{2}\] "#, options: .regularExpression) != nil,
+				"line missing timestamp prefix: \(line)")
+		}
+	}
+
+	@Test(.timeLimit(.minutes(10)))
+	func plainTranscriptionCarriesNoTimestamps() async throws {
+		let fixture = try synthesizeFixture()
+		defer { try? FileManager.default.removeItem(at: fixture) }
+
+		let manager = FileTranscriptionManager()
+		let output = try await manager.transcribeFile(at: fixture, withTimestamps: false)
+
+		try #require(!output.isEmpty)
+		#expect(output.lowercased().contains("fox"))
+		#expect(output.range(of: #"\[\d{2}:\d{2}\]"#, options: .regularExpression) == nil)
+	}
+
+	@Test(.timeLimit(.minutes(10)))
+	func queuePathProducesTimestampsWithFreshDefaults() async throws {
+		let fixture = try synthesizeFixture()
+		defer { try? FileManager.default.removeItem(at: fixture) }
+
+		// The exact resolution the queue path uses, against a fresh suite that has
+		// only the registered defaults - the shipped first-launch configuration.
+		let suite = "FileTranscriptionTimestampE2ETests.queue.\(UUID().uuidString)"
+		let defaults = UserDefaults(suiteName: suite)!
+		defaults.removePersistentDomain(forName: suite)
+		AppDelegate.registerInitialDefaults(in: defaults)
+		let includeTimestamps = FileTranscriptionManager.resolveIncludeTimestamps(from: defaults)
+		try #require(includeTimestamps)
+
+		let manager = FileTranscriptionManager()
+		let output = try await manager.transcribeFile(
+			at: fixture,
+			withTimestamps: includeTimestamps,
+			timestampFormat: defaults.string(forKey: "timestampFormat"))
+
+		#expect(output.range(of: #"^\[\d{2}:\d{2}\] "#, options: .regularExpression) != nil)
+		#expect(output.lowercased().contains("fox"))
+	}
+}


### PR DESCRIPTION
## Summary

File transcriptions were silently losing timestamps even with Settings showing "Show timestamps" enabled. Root cause: the settings UI declares `showTimestamps = true` only at the `@AppStorage` view layer, while the engine reads `UserDefaults.standard.bool(forKey:)` - which returns `false` for a key that was never written. Unless the user had once flipped the toggle by hand, every file transcription took the plain-text path.

- Register `defaultTranscriptionMode` ("timestamps"), `showTimestamps` (true), and `timestampFormat` ("MM:SS") as real initial defaults, and resolve them null-safely in the engine (`resolveIncludeTimestamps`) so absence means on
- Default mode is now "With Timestamps" across the settings picker and both view models
- `FileTranscriptionViewModel` no longer strips timestamps in timestamps mode (it fetched segments, then joined only the bare text for display/copy) - it now uses the formatted `[MM:SS]` string
- `transcribeFile(at:withTimestamps:timestampFormat:)` overload makes the decision explicit and testable; `formatSegmentsAsString` accepts an explicit format

## Tests

New `FileTranscriptionTimestampTests.swift` (Swift Testing):
- Formatting: exact output for MM:SS, HH:MM:SS, and Seconds formats; every line carries a timestamp prefix
- Default resolution (isolated `UserDefaults` suites): fresh install resolves to timestamps-on via registered defaults; plain mode and an explicit toggle-off both disable them
- End-to-end with real WhisperKit: synthesizes a spoken fixture via `say`, transcribes through the actual pipeline, asserts every output line matches `^\[\d{2}:\d{2}\] `, the plain-mode negative case, and the exact queue-path resolution against registered defaults

All 9 deterministic tests and all 3 E2E tests pass on Apple silicon with a downloaded model (E2E ~2 min after model load; time limit 10 min to absorb cold starts).