### PR TITLE
feat(transitions): Metal particle magnet for onboarding and dictation

### DIFF
--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -560,10 +560,30 @@ extension AudioManager {
 		NSSound(named: soundName)?.play()
 	}
 	fileprivate func pasteToFocusedApp(_ text: String) {
+		// read before the paste moves the caret; observers use it as the
+		// destination for the dictation particle flight
+		let caret = MagnetField.caretRect()
+		NotificationCenter.default.post(
+			name: .dictationWillPaste, object: caret.map { NSValue(rect: $0) })
+
 		let pasteboard = NSPasteboard.general
 		pasteboard.clearContents()
 		pasteboard.setString(text, forType: .string)
 
+		// the particle field is already in flight; landing the text as it arrives
+		// reads as one motion, where pasting immediately puts the text on screen
+		// well before the animation catches up
+		let lead = MagnetField.pasteLeadTime(caret: caret)
+		if lead > 0 {
+			DispatchQueue.main.asyncAfter(deadline: .now() + lead) {
+				AudioManager.sendPasteKeystroke()
+			}
+		} else {
+			AudioManager.sendPasteKeystroke()
+		}
+	}
+
+	fileprivate static func sendPasteKeystroke() {
 		let source = CGEventSource(stateID: .combinedSessionState)
 		let keyDownEvent = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)
 		let keyUpEvent = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)

--- a/DictationMagnetTransition.swift
+++ b/DictationMagnetTransition.swift
@@ -1,0 +1,78 @@
+import AppKit
+
+private let logger = AppLogger.shared.ui
+
+/// Carries the dictation result from the listening window into the text field it
+/// is being pasted into: the listening window drops away and the particle field
+/// flies from where it stood into the caret, dissolving as the paste lands.
+///
+/// One-way, unlike the onboarding route — there is nothing to come back to.
+@MainActor
+final class DictationMagnetController {
+	/// The caret is a hairline; widen it a little so the field gathers into a
+	/// blob rather than a one-pixel column.
+	private static let targetPadding: CGFloat = 7
+
+	private weak var sourceWindow: NSWindow?
+	private var panel: NSPanel?
+	private var renderer: EdgeMagnetRenderer?
+	private var observer: NSObjectProtocol?
+
+	init() {
+		observer = NotificationCenter.default.addObserver(
+			forName: .dictationWillPaste, object: nil, queue: .main
+		) { [weak self] notification in
+			let caret = (notification.object as? NSValue)?.rectValue
+			MainActor.assumeIsolated { self?.run(caretAt: caret) }
+		}
+	}
+
+	deinit {
+		if let observer {
+			NotificationCenter.default.removeObserver(observer)
+		}
+	}
+
+	/// The listening window the field flies out of.
+	func attach(sourceWindow: NSWindow) {
+		self.sourceWindow = sourceWindow
+	}
+
+	private func run(caretAt caret: CGRect?) {
+		// no caret means the focused element never exposed one — flying the field
+		// to a guessed location would be worse than not playing it at all
+		guard MagnetField.dictationRouteEnabled(caret: caret), let caret else {
+			logger.debug("EdgeMagnet: dictation transition not applicable")
+			return
+		}
+		guard let source = sourceWindow else { return }
+		guard panel == nil else { return }
+
+		let targetRect = caret.insetBy(dx: -Self.targetPadding, dy: -Self.targetPadding)
+		// the caret can be on a different display than the listening window;
+		// the field has to be drawn on the one it is flying to
+		let screen =
+			NSScreen.screens.first { $0.frame.intersects(caret) } ?? source.screen ?? NSScreen.main
+		guard let screen else { return }
+
+		guard
+			let built = MagnetField.make(
+				on: screen,
+				sourceRect: MagnetField.localRect(source.frame, on: screen),
+				route: .rect(MagnetField.localRect(targetRect, on: screen)),
+				profile: .dictation)
+		else { return }
+
+		built.renderer.onCompleted = { [weak self] in self?.teardown() }
+		panel = built.panel
+		renderer = built.renderer
+		logger.debug("EdgeMagnet: dictation flight to \(targetRect.debugDescription)")
+	}
+
+	private func teardown() {
+		renderer?.invalidate()
+		panel?.orderOut(nil)
+		panel = nil
+		renderer = nil
+	}
+}

--- a/EdgeMagnet.metal
+++ b/EdgeMagnet.metal
@@ -1,0 +1,212 @@
+#include <metal_stdlib>
+#include "GlowGeometry.h"
+using namespace metal;
+
+// Field layout must stay in lockstep with EdgeMagnetUniforms in
+// EdgeMagnetRenderer.swift: float4s first so both compilers agree on padding.
+struct EdgeMagnetUniforms {
+	float4 sourceRect;    // origin.xy / size.zw, drawable pixels, bottom-left origin
+	float4 color;         // ambient glow tint, rgb used
+	float4 targetRect;    // destination when targetMode is 1, same convention
+	float2 viewport;      // drawable size in pixels
+	float progress;       // 0 = pooled over the source rect, 1 = arrived
+	float fade;           // global opacity envelope
+	float time;           // seconds, drives shimmer only
+	float particleScale;  // base sprite radius in pixels
+	float pointScale;     // pixels per point, converts the shared glow geometry
+	float intensityScale; // per-particle energy, budgeted against particle count
+	float targetMode;     // 0 = pin to the screen border, 1 = gather into targetRect
+};
+
+struct EdgeMagnetVertexOut {
+	float4 position [[position]];
+	float2 sprite;
+	float3 tint;
+	float intensity;
+};
+
+// Decorrelated streams off one instance id. Everything a particle needs is
+// derived here, so the system stays stateless: no buffers, no simulation step,
+// and any frame can be drawn without the ones before it.
+static inline float randomStream(uint id, uint salt) {
+	uint n = id * 747796405u + salt * 2891336453u;
+	n = (n ^ (n >> 17)) * 668265263u;
+	n = n ^ (n >> 15);
+	return float(n & 0x00ffffffu) / float(0x01000000u);
+}
+
+struct BorderAnchor {
+	float2 point;
+	float2 inward;
+};
+
+// Walks the same rounded rectangle the ambient glow hugs, by arc length so
+// particles spread evenly instead of piling into the corners. Sharing
+// glowCornerRadius with RecordingGlow.metal is what lets the pinned field and
+// the glow occupy the same path.
+static inline BorderAnchor borderAnchor(float t, float2 size, float radius) {
+	float straightX = max(size.x - 2.0 * radius, 0.0);
+	float straightY = max(size.y - 2.0 * radius, 0.0);
+	float quarter = max(M_PI_F * 0.5 * radius, 1e-3);
+	float distance = fract(t) * (2.0 * (straightX + straightY) + 4.0 * quarter);
+
+	BorderAnchor anchor;
+	if (distance < straightX) {
+		anchor.point = float2(radius + distance, 0.0);
+		anchor.inward = float2(0.0, 1.0);
+		return anchor;
+	}
+	distance -= straightX;
+	if (distance < quarter) {
+		float angle = -M_PI_F * 0.5 + (distance / quarter) * M_PI_F * 0.5;
+		float2 normal = float2(cos(angle), sin(angle));
+		anchor.point = float2(size.x - radius, radius) + normal * radius;
+		anchor.inward = -normal;
+		return anchor;
+	}
+	distance -= quarter;
+	if (distance < straightY) {
+		anchor.point = float2(size.x, radius + distance);
+		anchor.inward = float2(-1.0, 0.0);
+		return anchor;
+	}
+	distance -= straightY;
+	if (distance < quarter) {
+		float angle = (distance / quarter) * M_PI_F * 0.5;
+		float2 normal = float2(cos(angle), sin(angle));
+		anchor.point = float2(size.x - radius, size.y - radius) + normal * radius;
+		anchor.inward = -normal;
+		return anchor;
+	}
+	distance -= quarter;
+	if (distance < straightX) {
+		anchor.point = float2(size.x - radius - distance, size.y);
+		anchor.inward = float2(0.0, -1.0);
+		return anchor;
+	}
+	distance -= straightX;
+	if (distance < quarter) {
+		float angle = M_PI_F * 0.5 + (distance / quarter) * M_PI_F * 0.5;
+		float2 normal = float2(cos(angle), sin(angle));
+		anchor.point = float2(radius, size.y - radius) + normal * radius;
+		anchor.inward = -normal;
+		return anchor;
+	}
+	distance -= quarter;
+	if (distance < straightY) {
+		anchor.point = float2(0.0, size.y - radius - distance);
+		anchor.inward = float2(1.0, 0.0);
+		return anchor;
+	}
+	distance -= straightY;
+	float angle = M_PI_F + (distance / quarter) * M_PI_F * 0.5;
+	float2 normal = float2(cos(angle), sin(angle));
+	anchor.point = float2(radius, radius) + normal * radius;
+	anchor.inward = -normal;
+	return anchor;
+}
+
+// Fraction of the timeline spent handing out staggered release times.
+constant float staggerSpan = 0.35;
+
+vertex EdgeMagnetVertexOut edgeMagnetVertex(
+	uint vertexID [[vertex_id]],
+	uint instanceID [[instance_id]],
+	constant EdgeMagnetUniforms &uniforms [[buffer(0)]]
+) {
+	float originX = randomStream(instanceID, 0u);
+	float originY = randomStream(instanceID, 1u);
+	float anchorT = randomStream(instanceID, 2u);
+	float release = randomStream(instanceID, 3u);
+	float sizeBias = randomStream(instanceID, 4u);
+	float arcBias = randomStream(instanceID, 5u);
+	float depthBias = randomStream(instanceID, 6u);
+
+	float2 start = uniforms.sourceRect.xy + uniforms.sourceRect.zw * float2(originX, originY);
+
+	float2 target;
+	if (uniforms.targetMode > 0.5) {
+		// gather into a destination rect — the caret the transcription is being
+		// pasted into — rather than spreading along the screen border
+		target = uniforms.targetRect.xy + uniforms.targetRect.zw * float2(anchorT, depthBias);
+	} else {
+		float radius = glowCornerRadius * uniforms.pointScale;
+		float falloff = glowWidth * uniforms.pointScale;
+		BorderAnchor anchor = borderAnchor(anchorT, uniforms.viewport, radius);
+
+		// inverse-CDF sample of exp(-depth / glowWidth): the settled particle
+		// density then matches the ambient glow's own falloff, so the crossfade
+		// at the end of the outbound leg has nothing to give away. The
+		// distribution is truncated rather than clamped: clamping would stack
+		// the whole tail onto one depth and draw a hard line there.
+		float depthSpan = 1.0 - exp(-4.0);
+		float depth = -falloff * log(max(1.0 - depthBias * depthSpan, 1e-4));
+		// a sprite sitting exactly on the border loses its outer half to
+		// clipping, which hollows out the outermost points; bias the whole band
+		// out by half a sprite so the density peak lands on the border like the
+		// glow's does
+		target = anchor.point + anchor.inward * (depth - uniforms.particleScale * 0.5);
+	}
+
+	// each particle leaves on its own beat: the field peels off the window
+	// rather than sliding away as one rigid sheet
+	float local = saturate((uniforms.progress - release * staggerSpan) / (1.0 - staggerSpan));
+
+	// smoothstep softens the release; blending toward a cubic keeps the tail
+	// accelerating, which is what sells the magnetic snap onto the border
+	float eased = mix(local * local * (3.0 - 2.0 * local), local * local * local, 0.35);
+
+	float2 travel = target - start;
+	float span = max(length(travel), 1.0);
+	float2 forward = travel / span;
+	float2 sideways = float2(-forward.y, forward.x);
+
+	float heat = sin(saturate(eased) * M_PI_F);
+	float arc = (arcBias - 0.5) * 2.0 * min(span * 0.18, 240.0);
+	float2 centre = mix(start, target, eased) + sideways * arc * heat;
+
+	// stretch into a comet at mid-flight, round back out as it parks
+	float stretch = 1.0 + 4.0 * heat;
+	float sprite = uniforms.particleScale * mix(0.65, 1.45, sizeBias);
+
+	float2 corner = float2(
+		(vertexID & 1u) != 0u ? 1.0 : -1.0,
+		(vertexID & 2u) != 0u ? 1.0 : -1.0
+	);
+	float2 pixel = centre + forward * corner.x * sprite * stretch + sideways * corner.y * sprite;
+
+	EdgeMagnetVertexOut out;
+	out.position = float4(pixel / uniforms.viewport * 2.0 - 1.0, 0.0, 1.0);
+	out.sprite = corner;
+
+	float born = smoothstep(0.0, 0.06, local);
+	float shimmer = 0.82 + 0.18 * sin(uniforms.time * 7.0 + originX * 63.0);
+	// a brief flare as it clamps onto the border, the visual "click" of a magnet
+	float impact = 1.0 + 0.35 * exp(-pow((local - 0.92) / 0.06, 2.0));
+	// each particle stays dim on its own; the border reads bright only because
+	// tens of thousands of them accumulate there, which is what keeps the
+	// settled field smooth instead of sandy
+	//
+	// mid-flight the field is spread over the whole screen, and at full
+	// brightness it curtains the desktop instead of streaking across it. Both
+	// endpoints keep their calibrated brightness because heat is zero there.
+	float flightDim = mix(1.0, 0.4, heat);
+	// gathering into a caret-sized rect would stack every particle into one
+	// blinding dot, so they dim as they land: the text field absorbs them
+	float absorb = uniforms.targetMode > 0.5 ? 1.0 - smoothstep(0.55, 1.0, local) : 1.0;
+	out.intensity =
+		born * shimmer * impact * flightDim * absorb * uniforms.fade * uniforms.intensityScale;
+	// only the airborne particles run hot; a settled one is exactly the glow's
+	// own colour, so the handoff is a pure crossfade with no hue shift
+	out.tint = mix(uniforms.color.rgb, float3(1.0), 0.35 * heat);
+	return out;
+}
+
+fragment half4 edgeMagnetFragment(EdgeMagnetVertexOut in [[stage_in]]) {
+	// radial falloff in the stretched sprite space, so a mid-flight particle
+	// reads as an elongated streak and a parked one as a round mote
+	float profile = exp(-3.2 * dot(in.sprite, in.sprite));
+	float alpha = profile * in.intensity;
+	// premultiplied; the pipeline blends these additively
+	return half4(half3(in.tint * alpha), half(alpha));
+}

--- a/GlowGeometry.h
+++ b/GlowGeometry.h
@@ -1,0 +1,35 @@
+#ifndef GLOW_GEOMETRY_H
+#define GLOW_GEOMETRY_H
+
+// Shared by RecordingGlow.metal and EdgeMagnet.metal so the magnet particles pin
+// themselves onto exactly the path the ambient glow occupies, at the same
+// brightness. If these drift, the handoff between the two effects shows up as a
+// jump in either position or exposure.
+
+// Falloff scale of the ambient glow, in points, at silence.
+constant float glowWidth = 24.0;
+// Widest possible glow at full voice level.
+constant float maxGlowWidth = glowWidth * 3.0;
+// exp(-4.6) < 1%: past this distance the glow is invisible, skip the math.
+constant float glowCutoff = maxGlowWidth * 4.6;
+// Radius of the rounded rectangle both effects hug, in points.
+constant float glowCornerRadius = 36.0;
+
+// Alpha the ambient glow puts on screen `edgeDistance` points inside the
+// border. The magnet calibrates its settled particle field against this so the
+// crossfade between the two is flat rather than a flare that decays.
+static inline float glowEdgeIntensity(float edgeDistance, float level, float pulse) {
+	// voice drives both thickness and brightness; at silence only a faint
+	// breathing base remains, so speech reads as a strong uniform bloom
+	float width = metal::mix(glowWidth, maxGlowWidth, level);
+	float energy = metal::mix(pulse * 0.45, 1.0, level);
+	return metal::exp(-edgeDistance / width) * energy;
+}
+
+// The level/pulse the glow sits at while idle. The handoff happens at the end
+// of the outbound leg, before anyone has spoken, so this is the state the
+// settled particle field has to match.
+constant float glowRestLevel = 0.0;
+constant float glowRestPulse = 0.8;
+
+#endif

--- a/MagnetField.swift
+++ b/MagnetField.swift
@@ -1,0 +1,159 @@
+import AppKit
+import ApplicationServices
+import Metal
+
+private let logger = AppLogger.shared.ui
+
+extension Notification.Name {
+	/// Posted immediately before a dictation result is pasted into the focused
+	/// app. Object is an `NSValue` wrapping the caret point in screen
+	/// coordinates, or nil when the focused element did not expose one.
+	static let dictationWillPaste = Notification.Name("DictationWillPaste")
+}
+
+/// Builds the transparent full-screen surface the particle field draws into.
+/// Shared by the onboarding route (out to the screen border and back) and the
+/// dictation route (a one-way flight into the caret).
+@MainActor
+enum MagnetField {
+	/// The caret's rect in Cocoa screen coordinates, or nil when the focused
+	/// element does not expose a usable one.
+	///
+	/// `AccessibilityHelper.getCaretPosition()` is deliberately not reused: it
+	/// flips Y against `NSScreen.main`, which is the focused screen rather than
+	/// the primary one, and it keeps degenerate rects. Chrome answers the bounds
+	/// query with a zero rect for many fields, which that path turns into a
+	/// bottom-corner "position" instead of a miss.
+	static func caretRect() -> CGRect? {
+		guard AXIsProcessTrusted() else { return nil }
+
+		let system = AXUIElementCreateSystemWide()
+		var app: CFTypeRef?
+		guard
+			AXUIElementCopyAttributeValue(
+				system, kAXFocusedApplicationAttribute as CFString, &app) == .success,
+			let app
+		else { return nil }
+
+		var focused: CFTypeRef?
+		guard
+			AXUIElementCopyAttributeValue(
+				app as! AXUIElement, kAXFocusedUIElementAttribute as CFString, &focused) == .success,
+			let focused
+		else { return nil }
+
+		var rangeRef: CFTypeRef?
+		guard
+			AXUIElementCopyAttributeValue(
+				focused as! AXUIElement, kAXSelectedTextRangeAttribute as CFString, &rangeRef)
+				== .success,
+			let rangeRef
+		else { return nil }
+
+		var boundsRef: CFTypeRef?
+		guard
+			AXUIElementCopyParameterizedAttributeValue(
+				focused as! AXUIElement, kAXBoundsForRangeParameterizedAttribute as CFString,
+				rangeRef as! AXValue, &boundsRef) == .success,
+			let boundsRef
+		else { return nil }
+
+		var axRect = CGRect.zero
+		guard AXValueGetValue(boundsRef as! AXValue, .cgRect, &axRect) else { return nil }
+		guard axRect.origin.x.isFinite, axRect.origin.y.isFinite,
+			axRect.width.isFinite, axRect.height.isFinite
+		else { return nil }
+		// a caret always has height; zero-height is how apps say "I don't know"
+		guard axRect.height > 0 else { return nil }
+
+		// AX reports a top-left origin measured from the primary display, which
+		// is screens[0] — not NSScreen.main, which follows keyboard focus
+		guard let primary = NSScreen.screens.first else { return nil }
+		let rect = CGRect(
+			x: axRect.origin.x,
+			y: primary.frame.maxY - axRect.maxY,
+			width: max(axRect.width, 1),
+			height: axRect.height)
+
+		// off-screen or scrolled out of view: there is nothing to fly to
+		guard NSScreen.screens.contains(where: { $0.frame.intersects(rect) }) else { return nil }
+		return rect
+	}
+
+	/// Whether the dictation flight can run for this caret. Shared by the
+	/// controller and by the paste timing so the two can never disagree.
+	static func dictationRouteEnabled(caret: CGRect?) -> Bool {
+		guard caret != nil else { return false }
+		// onboarding owns the screen during its own run; this is the everyday path
+		guard UserDefaults.standard.bool(forKey: "hasCompletedOnboarding") else { return false }
+		// rides the same switch as the edge glow: turning that off turns the
+		// whole particle treatment off
+		guard UserDefaults.standard.bool(forKey: "enableRecordingGlow") else { return false }
+		guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else { return false }
+		return true
+	}
+
+	/// How long to hold the paste keystroke so the text appears as the field
+	/// lands, instead of a beat before it. Zero when the flight will not run.
+	static func pasteLeadTime(caret: CGRect?) -> TimeInterval {
+		guard dictationRouteEnabled(caret: caret) else { return 0 }
+		return EdgeMagnetProfile.dictation.outbound * 0.7
+	}
+
+	static func glowColor() -> NSColor {
+		NSColor(
+			RecordingGlowColor.color(
+				fromHex: UserDefaults.standard.string(forKey: RecordingGlowColor.key)
+					?? RecordingGlowColor.defaultHex))
+	}
+
+	static func make(
+		on screen: NSScreen, sourceRect: CGRect, route: EdgeMagnetRoute,
+		profile: EdgeMagnetProfile
+	) -> (panel: NSPanel, renderer: EdgeMagnetRenderer)? {
+		guard let device = MTLCreateSystemDefaultDevice() else {
+			logger.error("EdgeMagnet: no Metal device, skipping transition")
+			return nil
+		}
+
+		let view = EdgeMagnetLayerView(frame: CGRect(origin: .zero, size: screen.frame.size))
+		guard
+			let renderer = EdgeMagnetRenderer(
+				layer: view.metalLayer,
+				device: device,
+				sourceRect: sourceRect,
+				route: route,
+				color: glowColor(),
+				profile: profile)
+		else { return nil }
+
+		let panel = NSPanel(
+			contentRect: screen.frame,
+			styleMask: [.borderless, .nonactivatingPanel],
+			backing: .buffered,
+			defer: false
+		)
+		panel.level = .screenSaver
+		panel.isOpaque = false
+		panel.backgroundColor = .clear
+		panel.hasShadow = false
+		panel.ignoresMouseEvents = true
+		panel.hidesOnDeactivate = false
+		panel.collectionBehavior = [
+			.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle,
+		]
+		panel.contentView = view
+		panel.orderFrontRegardless()
+		// drawable size needs the panel's backing scale, so size it once the
+		// view actually has a window
+		view.syncDrawableSize()
+		renderer.start(pointScale: view.metalLayer.contentsScale)
+
+		return (panel, renderer)
+	}
+
+	/// Rebases a global screen rect into a panel that spans `screen`.
+	static func localRect(_ rect: CGRect, on screen: NSScreen) -> CGRect {
+		rect.offsetBy(dx: -screen.frame.origin.x, dy: -screen.frame.origin.y)
+	}
+}

--- a/Onboarding/EdgeMagnetRenderer.swift
+++ b/Onboarding/EdgeMagnetRenderer.swift
@@ -1,0 +1,420 @@
+import AppKit
+import Metal
+import QuartzCore
+
+private let logger = AppLogger.shared.ui
+
+// Field layout must stay in lockstep with EdgeMagnetUniforms in EdgeMagnet.metal:
+// float4s first so Swift and Metal agree on padding without explicit offsets.
+private struct EdgeMagnetUniforms {
+	var sourceRect: SIMD4<Float>
+	var color: SIMD4<Float>
+	var targetRect: SIMD4<Float>
+	var viewport: SIMD2<Float>
+	var progress: Float
+	var fade: Float
+	var time: Float
+	var particleScale: Float
+	var pointScale: Float
+	var intensityScale: Float
+	var targetMode: Float
+}
+
+/// Where the field is headed, which also decides whether it can come back.
+enum EdgeMagnetRoute {
+	/// Onboarding: pin to the screen border and return to the source later.
+	case screenBorder
+	/// Dictation: a one-way flight into the caret the text is pasted at.
+	case rect(CGRect)
+}
+
+/// Everything that differs between the two routes: how much light the field
+/// carries, and how long it takes. Kept together so a route is tuned in one place.
+struct EdgeMagnetProfile {
+	let particleCount: Int
+	/// Per-particle energy, calibrated at `particleCount`. Raising it without
+	/// lowering the count blows the field out.
+	let intensity: Float
+	/// Sprite radius in points. Large enough that neighbouring particles overlap,
+	/// which is what keeps the field smooth instead of sandy.
+	let spriteRadius: Float
+	let outbound: CFTimeInterval
+	let settle: CFTimeInterval
+	let inbound: CFTimeInterval
+	/// Fraction of the outbound leg after which the source window starts fading.
+	let vanishCue: CFTimeInterval
+	/// Fraction of the inbound leg after which the source window starts returning.
+	let returnCue: CFTimeInterval
+
+	/// Measured against `glowEdgeIntensity` at rest so the settled field and the
+	/// ambient glow sit at the same alpha and the handoff is a flat crossfade.
+	static let onboarding = EdgeMagnetProfile(
+		particleCount: 200_000, intensity: 0.024, spriteRadius: 3.2,
+		outbound: 0.55, settle: 0.3, inbound: 0.5, vanishCue: 0.12, returnCue: 0.6)
+
+	/// Fewer and quicker: the paste it accompanies is instantaneous, and the
+	/// field gathers into a caret rather than spreading along the screen border,
+	/// so far less light is needed to read.
+	static let dictation = EdgeMagnetProfile(
+		particleCount: 24_000, intensity: 0.05, spriteRadius: 3.0,
+		outbound: 0.18, settle: 0.07, inbound: 0, vanishCue: 0, returnCue: 0)
+}
+
+/// Backing view for the particle field. Owns a CAMetalLayer directly rather than
+/// using MTKView, because MTKView delivers its draw callback on the main thread
+/// and this animation plays while WhisperKit is loading a CoreML model on the
+/// main actor — which stalled it mid-flight.
+final class EdgeMagnetLayerView: NSView {
+	override init(frame frameRect: NSRect) {
+		super.init(frame: frameRect)
+		wantsLayer = true
+	}
+
+	@available(*, unavailable)
+	required init?(coder: NSCoder) { fatalError("not supported") }
+
+	override func makeBackingLayer() -> CALayer {
+		let layer = CAMetalLayer()
+		layer.isOpaque = false
+		layer.pixelFormat = .bgra8Unorm
+		layer.framebufferOnly = true
+		return layer
+	}
+
+	var metalLayer: CAMetalLayer { layer as! CAMetalLayer }
+
+	override func viewDidChangeBackingProperties() {
+		super.viewDidChangeBackingProperties()
+		syncDrawableSize()
+	}
+
+	override func setFrameSize(_ newSize: NSSize) {
+		super.setFrameSize(newSize)
+		syncDrawableSize()
+	}
+
+	func syncDrawableSize() {
+		let scale = window?.backingScaleFactor ?? 2
+		metalLayer.contentsScale = scale
+		metalLayer.drawableSize = CGSize(
+			width: bounds.width * scale, height: bounds.height * scale)
+	}
+}
+
+/// Draws the particle field that carries the window into the screen border and
+/// back. Motion is a pure function of `progress`, so the renderer only has to
+/// advance a clock and hand the shader a few floats.
+///
+/// Rendering runs on a dedicated thread so main-thread work (CoreML model
+/// loading, SwiftUI layout) cannot stall the animation. Pacing comes from
+/// `nextDrawable()`, which blocks until the layer has a free buffer and so
+/// self-synchronises to the display; CAMetalDisplayLink is deliberately not used
+/// because its callbacks are never delivered on a secondary thread on macOS.
+final class EdgeMagnetRenderer {
+	private enum Stage {
+		case outbound(start: CFTimeInterval)
+		case pinned(start: CFTimeInterval)
+		case inbound(start: CFTimeInterval)
+		case finished
+	}
+
+	private let layer: CAMetalLayer
+	private let commandQueue: MTLCommandQueue
+	private let pipelineState: MTLRenderPipelineState
+	private let profile: EdgeMagnetProfile
+	private let color: SIMD4<Float>
+	private let sourceRect: CGRect
+	private let route: EdgeMagnetRoute
+	private let epoch = CACurrentMediaTime()
+
+	// touched from both the render thread and the main thread
+	private let lock = NSLock()
+	private var stage: Stage
+	private var hasCuedVanish = false
+	private var hasCuedReturn = false
+
+	private var renderThread: Thread?
+	/// Set once the field has nothing left to draw, cleared by `reverse()`.
+	private var isParked = false
+	/// Captured on the main thread by `start(pointScale:)`.
+	private var pointScale: Float = 2
+	private var frameCount = 0
+
+	/// Fired once the field has enough mass on screen to cover the window leaving.
+	var onSourceShouldVanish: (() -> Void)?
+	/// Fired while the field is still converging, so the window fades back under it.
+	var onSourceShouldReturn: (() -> Void)?
+	/// Fired when the inbound leg finishes and the panel can be torn down.
+	var onCompleted: (() -> Void)?
+
+	init?(layer: CAMetalLayer, device: MTLDevice, sourceRect: CGRect, route: EdgeMagnetRoute,
+		color: NSColor, profile: EdgeMagnetProfile)
+	{
+		guard let queue = device.makeCommandQueue() else {
+			logger.error("EdgeMagnet: could not create a Metal command queue")
+			return nil
+		}
+		guard let library = device.makeDefaultLibrary(),
+			let vertexFunction = library.makeFunction(name: "edgeMagnetVertex"),
+			let fragmentFunction = library.makeFunction(name: "edgeMagnetFragment")
+		else {
+			logger.error("EdgeMagnet: shader functions missing from the default library")
+			return nil
+		}
+
+		let descriptor = MTLRenderPipelineDescriptor()
+		descriptor.vertexFunction = vertexFunction
+		descriptor.fragmentFunction = fragmentFunction
+		if let attachment = descriptor.colorAttachments[0] {
+			attachment.pixelFormat = layer.pixelFormat
+			// additive, premultiplied: overlapping particles build the bloom
+			// instead of the last one drawn winning
+			attachment.isBlendingEnabled = true
+			attachment.rgbBlendOperation = .add
+			attachment.alphaBlendOperation = .add
+			attachment.sourceRGBBlendFactor = .one
+			attachment.destinationRGBBlendFactor = .one
+			attachment.sourceAlphaBlendFactor = .one
+			attachment.destinationAlphaBlendFactor = .one
+		}
+
+		do {
+			pipelineState = try device.makeRenderPipelineState(descriptor: descriptor)
+		} catch {
+			logger.error("EdgeMagnet: pipeline state failed: \(error)")
+			return nil
+		}
+
+		let srgb = color.usingColorSpace(.sRGB) ?? NSColor.systemBlue
+		self.layer = layer
+		self.commandQueue = queue
+		self.profile = profile
+		self.sourceRect = sourceRect
+		self.route = route
+		self.color = SIMD4<Float>(
+			Float(srgb.redComponent), Float(srgb.greenComponent), Float(srgb.blueComponent), 1)
+		self.stage = .outbound(start: CACurrentMediaTime())
+		layer.device = device
+	}
+
+	// MARK: - Lifecycle
+
+	/// `pointScale` is read from the layer on the main thread and captured, so the
+	/// render thread never touches CALayer state.
+	func start(pointScale: CGFloat) {
+		self.pointScale = Float(pointScale)
+
+		let thread = Thread { [weak self] in
+			while !Thread.current.isCancelled {
+				guard let self else { return }
+				if self.parked {
+					// nothing to draw until reverse() wakes us; idle cheaply
+					// rather than spinning the GPU for the whole recording
+					Thread.sleep(forTimeInterval: 0.03)
+					continue
+				}
+				// drained every frame, or the CAMetalDrawables are retained and
+				// the layer's buffer pool starves
+				autoreleasepool { self.renderFrame() }
+			}
+		}
+		thread.name = "com.whispera.edge-magnet"
+		thread.qualityOfService = .userInteractive
+		renderThread = thread
+		thread.start()
+	}
+
+	func invalidate() {
+		logger.debug("EdgeMagnet: rendered \(frameCount) frames")
+		renderThread?.cancel()
+		renderThread = nil
+	}
+
+	private var parked: Bool {
+		lock.lock()
+		defer { lock.unlock() }
+		return isParked
+	}
+
+	/// True once the field is already heading home. The mic closing posts several
+	/// state changes in a row, and without this each one would wake the render
+	/// loop back up after it had parked.
+	var isReturning: Bool {
+		lock.lock()
+		defer { lock.unlock() }
+		switch stage {
+		case .inbound, .finished: return true
+		case .outbound, .pinned: return false
+		}
+	}
+
+	/// Starts the return leg. Safe to call at any point in the outbound leg: the
+	/// clock is rewound so the field converges from wherever it currently is.
+	func reverse() {
+		lock.lock()
+		switch stage {
+		case .outbound, .pinned:
+			let elapsed = Double(1 - progressLocked(at: CACurrentMediaTime()))
+			stage = .inbound(start: CACurrentMediaTime() - elapsed * profile.inbound)
+		case .inbound, .finished:
+			break
+		}
+		isParked = false
+		lock.unlock()
+	}
+
+	// MARK: - Rendering
+
+	private func renderFrame() {
+		let now = CACurrentMediaTime()
+		frameCount += 1
+		let frame = advance(to: now)
+
+		// blocks until the layer frees a buffer, which paces this loop to the
+		// display without needing a display link
+		guard let drawable = layer.nextDrawable(),
+			drawable.texture.width > 0, drawable.texture.height > 0,
+			let buffer = commandQueue.makeCommandBuffer()
+		else { return }
+
+		let pass = MTLRenderPassDescriptor()
+		pass.colorAttachments[0].texture = drawable.texture
+		pass.colorAttachments[0].loadAction = .clear
+		pass.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+		pass.colorAttachments[0].storeAction = .store
+
+		guard let encoder = buffer.makeRenderCommandEncoder(descriptor: pass) else { return }
+
+		let scale = pointScale
+		let target: CGRect
+		let targetMode: Float
+		switch route {
+		case .screenBorder:
+			target = .zero
+			targetMode = 0
+		case .rect(let rect):
+			target = rect
+			targetMode = 1
+		}
+		var uniforms = EdgeMagnetUniforms(
+			sourceRect: SIMD4<Float>(
+				Float(sourceRect.origin.x) * scale, Float(sourceRect.origin.y) * scale,
+				Float(sourceRect.width) * scale, Float(sourceRect.height) * scale),
+			color: color,
+			targetRect: SIMD4<Float>(
+				Float(target.origin.x) * scale, Float(target.origin.y) * scale,
+				Float(target.width) * scale, Float(target.height) * scale),
+			viewport: SIMD2<Float>(
+				Float(drawable.texture.width), Float(drawable.texture.height)),
+			progress: frame.progress,
+			fade: frame.fade,
+			time: Float(now - epoch),
+			particleScale: profile.spriteRadius * scale,
+			pointScale: scale,
+			intensityScale: profile.intensity,
+			targetMode: targetMode
+		)
+
+		encoder.setRenderPipelineState(pipelineState)
+		encoder.setVertexBytes(
+			&uniforms, length: MemoryLayout<EdgeMagnetUniforms>.stride, index: 0)
+		encoder.drawPrimitives(
+			type: .triangleStrip, vertexStart: 0, vertexCount: 4, instanceCount: profile.particleCount)
+		encoder.endEncoding()
+		buffer.present(drawable)
+		buffer.commit()
+	}
+
+	// MARK: - Timeline
+
+	/// Progress of the outbound leg at `now`, assuming the lock is held.
+	private func progressLocked(at now: CFTimeInterval) -> Float {
+		switch stage {
+		case .outbound(let start):
+			return Float(min((now - start) / profile.outbound, 1))
+		case .pinned: return 1
+		case .inbound(let start):
+			return Float(1 - min(max((now - start) / profile.inbound, 0), 1))
+		case .finished: return 0
+		}
+	}
+
+	private func advance(to now: CFTimeInterval) -> (progress: Float, fade: Float) {
+		var cueVanish = false
+		var cueReturn = false
+		var completed = false
+		var park = false
+		var progress: Float = 0
+		var fade: Float = 0
+
+		lock.lock()
+		switch stage {
+		case .outbound(let start):
+			let t = (now - start) / profile.outbound
+			progress = Float(min(t, 1))
+			fade = 1
+			if t >= profile.vanishCue, !hasCuedVanish {
+				hasCuedVanish = true
+				cueVanish = true
+			}
+			if t >= 1 { stage = .pinned(start: now) }
+
+		case .pinned(let start):
+			progress = 1
+			if !hasCuedVanish {
+				hasCuedVanish = true
+				cueVanish = true
+			}
+			let t = (now - start) / profile.settle
+			// the pinned field dims out and hands the border over to the
+			// ambient recording glow
+			fade = Float(max(0, 1 - t))
+			if t >= 1 {
+				if case .rect = route {
+					// a one-way flight has nowhere to return to; the run ends
+					// once the field has dissolved into the target
+					stage = .finished
+					completed = true
+				}
+				// otherwise nothing left to draw until reverse() wakes us, so
+				// stop burning frames for however long the user keeps talking
+				park = true
+			}
+
+		case .inbound(let start):
+			let t = min(max((now - start) / profile.inbound, 0), 1)
+			progress = Float(1 - t)
+			fade = smoothstep(0, 0.12, t) * (1 - smoothstep(0.78, 1.0, t))
+			if t >= profile.returnCue, !hasCuedReturn {
+				hasCuedReturn = true
+				cueReturn = true
+			}
+			if t >= 1 {
+				stage = .finished
+				park = true
+				completed = true
+			}
+
+		case .finished:
+			fade = 0
+			park = true
+		}
+		lock.unlock()
+
+		if park { lock.lock(); isParked = true; lock.unlock() }
+		if cueVanish || cueReturn || completed {
+			DispatchQueue.main.async { [weak self] in
+				guard let self else { return }
+				if cueVanish { self.onSourceShouldVanish?() }
+				if cueReturn { self.onSourceShouldReturn?() }
+				if completed { self.onCompleted?() }
+			}
+		}
+		return (progress, fade)
+	}
+
+	private func smoothstep(_ edge0: Double, _ edge1: Double, _ x: Double) -> Float {
+		let t = min(max((x - edge0) / (edge1 - edge0), 0), 1)
+		return Float(t * t * (3 - 2 * t))
+	}
+}

--- a/Onboarding/OnboardingMagnetTransition.swift
+++ b/Onboarding/OnboardingMagnetTransition.swift
@@ -1,0 +1,131 @@
+import AppKit
+
+private let logger = AppLogger.shared.ui
+
+extension Notification.Name {
+	/// Object is a `Bool`: true while the onboarding content should read as
+	/// being pulled apart, false once it should settle back.
+	static let onboardingMagnetDissolve = Notification.Name("OnboardingMagnetDissolve")
+}
+
+/// Onboarding-only flourish: when the Try It step starts recording, the window
+/// dissolves into a particle field that flies out and pins itself to the screen
+/// border, where the recording glow takes over. When the mic closes the field
+/// converges back to the window rect and the window returns under it.
+@MainActor
+final class OnboardingMagnetController {
+
+	private weak var window: NSWindow?
+	private var panel: NSPanel?
+	private var renderer: EdgeMagnetRenderer?
+	private var isRunning = false
+
+	/// Set by `OnboardingView` so the effect only fires from the Try It step.
+	var isArmed = false {
+		didSet {
+			guard oldValue != isArmed, !isArmed else { return }
+			cancel()
+		}
+	}
+
+	func attach(to window: NSWindow) {
+		self.window = window
+	}
+
+	func detach() {
+		cancel()
+		isArmed = false
+		window = nil
+	}
+
+	func handle(state: AudioState) {
+		switch state {
+		case .initializing, .recording:
+			start()
+		case .transcribing, .idle:
+			// the field comes home as soon as the mic closes; transcription
+			// then runs with the window already back, and the ambient glow
+			// tears down on the same state change so the two leave together
+			beginReturn()
+		}
+	}
+
+	// MARK: - Outbound
+
+	private func start() {
+		guard isArmed, !isRunning else { return }
+		guard let window, window.isVisible else { return }
+		guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else { return }
+		guard let screen = window.screen ?? NSScreen.main else { return }
+		// window frame is global; the panel spans one screen, so rebase onto it
+		guard
+			let built = MagnetField.make(
+				on: screen,
+				sourceRect: MagnetField.localRect(window.frame, on: screen),
+				route: .screenBorder,
+				profile: .onboarding)
+		else { return }
+
+		built.renderer.onSourceShouldVanish = { [weak self] in self?.hideWindow() }
+		built.renderer.onSourceShouldReturn = { [weak self] in self?.showWindow() }
+		built.renderer.onCompleted = { [weak self] in self?.finish() }
+
+		self.panel = built.panel
+		self.renderer = built.renderer
+		isRunning = true
+		logger.debug("EdgeMagnet: outbound started over \(screen.frame.debugDescription)")
+	}
+
+	private func hideWindow() {
+		NotificationCenter.default.post(name: .onboardingMagnetDissolve, object: true)
+		guard let window else { return }
+		NSAnimationContext.runAnimationGroup { context in
+			context.duration = 0.2
+			context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+			window.animator().alphaValue = 0
+		} completionHandler: { [weak window] in
+			// alpha-zero windows still take clicks; get it out of the way
+			window?.orderOut(nil)
+		}
+	}
+
+	// MARK: - Inbound
+
+	private func beginReturn() {
+		guard isRunning, let renderer, !renderer.isReturning else { return }
+		renderer.reverse()
+	}
+
+	private func showWindow() {
+		NotificationCenter.default.post(name: .onboardingMagnetDissolve, object: false)
+		guard let window else { return }
+		window.alphaValue = 0
+		window.makeKeyAndOrderFront(nil)
+		NSAnimationContext.runAnimationGroup { context in
+			context.duration = 0.24
+			context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+			window.animator().alphaValue = 1
+		}
+	}
+
+	private func finish() {
+		teardown()
+		logger.debug("EdgeMagnet: transition complete")
+	}
+
+	// MARK: - Teardown
+
+	func cancel() {
+		guard isRunning else { return }
+		showWindow()
+		teardown()
+	}
+
+	private func teardown() {
+		renderer?.invalidate()
+		panel?.orderOut(nil)
+		panel = nil
+		renderer = nil
+		isRunning = false
+	}
+}

--- a/OnboardingView.swift
+++ b/OnboardingView.swift
@@ -4,9 +4,11 @@ import SwiftUI
 struct OnboardingView: View {
 	@Bindable var audioManager: AudioManager
 	@ObservedObject var shortcutManager: GlobalShortcutManager
+	let magnetController: OnboardingMagnetController?
 
 	@State private var currentStep = 0
 	@State private var direction: Int = 1
+	@State private var isDissolving = false
 	@State private var selectedModel = ""
 	@State private var customShortcut = ""
 	@State private var hasPermissions = false
@@ -25,6 +27,7 @@ struct OnboardingView: View {
 	}
 
 	private let steps = ["Welcome", "Permissions", "Setup", "Try It", "Complete"]
+	private static let tryItStep = 3
 
 	var body: some View {
 		VStack(spacing: 0) {
@@ -82,10 +85,29 @@ struct OnboardingView: View {
 			.allowsHitTesting(false)
 		)
 		.frame(width: 600, height: 750)
+		// the window's own alpha is animated by the magnet controller; this only
+		// makes the content read as being pulled apart rather than switched off
+		.scaleEffect(isDissolving ? 0.9 : 1)
+		.blur(radius: isDissolving ? 8 : 0)
+		.opacity(isDissolving ? 0 : 1)
 		.onAppear {
 			checkPermissions()
 			customShortcut = globalShortcut
 			launchAtLogin = storedLaunchAtLogin
+			magnetController?.isArmed = currentStep == Self.tryItStep
+		}
+		.onDisappear {
+			magnetController?.detach()
+		}
+		.onChange(of: currentStep) { _, step in
+			magnetController?.isArmed = step == Self.tryItStep
+		}
+		.onReceive(NotificationCenter.default.publisher(for: .onboardingMagnetDissolve)) {
+			notification in
+			let dissolving = notification.object as? Bool ?? false
+			withAnimation(.easeInOut(duration: 0.2)) {
+				isDissolving = dissolving
+			}
 		}
 	}
 

--- a/OnboardingView.swift
+++ b/OnboardingView.swift
@@ -86,9 +86,11 @@ struct OnboardingView: View {
 		)
 		.frame(width: 600, height: 750)
 		// the window's own alpha is animated by the magnet controller; this only
-		// makes the content read as being pulled apart rather than switched off
+		// makes the content read as being pulled apart rather than switched off.
+		// Deliberately no .blur: SwiftUI keeps an offscreen render pass alive for
+		// it even at radius 0, which redraws this whole Material-backed window
+		// every frame for the entire time onboarding is open.
 		.scaleEffect(isDissolving ? 0.9 : 1)
-		.blur(radius: isDissolving ? 8 : 0)
 		.opacity(isDissolving ? 0 : 1)
 		.onAppear {
 			checkPermissions()

--- a/RecordingGlow.metal
+++ b/RecordingGlow.metal
@@ -1,13 +1,7 @@
 #include <metal_stdlib>
 #include <SwiftUI/SwiftUI_Metal.h>
+#include "GlowGeometry.h"
 using namespace metal;
-
-constant float glowWidth = 24.0;
-// widest possible glow at full voice level
-constant float maxGlowWidth = glowWidth * 3.0;
-// exp(-4.6) < 1%: past this distance the glow is invisible, skip the math
-constant float glowCutoff = maxGlowWidth * 4.6;
-constant float cornerRadius = 36.0;
 
 [[stitchable]] half4 recordingGlow(
 	float2 position, half4 color, float4 bounds, half4 glowColor, float time, float pulse,
@@ -17,18 +11,14 @@ constant float cornerRadius = 36.0;
 	// signed distance to a rounded rectangle inset to the screen bounds,
 	// negative inside; the glow hugs its rounded border instead of the
 	// sharp screen corners
-	float2 q = abs(position - halfSize) - (halfSize - cornerRadius);
-	float sdf = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - cornerRadius;
+	float2 q = abs(position - halfSize) - (halfSize - glowCornerRadius);
+	float sdf = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - glowCornerRadius;
 	float edgeDistance = max(-sdf, 0.0);
 	if (edgeDistance > glowCutoff) {
 		return half4(0.0);
 	}
 
-	// voice drives both thickness and brightness; at silence only a faint
-	// breathing base remains, so speech reads as a strong uniform bloom
-	float width = mix(glowWidth, maxGlowWidth, level);
-	float energy = mix(pulse * 0.45, 1.0, level);
-	float intensity = exp(-edgeDistance / width) * energy;
+	float intensity = glowEdgeIntensity(edgeDistance, level, pulse);
 
 	// premultiplied alpha, as SwiftUI colorEffect expects
 	half alpha = half(intensity) * glowColor.a;

--- a/Whispera.xcodeproj/project.pbxproj
+++ b/Whispera.xcodeproj/project.pbxproj
@@ -60,6 +60,11 @@
 		D6B81FB62DEFFE4000D32F2A /* RecordingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B81FB52DEFFE4000D32F2A /* RecordingIndicator.swift */; };
 		D6C10A012F20000000000002 /* RecordingGlowWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C10A012F20000000000001 /* RecordingGlowWindow.swift */; };
 		D6C10A022F20000000000002 /* RecordingGlow.metal in Sources */ = {isa = PBXBuildFile; fileRef = D6C10A022F20000000000001 /* RecordingGlow.metal */; };
+		D6MAGNET12F0000000000001 /* EdgeMagnetRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6MAGNET22F0000000000001 /* EdgeMagnetRenderer.swift */; };
+		D6MAGNET12F0000000000002 /* OnboardingMagnetTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6MAGNET22F0000000000002 /* OnboardingMagnetTransition.swift */; };
+		D6MAGNET12F0000000000003 /* EdgeMagnet.metal in Sources */ = {isa = PBXBuildFile; fileRef = D6MAGNET22F0000000000003 /* EdgeMagnet.metal */; };
+		D6MAGNET12F0000000000004 /* MagnetField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6MAGNET22F0000000000005 /* MagnetField.swift */; };
+		D6MAGNET12F0000000000005 /* DictationMagnetTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6MAGNET22F0000000000006 /* DictationMagnetTransition.swift */; };
 		D6BENCH012F0000000000001 /* BenchmarkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BENCH022F0000000000001 /* BenchmarkResult.swift */; };
 		D6BENCH012F0000000000002 /* BenchmarkRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BENCH022F0000000000002 /* BenchmarkRunner.swift */; };
 		D6BENCH012F0000000000003 /* BenchmarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BENCH022F0000000000003 /* BenchmarkView.swift */; };
@@ -156,6 +161,12 @@
 		D6B81FB52DEFFE4000D32F2A /* RecordingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingIndicator.swift; sourceTree = "<group>"; };
 		D6C10A012F20000000000001 /* RecordingGlowWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingGlowWindow.swift; sourceTree = "<group>"; };
 		D6C10A022F20000000000001 /* RecordingGlow.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = RecordingGlow.metal; sourceTree = "<group>"; };
+		D6MAGNET22F0000000000001 /* EdgeMagnetRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeMagnetRenderer.swift; sourceTree = "<group>"; };
+		D6MAGNET22F0000000000002 /* OnboardingMagnetTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMagnetTransition.swift; sourceTree = "<group>"; };
+		D6MAGNET22F0000000000003 /* EdgeMagnet.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = EdgeMagnet.metal; sourceTree = "<group>"; };
+		D6MAGNET22F0000000000005 /* MagnetField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagnetField.swift; sourceTree = "<group>"; };
+		D6MAGNET22F0000000000006 /* DictationMagnetTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationMagnetTransition.swift; sourceTree = "<group>"; };
+		D6MAGNET22F0000000000004 /* GlowGeometry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GlowGeometry.h; sourceTree = "<group>"; };
 		D6BENCH022F0000000000001 /* BenchmarkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkResult.swift; sourceTree = "<group>"; };
 		D6BENCH022F0000000000002 /* BenchmarkRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkRunner.swift; sourceTree = "<group>"; };
 		D6BENCH022F0000000000003 /* BenchmarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkView.swift; sourceTree = "<group>"; };
@@ -227,6 +238,10 @@
 				D6B81FB52DEFFE4000D32F2A /* RecordingIndicator.swift */,
 				D6C10A012F20000000000001 /* RecordingGlowWindow.swift */,
 				D6C10A022F20000000000001 /* RecordingGlow.metal */,
+				D6MAGNET22F0000000000003 /* EdgeMagnet.metal */,
+				D6MAGNET22F0000000000005 /* MagnetField.swift */,
+				D6MAGNET22F0000000000006 /* DictationMagnetTransition.swift */,
+				D6MAGNET22F0000000000004 /* GlowGeometry.h */,
 				2A2A2A2A2A2A2A2A2A2A2A2B /* MenuBarView.swift */,
 				2A2A2A2A2A2A2A2A2A2A2A2C /* SettingsView.swift */,
 				B91EF5D0CAB5432B90AFFF23 /* KeyboardInputSourceManager.swift */,
@@ -338,6 +353,8 @@
 				D66E6D6A2E185B8A00F55A5B /* ShortcutOptionsView.swift */,
 				D60NBOARD22F0000000000002 /* ConfettiView.swift */,
 				D60NBOARD22F0000000000003 /* OnboardingTransition.swift */,
+				D6MAGNET22F0000000000001 /* EdgeMagnetRenderer.swift */,
+				D6MAGNET22F0000000000002 /* OnboardingMagnetTransition.swift */,
 				D66E6D642E185B0100F55A5B /* OnboardingProgressView.swift */,
 				D66E6D622E185AE100F55A5B /* PermissionRowView.swift */,
 				D66E6D5E2E185A5400F55A5B /* PermissionsStepView.swift */,
@@ -553,6 +570,11 @@
 				D6B81FB62DEFFE4000D32F2A /* RecordingIndicator.swift in Sources */,
 				D6C10A012F20000000000002 /* RecordingGlowWindow.swift in Sources */,
 				D6C10A022F20000000000002 /* RecordingGlow.metal in Sources */,
+				D6MAGNET12F0000000000003 /* EdgeMagnet.metal in Sources */,
+				D6MAGNET12F0000000000004 /* MagnetField.swift in Sources */,
+				D6MAGNET12F0000000000005 /* DictationMagnetTransition.swift in Sources */,
+				D6MAGNET12F0000000000001 /* EdgeMagnetRenderer.swift in Sources */,
+				D6MAGNET12F0000000000002 /* OnboardingMagnetTransition.swift in Sources */,
 				D698B91D2E18F3DD008FE0CF /* PermissionManager.swift in Sources */,
 				D63900D62E3D77EF005B5623 /* FileTranscriptionProtocols.swift in Sources */,
 				D63900D72E3D77EF005B5623 /* YouTubeTranscriptionManager.swift in Sources */,

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -111,6 +111,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 	private var settingsWindow: NSWindow?
 	private var swiftUIOpenSettings: (@MainActor () -> Void)?
 	let popoverPresenter = PopoverPresenter()
+	private var onboardingMagnet: OnboardingMagnetController?
+	private var dictationMagnet: DictationMagnetController?
 	private var liveTranscriptionWindow: LiveTranscriptionWindow?
 	private var listeningWindow: ListeningWindow?
 	private static let alphaPulseKey = "whispera.statusItem.alphaPulse"
@@ -157,7 +159,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
 			liveTranscriptionWindow = LiveTranscriptionWindow(audioManager: audioManager)
 			listeningWindow = ListeningWindow(audioManager: audioManager)
+			dictationMagnet = DictationMagnetController()
+			if let listeningWindow {
+				// the field flies out of wherever the listening window stood
+				dictationMagnet?.attach(sourceWindow: listeningWindow)
+			}
 			recordingGlowController = RecordingGlowController(audioManager: audioManager)
+			onboardingMagnet = OnboardingMagnetController()
 			if !hasCompletedOnboarding {
 				showOnboarding()
 			}
@@ -459,7 +467,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 	private func showOnboarding() {
 		let onboardingView = OnboardingView(
 			audioManager: audioManager,
-			shortcutManager: shortcutManager
+			shortcutManager: shortcutManager,
+			magnetController: onboardingMagnet
 		)
 
 		let hostingController = NSHostingController(rootView: onboardingView)
@@ -478,6 +487,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 		onboardingWindow?.contentViewController = hostingController
 		onboardingWindow?.center()
 		onboardingWindow?.makeKeyAndOrderFront(nil)
+		if let onboardingWindow {
+			MainActor.assumeIsolated { onboardingMagnet?.attach(to: onboardingWindow) }
+		}
 
 		NSApp.setActivationPolicy(.regular)
 		NSApp.activate(ignoringOtherApps: true)
@@ -487,6 +499,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 			queue: .main
 		) { [weak self] _ in
 			NSApp.setActivationPolicy(.accessory)
+			MainActor.assumeIsolated { self?.onboardingMagnet?.detach() }
 			self?.onboardingWindow?.close()
 			Task { @MainActor in
 				self?.applyStoredModel()
@@ -503,6 +516,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 			Task { @MainActor in
 				self?.updateStatusIcon()
 				self?.recordingGlowController?.updateVisibility()
+				if let state = self?.audioManager.currentState {
+					self?.onboardingMagnet?.handle(state: state)
+				}
 			}
 		}
 


### PR DESCRIPTION
Adds a GPU particle field that carries a window into the recording glow, and carries a dictation result into the caret it is pasted at.

## What it does

**Onboarding — Try It step.** Tapping record dissolves the window into ~200k particles that fly out and pin themselves along the screen border, where the ambient recording glow takes over. When the mic closes the field converges back and the window returns under it.

**Dictation — text mode.** On transcription completion the listening window drops away and ~24k particles fly from where it stood into the caret, dissolving as the paste lands.

## How it hangs together

Two routes over one renderer (`EdgeMagnetRoute.screenBorder` / `.rect`), with per-route tuning in `EdgeMagnetProfile` — particle count, energy, sprite radius and all five durations in one place.

Particle motion is a pure function of `progress`: no simulation buffers, no per-frame state, so any frame can be drawn independently.

## Matching the glow

`GlowGeometry.h` is shared by `RecordingGlow.metal` and `EdgeMagnet.metal`, so the particles pin to the same rounded rectangle the glow occupies and cannot drift from it. `glowEdgeIntensity()` is now shared code rather than duplicated math.

Settled per-particle energy was calibrated by rendering the field offscreen at Retina density and comparing accumulated alpha against the glow, depth by depth. It was uniformly 3.3x too bright, which read as a flare that decayed; it now sits at 0.89–0.97 of the glow, deliberately a touch dim so the particles never out-shine what they hand off to.

## Threading

Rendering runs on a dedicated thread against a `CAMetalLayer`, paced by `nextDrawable()`.

- `MTKView` is not used: it delivers `draw(in:)` on the main thread, where WhisperKit's `@MainActor` CoreML model load blocks for ~370ms and stalled the animation mid-flight.
- `CAMetalDisplayLink` is not used either — its callbacks are [never delivered on a secondary thread on macOS](https://developer.apple.com/forums/thread/766889).
- The loop drains an autoreleasepool each frame, or `CAMetalDrawable`s are retained and the layer's buffer pool starves.

## Paste timing

The dictation route holds the ⌘V keystroke for `outbound * 0.7` (~126ms) so the text appears as the field arrives rather than well before it. The pasteboard is filled immediately; only the keystroke waits.

Gating lives in one function so the animation and the paste timing cannot disagree — a usable caret, completed onboarding, the recording glow switch on, Reduce Motion off. When any is false there is no animation and the paste is immediate, exactly as before.

## Caret lookup

`MagnetField.caretRect()` is deliberately separate from `AccessibilityHelper.getCaretPosition()`, which flips Y against `NSScreen.main` (the focused screen, not the primary) and keeps degenerate rects. Chrome answers the bounds query with a zero rect for many fields, which that path turns into a bottom-corner "position". The new lookup converts against the primary display and rejects non-finite values, zero height, and rects that intersect no screen.

The existing helper is untouched, since `LiveTranscriptionWindow` and `RecordingIndicator` depend on its current behaviour.

## Notes

- Onboarding effect is gated to the Try It step and torn down on completion; it cannot fire afterwards.
- The whole particle treatment rides the existing `enableRecordingGlow` switch.
- No-ops under Reduce Motion.

## Testing

Shader verified by offscreen renders at true Retina density (3456x2234) — this is what caught the 3.3x overexposure, a hard line where clamping stacked the density tail onto one depth, and a mid-flight pass that curtained the desktop. The border profile was re-measured after adding `targetRect` mid-struct and came back byte-identical, confirming Swift and Metal still agree on the uniform layout.

Both routes exercised by hand on a signed build.