### PR TITLE
fix(settings): default Live Transcription Mode off

### DIFF
--- a/Constants.swift
+++ b/Constants.swift
@@ -152,7 +152,7 @@ struct Constants {
 	public static let defaultLanguageName = "english"
 	// Shared by every @AppStorage("enableStreaming") fallback and the first-launch
 	// defaults: divergent inline copies of this literal caused duplicate recording windows.
-	public static let enableStreamingDefault = true
+	public static let enableStreamingDefault = false
 
 	// Helper to get sorted language names for UI
 	public static var sortedLanguageNames: [String] {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A native macOS app that replaces the built-in dictation with OpenAI's Whisper for superior transcription accuracy. Transcribe speech, local files, YouTube videos, and network streams - all processed locally on your Neural Engine.
 <div align="center">
   
-  ### [⬇️ Download Latest Release](https://github.com/sapoepsilon/Whispera/releases/latest)
+  ### [⬇️ Download Latest Release](https://github.com/sapoepsilon/Whispera/releases/latest/download/Whispera.dmg)
   
   [![GitHub release (latest by date)](https://img.shields.io/github/v/release/sapoepsilon/Whispera?style=for-the-badge&logo=github&color=0969da&labelColor=1f2328)](https://github.com/sapoepsilon/Whispera/releases/latest)
   


### PR DESCRIPTION
Hotfix: the beta Live Transcription Mode toggle was on by default for fresh installs; it is now an explicit opt-in (users who already enabled it keep their persisted choice - the flip is in Constants.enableStreamingDefault, which every @AppStorage fallback and the registered defaults share).

Also points the README download button directly at the stable Whispera.dmg asset of the latest release instead of the releases page.