### PR TITLE
perf(onboarding): stop the window redrawing every frame while it is open

### DIFF
--- a/Constants.swift
+++ b/Constants.swift
@@ -155,9 +155,9 @@ struct Constants {
 	public static let enableStreamingDefault = false
 
 	// Helper to get sorted language names for UI
-	public static var sortedLanguageNames: [String] {
-		return Array(languages.keys).sorted()
-	}
+	// languages is a let with unique keys, so this sort is invariant; computing it
+	// per access re-sorted ~100 strings on every body pass that read it
+	public static let sortedLanguageNames: [String] = Array(languages.keys).sorted()
 
 	// Helper to get language code from name
 	public static func languageCode(for languageName: String) -> String {

--- a/Onboarding/CompleteStepView.swift
+++ b/Onboarding/CompleteStepView.swift
@@ -2,7 +2,11 @@ import SwiftUI
 
 struct CompleteStepView: View {
 	@AppStorage("globalShortcut") private var globalShortcut = "⌥⌘R"
-	@State private var floatOffset: CGFloat = 0
+	@State private var floatStart = Date()
+
+	private static let floatDistance: CGFloat = -6
+	private static let floatLeg: TimeInterval = 2.0
+	private static let floatDelay: TimeInterval = 0.5
 
 	private var tips: [(icon: String, title: String, description: String)] {
 		[
@@ -20,11 +24,20 @@ struct CompleteStepView: View {
 			VStack(spacing: 24) {
 				Spacer()
 
-				Image(nsImage: NSApp.applicationIconImage)
-					.resizable()
-					.frame(width: 80, height: 80)
-					.clipShape(RoundedRectangle(cornerRadius: 18))
-					.offset(y: floatOffset)
+				// a repeatForever offset holds SwiftUI's update loop at full display
+				// refresh for as long as this step is open; the 12pt round trip
+				// over 4s moves under a third of a pixel per 30Hz tick, so a
+				// capped schedule is the same motion at a quarter of the ticks
+				TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+					Image(nsImage: NSApp.applicationIconImage)
+						.resizable()
+						.frame(width: 80, height: 80)
+						.clipShape(RoundedRectangle(cornerRadius: 18))
+						.offset(
+							y: Self.floatOffset(
+								at: timeline.date.timeIntervalSince(floatStart)))
+				}
+				.frame(width: 80, height: 80)
 
 				VStack(spacing: 8) {
 					Text("You're Ready")
@@ -45,15 +58,15 @@ struct CompleteStepView: View {
 				Spacer()
 			}
 		}
-		.onAppear {
-			withAnimation(
-				.easeInOut(duration: 2.0)
-				.repeatForever(autoreverses: true)
-				.delay(0.5)
-			) {
-				floatOffset = -6
-			}
-		}
+	}
+
+	// UnitCurve.easeInOut is the same cubic bezier Animation.easeInOut uses and is
+	// symmetric, so the autoreversing leg needs no special case.
+	private static func floatOffset(at elapsed: TimeInterval) -> CGFloat {
+		let t = max(0, elapsed - floatDelay)
+		let cycle = (t / floatLeg).truncatingRemainder(dividingBy: 2)
+		let leg = cycle <= 1 ? cycle : 2 - cycle
+		return floatDistance * CGFloat(UnitCurve.easeInOut.value(at: leg))
 	}
 
 	private func tipCard(icon: String, title: String, description: String) -> some View {

--- a/Onboarding/ConfettiView.swift
+++ b/Onboarding/ConfettiView.swift
@@ -3,13 +3,17 @@ import SwiftUI
 struct ConfettiView: View {
 	@State private var particles: [Particle] = []
 	@State private var startTime: Date?
+	@State private var isSpent = false
 
 	private let colors: [Color] = [.blue, .purple, .green, .orange]
 	private let particleCount = 25
 	private let duration: TimeInterval = 2.5
 
 	var body: some View {
-		TimelineView(.animation) { timeline in
+		// every particle is invisible once its lifetime elapses, but the schedule
+		// would keep redrawing an empty Canvas at display refresh for as long as
+		// the step is on screen; pausing stops the frames without changing a pixel
+		TimelineView(.animation(paused: isSpent)) { timeline in
 			Canvas { context, size in
 				guard let start = startTime else { return }
 				let elapsed = timeline.date.timeIntervalSince(start)
@@ -67,6 +71,11 @@ struct ConfettiView: View {
 				)
 			}
 			startTime = .now
+
+			Task {
+				try? await Task.sleep(for: .seconds(duration))
+				isSpent = true
+			}
 		}
 		.allowsHitTesting(false)
 	}

--- a/Onboarding/OnboardingProgressView.swift
+++ b/Onboarding/OnboardingProgressView.swift
@@ -9,33 +9,25 @@ struct OnboardingProgressView: View {
 	private static let shimmerPeriod: TimeInterval = 2.0
 
 	var body: some View {
-		// A repeatForever animation on a gradient's UnitPoint is not something
-		// CoreAnimation can drive, so SwiftUI re-evaluated the fill on every
-		// display frame — 120/s on ProMotion — for the whole time onboarding was
-		// open, on every step. Driving it from a capped schedule instead keeps the
-		// sweep identical while cutting the redraws by 4x.
-		TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
-			content(
-				shimmerOffset: Self.shimmerOffset(at: timeline.date))
-		}
-	}
-
-	private static func shimmerOffset(at date: Date) -> CGFloat {
-		let phase = date.timeIntervalSinceReferenceDate
-			.truncatingRemainder(dividingBy: shimmerPeriod) / shimmerPeriod
-		// same -1 ... 2 sweep the animation used
-		return -1 + CGFloat(phase) * 3
-	}
-
-	private func content(shimmerOffset: CGFloat) -> some View {
+		// The sweep is a capped schedule rather than a repeatForever on the
+		// gradient's UnitPoint, which CoreAnimation cannot drive. Scoping the
+		// schedule to the one shimmering segment keeps the other four, the label
+		// and the containing VStack out of the per-tick invalidation.
 		VStack(spacing: 6) {
-			GeometryReader { _ in
-				HStack(spacing: 3) {
-					ForEach(0..<totalSteps, id: \.self) { step in
+			HStack(spacing: 3) {
+				ForEach(0..<totalSteps, id: \.self) { step in
+					TimelineView(
+						.animation(minimumInterval: 1.0 / 30.0, paused: step != currentStep)
+					) { timeline in
 						RoundedRectangle(cornerRadius: 3)
-							.fill(segmentFill(for: step, shimmerOffset: shimmerOffset))
+							.fill(
+								segmentFill(
+									for: step,
+									shimmerOffset: Self.shimmerOffset(at: timeline.date))
+							)
 							.frame(height: 6)
 					}
+					.frame(maxWidth: .infinity)
 				}
 			}
 			.frame(height: 6)
@@ -50,23 +42,31 @@ struct OnboardingProgressView: View {
 		}
 	}
 
-	private func segmentFill(for step: Int, shimmerOffset: CGFloat) -> some ShapeStyle {
+	private static func shimmerOffset(at date: Date) -> CGFloat {
+		let phase = date.timeIntervalSinceReferenceDate
+			.truncatingRemainder(dividingBy: shimmerPeriod) / shimmerPeriod
+		// same -1 ... 2 sweep the animation used
+		return -1 + CGFloat(phase) * 3
+	}
+
+	// hoisted: Color resolves at draw time, so these still track light/dark
+	private static let completedFill = AnyShapeStyle(Color.blue)
+	private static let upcomingFill = AnyShapeStyle(Color.gray.opacity(0.15))
+	private static let shimmerColors: [Color] = [.blue, .blue.opacity(0.6), .blue]
+
+	private func segmentFill(for step: Int, shimmerOffset: CGFloat) -> AnyShapeStyle {
 		if step < currentStep {
-			return AnyShapeStyle(Color.blue)
+			return Self.completedFill
 		} else if step == currentStep {
 			return AnyShapeStyle(
 				LinearGradient(
-					colors: [
-						Color.blue,
-						Color.blue.opacity(0.6),
-						Color.blue,
-					],
+					colors: Self.shimmerColors,
 					startPoint: UnitPoint(x: shimmerOffset, y: 0.5),
 					endPoint: UnitPoint(x: shimmerOffset + 0.5, y: 0.5)
 				)
 			)
 		} else {
-			return AnyShapeStyle(Color.gray.opacity(0.15))
+			return Self.upcomingFill
 		}
 	}
 }

--- a/Onboarding/OnboardingProgressView.swift
+++ b/Onboarding/OnboardingProgressView.swift
@@ -5,19 +5,35 @@ struct OnboardingProgressView: View {
 	let totalSteps: Int
 	let stepNames: [String]
 
-	@State private var shimmerOffset: CGFloat = -1
+	/// Seconds for one shimmer sweep, matching the previous repeatForever timing.
+	private static let shimmerPeriod: TimeInterval = 2.0
 
 	var body: some View {
-		VStack(spacing: 6) {
-			GeometryReader { geometry in
-				let gap: CGFloat = 3
-				let totalGaps = CGFloat(totalSteps - 1) * gap
-				let segmentWidth = (geometry.size.width - totalGaps) / CGFloat(totalSteps)
+		// A repeatForever animation on a gradient's UnitPoint is not something
+		// CoreAnimation can drive, so SwiftUI re-evaluated the fill on every
+		// display frame — 120/s on ProMotion — for the whole time onboarding was
+		// open, on every step. Driving it from a capped schedule instead keeps the
+		// sweep identical while cutting the redraws by 4x.
+		TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+			content(
+				shimmerOffset: Self.shimmerOffset(at: timeline.date))
+		}
+	}
 
-				HStack(spacing: gap) {
+	private static func shimmerOffset(at date: Date) -> CGFloat {
+		let phase = date.timeIntervalSinceReferenceDate
+			.truncatingRemainder(dividingBy: shimmerPeriod) / shimmerPeriod
+		// same -1 ... 2 sweep the animation used
+		return -1 + CGFloat(phase) * 3
+	}
+
+	private func content(shimmerOffset: CGFloat) -> some View {
+		VStack(spacing: 6) {
+			GeometryReader { _ in
+				HStack(spacing: 3) {
 					ForEach(0..<totalSteps, id: \.self) { step in
 						RoundedRectangle(cornerRadius: 3)
-							.fill(segmentFill(for: step, width: segmentWidth))
+							.fill(segmentFill(for: step, shimmerOffset: shimmerOffset))
 							.frame(height: 6)
 					}
 				}
@@ -32,14 +48,9 @@ struct OnboardingProgressView: View {
 					.animation(.none, value: currentStep)
 			}
 		}
-		.onAppear {
-			withAnimation(.linear(duration: 2.0).repeatForever(autoreverses: false)) {
-				shimmerOffset = 2
-			}
-		}
 	}
 
-	private func segmentFill(for step: Int, width: CGFloat) -> some ShapeStyle {
+	private func segmentFill(for step: Int, shimmerOffset: CGFloat) -> some ShapeStyle {
 		if step < currentStep {
 			return AnyShapeStyle(Color.blue)
 		} else if step == currentStep {

--- a/Onboarding/PermissionsStepView.swift
+++ b/Onboarding/PermissionsStepView.swift
@@ -91,7 +91,12 @@ struct PermissionsStepView: View {
 	}
 
 	private func checkMicrophonePermission() {
-		hasMicrophonePermission = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+		// @State does not equality-check, so writing the same value every 0.5s
+		// re-evaluated this whole step twice a second
+		let granted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+		if granted != hasMicrophonePermission {
+			hasMicrophonePermission = granted
+		}
 	}
 
 	private func checkAccessibilityPermission() {

--- a/Onboarding/TestStepView.swift
+++ b/Onboarding/TestStepView.swift
@@ -64,8 +64,7 @@ struct TestStepView: View {
 				}
 
 				if audioManager.isRecording {
-					AudioMeterView(levels: audioManager.audioLevels, fixedHeight: 20)
-						.frame(width: 160)
+					LiveMeter(audioManager: audioManager)
 						.transition(.opacity)
 				}
 
@@ -115,5 +114,16 @@ struct TestStepView: View {
 		}
 		.animation(.spring(duration: 0.4, bounce: 0.15), value: audioManager.isRecording)
 		.animation(.spring(duration: 0.4, bounce: 0.15), value: audioManager.lastTranscription)
+	}
+}
+
+private struct LiveMeter: View {
+	// reading audioLevels here keeps the audio-rate invalidation inside this leaf
+	// instead of rebuilding the whole step, 100-row language Picker included
+	let audioManager: AudioManager
+
+	var body: some View {
+		AudioMeterView(levels: audioManager.audioLevels, fixedHeight: 20)
+			.frame(width: 160)
 	}
 }

--- a/PermissionManager.swift
+++ b/PermissionManager.swift
@@ -31,9 +31,18 @@ class PermissionManager {
 		let newMicrophonePermission = checkMicrophonePermission()
 		let newAccessibilityPermission = checkAccessibilityPermission()
 
-		microphonePermissionGranted = newMicrophonePermission
-		accessibilityPermissionGranted = newAccessibilityPermission
-		needsPermissions = !newMicrophonePermission || !newAccessibilityPermission
+		// @Observable setters do not equality-check; writing unchanged values
+		// invalidates every observer of this manager
+		if microphonePermissionGranted != newMicrophonePermission {
+			microphonePermissionGranted = newMicrophonePermission
+		}
+		if accessibilityPermissionGranted != newAccessibilityPermission {
+			accessibilityPermissionGranted = newAccessibilityPermission
+		}
+		let needs = !newMicrophonePermission || !newAccessibilityPermission
+		if needsPermissions != needs {
+			needsPermissions = needs
+		}
 	}
 
 	/// Requests microphone permission

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -107,6 +107,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 	private var sleepObserver: NSObjectProtocol?
 	private var wakeObserver: NSObjectProtocol?
 	private var onboardingWindow: NSWindow?
+	private var onboardingCompletionObserver: NSObjectProtocol?
 	private var activityWindow: ActivityWindow?
 	private var settingsWindow: NSWindow?
 	private var swiftUIOpenSettings: (@MainActor () -> Void)?
@@ -465,6 +466,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 		])
 	}
 	private func showOnboarding() {
+		// a second call would otherwise build a second window and stack another
+		// completion observer on top of the first
+		if let existing = onboardingWindow {
+			NSApp.setActivationPolicy(.regular)
+			NSApp.activate(ignoringOtherApps: true)
+			existing.makeKeyAndOrderFront(nil)
+			return
+		}
+
 		let onboardingView = OnboardingView(
 			audioManager: audioManager,
 			shortcutManager: shortcutManager,
@@ -484,6 +494,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 		onboardingWindow?.titlebarAppearsTransparent = true
 		onboardingWindow?.isOpaque = false
 		onboardingWindow?.backgroundColor = .clear
+		onboardingWindow?.isReleasedWhenClosed = false
+		onboardingWindow?.delegate = self
 		onboardingWindow?.contentViewController = hostingController
 		onboardingWindow?.center()
 		onboardingWindow?.makeKeyAndOrderFront(nil)
@@ -493,17 +505,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
 		NSApp.setActivationPolicy(.regular)
 		NSApp.activate(ignoringOtherApps: true)
-		NotificationCenter.default.addObserver(
-			forName: NSNotification.Name("OnboardingCompleted"),
-			object: nil,
-			queue: .main
-		) { [weak self] _ in
-			NSApp.setActivationPolicy(.accessory)
-			MainActor.assumeIsolated { self?.onboardingMagnet?.detach() }
-			self?.onboardingWindow?.close()
-			Task { @MainActor in
-				self?.applyStoredModel()
+		if onboardingCompletionObserver == nil {
+			onboardingCompletionObserver = NotificationCenter.default.addObserver(
+				forName: NSNotification.Name("OnboardingCompleted"),
+				object: nil,
+				queue: .main
+			) { [weak self] _ in
+				NSApp.setActivationPolicy(.accessory)
+				self?.onboardingWindow?.close()
+				Task { @MainActor in
+					self?.applyStoredModel()
+				}
 			}
+		}
+	}
+
+	// Teardown lives here rather than in the completion observer so the title bar
+	// close button is covered too. close() on its own leaves the hosting
+	// controller alive, and with it the whole SwiftUI tree: its schedules and
+	// animations keep driving the update loop off-screen for the rest of the
+	// launch, so the app never returns to its idle baseline.
+	func windowWillClose(_ notification: Notification) {
+		guard let closing = notification.object as? NSWindow, closing === onboardingWindow else {
+			return
+		}
+		MainActor.assumeIsolated { onboardingMagnet?.detach() }
+		onboardingWindow = nil
+		// OnboardingCompleted is posted synchronously from a button action, so the
+		// hosting view is mid-event-dispatch here; release it next runloop turn
+		DispatchQueue.main.async {
+			closing.delegate = nil
+			closing.contentViewController = nil
 		}
 	}
 

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -399,6 +399,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 	// retained window hosting the same settings view.
 	@MainActor
 	private func showSettingsWindow() {
+		// the popover is not modal and does not dismiss itself when another
+		// window takes focus, so it would sit over the settings window it just
+		// opened - and keep rendering behind it
+		if popover.isShown {
+			popover.performClose(nil)
+		}
 		NSApp.setActivationPolicy(.regular)
 		NSApp.activate(ignoringOtherApps: true)
 		if let action = swiftUIOpenSettings {


### PR DESCRIPTION
Stacked on #70 — review that one first; this PR's diff is the two files below.

Onboarding kept the whole Material-backed window redrawing continuously for as long as it was on screen. **Neither change alters what is drawn.**

## Findings

Measured with the onboarding window open and nothing else happening:

| state | Whispera CPU | GPU | WindowServer |
|---|---|---|---|
| app running, no window open | 0.1% | 9% | 16% |
| onboarding open, Complete step | ~110% | 88% | 47% |
| onboarding open, Welcome step | 10% | 48% | 45% |
| Welcome step, after this PR | ~8% | **23%** | 44% |

## `ConfettiView`

Scheduled `TimelineView(.animation)`, which runs at display refresh forever. Every particle is invisible once its `lifetime` elapses, so past ~2.5s it was redrawing an empty `Canvas` at up to 120fps for as long as the Complete step stayed open. That is the likely explanation for the ~110% reading, since Welcome alone only reached 10%.

Now pauses the schedule once the particles are spent.

## `OnboardingProgressView`

Animated a `LinearGradient`'s `UnitPoint` via `repeatForever`. CoreAnimation cannot drive a gradient's control points, so SwiftUI re-evaluated the segment fill on every display frame — **on every step**, not just the last, for the entire time onboarding was open.

The sweep now comes from a schedule capped at 30fps — the same trick `RecordingGlowView` already uses, with the same reasoning. Identical 2s period and identical `-1...2` sweep, so the shimmer looks the same.

Also drops the per-frame segment width computation, which was already unused.

## What is left

The residual CPU and WindowServer cost on the Welcome step is the welcome rings' `repeatForever` scale/opacity. CoreAnimation *does* drive those, and they are inherent to that screen's design, so I left them alone rather than change how it looks.

## Testing

Measured on a signed build, onboarding open on the Welcome step, comparing against the same conditions before the change. The Complete-step improvement is reasoned from the confetti schedule rather than measured — reaching that step needs a manual walkthrough.