### PR TITLE
feat(transcription): one engine protocol — WhisperKit, server, and direct streaming (WHI-58)

### DIFF
--- a/AUTOCHOOSE-RESULT.md
+++ b/AUTOCHOOSE-RESULT.md
@@ -1,0 +1,168 @@
+# WHI-58 follow-up: automatic engine/tier selection
+
+An `auto` `TranscriptionEngine` that picks the best available transcription path —
+native-delta server, synthesized-delta server, utterance-only server, or on-device
+WhisperKit — without the user configuring anything. Branch
+`ismatulla/whi-58-engine-protocol`. Neither this change nor its tests touch the
+sibling `WhisperaDictation` package (`../../whispera-components-worktrees/dictation/apple`).
+
+## The one thing the package can't give us yet
+
+`WhisperaDictation.DictationServer` (`ServerDiscovery.swift`) does not decode
+`realtime.granularity` — the field this whole feature ranks servers on. The package's
+own `GET /transcription/servers` request (`DictationServerDirectory.servers()`) drops
+it silently because its `Realtime` struct doesn't declare the property.
+
+Rather than edit the package, `Client/AutoTranscriber.swift` adds `ServerDiscoveryProbe`:
+an app-side `Decodable` mirror of the same response (`id`, `label`, `capabilities`,
+`status`, `default`, and `realtime.granularity`), built with the exact same request shape
+the package uses (same path, same credential-in-header/query-item placement) so the two
+can't quietly drift apart. It talks to the credential protocol
+(`DictationCredentialProvider`, public) directly — no package-internal API needed.
+
+**The one-line package change that would let this go away:** add `public let
+granularity: String?` to `DictationServer.Realtime` in `ServerDiscovery.swift`, and drop
+`ServerDiscoveryProbe` in favor of `DictationServerDirectory.servers()`. Everything else
+here — the ranking, the caching, the conformer — is unaffected either way.
+
+This was checked against the real thing, not just imagined: hit the live dev backend at
+`http://127.0.0.1:3000/transcription/servers` (bearer `demo-user`) directly, and its
+sibling's delta-synthesis work has already landed *and* a native NeMo engine is already
+registered:
+
+```json
+speaches-lan   default:true   capabilities:[batch,realtime]  granularity: synthesized-delta
+speaches-plain default:false  capabilities:[batch,realtime]  granularity: utterance
+nemo-stream    default:false  capabilities:[realtime]        granularity: native-delta
+```
+
+Running the probe's exact decode + ranking logic against that live payload (via a
+throwaway `swift` script, not committed) picks `nemo-stream` — the non-default,
+native-delta server — over the backend's own flagged default. That is the feature
+working as specified: rank beats "default" when nothing is pinned.
+
+## Resolution policy (`AutoEnginePolicy.resolve`, pure, in `Client/AutoTranscriber.swift`)
+
+| serverURLConfigured | discovery | pinnedServerId | usable servers | → |
+|---|---|---|---|---|
+| false | — | — | — | local — "no transcription server configured" |
+| true | unavailable (timeout/error) | — | — | local — "backend unreachable" |
+| true | servers([]) or none online+realtime | — | — | local — "no realtime server available" |
+| true | servers | non-empty, found among usable | — | that pinned server, its own granularity |
+| true | servers | non-empty, **not** found/usable | — | falls through to ranking below (pin isn't a dead end) |
+| true | servers | empty | ≥1 usable | best by granularity rank (native-delta > synthesized-delta > utterance), ties broken by the backend's own `default` flag, then id |
+
+Absent or unrecognised `granularity` decodes to `.utterance` — the worst rank, not the
+best — so an older backend, or one whose delta-synthesis hasn't landed, degrades to
+"looks like it has no live words" rather than being assumed to have the best kind.
+
+Discovery runs with a 3s request timeout (`ServerDiscoveryProbe`'s
+`URLRequest.timeoutInterval`) and the resolved answer is cached for 20s
+(`AutoTranscriber.cacheTTL`) — resolved fresh at the top of every `prepare()`,
+`startStreaming()`, and one-shot `transcribe()` call, not on every audio frame, and not
+re-fetched on a rapid stop/start inside that window.
+
+## Default for fresh installs: `auto`
+
+`WhisperaSettings.transcriptionEngine`'s fallback (`Client/TranscriptionRouter.swift`)
+changed from `.whisperKit` to `.auto` for absent/unrecognised stored values, and
+`SettingsView`'s `@AppStorage` default followed it, so the picker and the runtime default
+never disagree.
+
+This was verified safe rather than assumed: nothing in `WhisperaUnitTests` constructs an
+`AudioManager` or otherwise exercises `TranscriptionRouter`'s default-resolution path —
+every existing test that touches the router passes an explicit engine or an explicit
+`engineProvider`. Ran the full `WhisperaUnitTests` target after the change; everything
+that could plausibly be sensitive to the default (`TranscriptionRouterTests`,
+`ServerEngineTests`, `TranscriptionFailureTests`, streaming/live-transcription suites)
+stayed green. This is honest, not just convenient: `auto` with no server configured
+resolves to exactly what `.whisperKit` used to mean, so a fresh install behaves
+identically to before until the user points it at a server.
+
+## `auto` as a conformer, not a `switch` case
+
+`AutoTranscriber` (`Client/AutoTranscriber.swift`) is a `SpeechTranscribing` conformer in
+its own right — `engine == .auto` — that resolves at the top of every call and delegates
+to whichever of `WhisperKitTranscriber.shared` or an internally-held `StreamingTranscriber`
+it picked. This, not a `switch` on `.auto` somewhere in `AudioManager` or
+`TranscriptionRouter`, is why `TranscriptionRouter.transcriber(for:)` stays exhaustive
+without reopening — `TranscriptionRouterTests.everyEngineResolvesToAConformer` already
+enforced that shape, and it still does with `.auto` in the loop.
+
+Two consequences worth stating plainly:
+
+- `TranscriptionEngine.auto.streamsFromAServer` is `false` even though `auto` may end up
+  streaming, because `ServerEngineTests.everyServerEngineResolvesToTheStreamingConformer`
+  asserts every engine that answers `true` there resolves to a `StreamingTranscriber`
+  instance specifically — `AutoTranscriber` isn't one. Because of that, the existing
+  "turn on Live Transcription Mode to see live words" `InfoBox` in `SettingsView` — gated
+  on `streamsFromAServer` — would have silently stopped applying to `auto`, even though
+  its wording is engine-agnostic and the caveat is exactly as true whether `auto` lands on
+  a server or on WhisperKit. Its visibility condition now also checks `== .auto` directly
+  rather than folding that into `streamsFromAServer`'s meaning.
+- Model management (`models()`, `selectModel`, `downloadModel`) always addresses the
+  on-device model bank, unconditionally on the currently-resolved delegate — mirroring
+  the existing "Whisper Model" Settings section, which is already unconditional on the
+  engine picker. There is no server for a user to manage models against under `auto`
+  even on a run that happens to stream.
+- A remote pick is not `StreamingTranscriber.shared` (which would resolve through the
+  package's own default-first logic, ignoring granularity) but a second, dedicated
+  `StreamingTranscriber` instance inside `AutoTranscriber`, pointed at the specific server
+  id the policy chose via an injected `serverIdProvider`. This costs one extra discovery
+  round trip per resolution (the probe, then that instance's own `resolveServer()` when it
+  actually connects) — accepted rather than engineered away, since avoiding it would mean
+  either mutating the user's pinned-server setting to reflect an auto pick (dishonest: it
+  would look like the user chose it) or touching the package to expose granularity through
+  the existing directory (out of scope here).
+
+## Settings
+
+The picker gains `.auto` as `"Automatic (recommended)"`, first in `TranscriptionEngine`'s
+case order so it's also first in the picker. Selecting it shows a caption block (same
+pattern as the existing streaming/direct-mode blocks) with a static explanation plus a
+live one-liner — `AutoTranscriber.resolutionCaption()` — fetched via `.task(id:)` the same
+way the direct-mode model list already refreshes itself, sharing the same 20s cache a
+dictation would use rather than triggering its own round trip.
+
+## Status legibility
+
+`AutoTranscriber.apply(_:)` sets `LiveTranscriptionState.shared.waitingForModelStatusText`
+to `resolution.summary` (e.g. `"auto: server nemo-stream (native-delta)"` or `"auto: local
+WhisperKit (backend unreachable)"`) once, at the top of resolution, before delegating.
+The delegate's own `startStreaming` immediately refines that with its usual
+connecting/loading text — expected, since this is only the first word on what `auto`
+picked and why. The same line goes to `AppLogger.shared.transcriber.info`.
+
+## Tests
+
+`WhisperaUnitTests/AutoEnginePolicyTests.swift` — ten pure `AutoEnginePolicy.resolve`
+cases: no URL, discovery failure, no usable server, native > synthesized > utterance
+ranking, absent-granularity-degrades-not-wins, default-flag tie-break, a pin winning over
+better-ranked alternatives, a stale/unusable pin falling through to ranking rather than
+dead-ending, and the summary string's exact wording. No network, no `MainActor`, no
+backend.
+
+Small additions to existing suites rather than new ones: `TranscriptionRouterTests` gained
+`autoResolvesToTheAutoTranscriber`, `anAbsentOrUnknownStoredEngineFallsBackToAuto`, and an
+`.auto` case in `resolvingTwiceReturnsTheSameInstance`; `ServerEngineTests` gained one
+assertion that `.auto.streamsFromAServer` is `false`.
+
+## What was run
+
+- `xcodebuild … -scheme Whispera build` — succeeded, on the remote build Mac (this Mac
+  has no full Xcode), synced via `rsync` per the environment recipe, both the app worktree
+  and the `whispera-components-worktrees/dictation/apple` package copy.
+- `xcodebuild … -only-testing:WhisperaUnitTests test` — full target run, exit 0. Read
+  individual test-case lines rather than trusting the summary line (known bootstrap
+  flake). Every `TranscriptionRouterTests`, `ServerEngineTests`,
+  `TranscriptionFailureMessageTests`, `AutoEnginePolicyTests`, `StreamingTranscriberDirectModelsTests`,
+  `LiveTranscriptionSegmentBufferTests`/`LiveTranscriptionRemoteIngestTests`/`LiveTranscriptionFlickerFilterTests`,
+  `PillAnchorTests`/`PillAnchorProviderTests`, `RecordingWindowPolicyTests`,
+  `DeviceSwitchRouteTests`, `FailedActivationHealingTests`, `RecordingSegmentLoadingTests`,
+  `LiveDictationPasteTests`, and `SystemAudioMuterTests` case passed. The one failure in
+  the run, `YouTubeDownloadTranscriptionTests.queueManagerProcessesYouTubeWithTitle`
+  (180s timeout), is a pre-existing real-network YouTube integration test unrelated to
+  transcription engine routing — untouched by this change.
+- A throwaway `swift` script (not committed) decoding the live backend's real
+  `/transcription/servers` response with `ServerDiscoveryProbe`'s exact shape and running
+  `AutoEnginePolicy`'s ranking against it — confirmed above.

--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -871,8 +871,15 @@ extension AudioManager {
 		// back down in bounded time.
 		isTranscribing = true
 		Task {
-			let transcript = await engine.stopStreaming()
-			guard let toPaste = Self.textToPaste(afterLiveDictationFinished: transcript) else {
+			let draft = await engine.stopStreaming()
+			// The two-pass finalizer, when the engine retained audio for one. It
+			// answers nil with no real suspension on the instant path, so a
+			// finalizer set to off pastes exactly as fast as before; when it is
+			// on, this is the bounded "polishing" wait, and isTranscribing holds
+			// the spinner up until the paste lands — the semantics it already had.
+			let polished = await engine.finalizeDictation(draft: draft)
+			guard let toPaste = Self.textToPaste(afterLiveDictationFinished: polished ?? draft)
+			else {
 				isTranscribing = false
 				return
 			}

--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -141,6 +141,30 @@ final class AudioManager: NSObject {
 	@ObservationIgnored
 	let whisperKitTranscriber = WhisperKitTranscriber.shared
 
+	/// The engine the user selected. Resolved per call rather than cached so a
+	/// change in Settings applies to the next dictation without a restart, and
+	/// so remote and on-device reach AudioManager through one interface instead
+	/// of a branch. See WHI-58.
+	@ObservationIgnored
+	var transcriberProvider: () -> SpeechTranscribing = { TranscriptionRouter.shared.active }
+
+	private var transcriber: SpeechTranscribing { transcriberProvider() }
+
+	/// The engine the current dictation started on. Keeping it means a change in
+	/// Settings mid-recording cannot route stop, or a device switch, at an
+	/// engine that never started — the same reason `toggleRecording` keeps the
+	/// mode the session began with.
+	@ObservationIgnored
+	private var sessionTranscriber: SpeechTranscribing?
+
+	/// Options for one dictation. The language is passed for engines that need
+	/// telling; WhisperKit reads its own persisted language, as it always has.
+	fileprivate func dictationOptions(translate: Bool) -> TranscriptionOptions {
+		TranscriptionOptions(
+			mode: translate ? .translate : .transcribe,
+			language: Constants.languageCode(for: selectedLanguage))
+	}
+
 	/// Transforms a finished transcription before it is pasted (recipe matching
 	/// + execution). Returns nil to paste nothing. Injected by the app so
 	/// AudioManager stays free of recipe/network dependencies. WHI-41.
@@ -152,8 +176,12 @@ final class AudioManager: NSObject {
 	override init() {
 		super.init()
 		whisperKitTranscriber.startInitialization()
-		whisperKitTranscriber.onLiveAudioSamples = { [weak self] samples in
-			// WhisperKit delivers per-buffer chunks; cap the window so level
+		whisperKitTranscriber.onLiveAudioSamples = liveAudioSampleHandler()
+	}
+
+	private func liveAudioSampleHandler() -> @MainActor ([Float]) -> Void {
+		{ [weak self] samples in
+			// Engines deliver per-buffer chunks; cap the window so level
 			// math stays cheap even if a large backlog arrives at once
 			self?.levelMonitor.update(from: Array(samples.suffix(4800)))
 		}
@@ -258,7 +286,7 @@ final class AudioManager: NSObject {
 		deviceActivationTask = Task {
 			switch route {
 			case .liveRestart:
-				await whisperKitTranscriber.switchLiveStreamDevice()
+				await (sessionTranscriber ?? transcriber).switchStreamingDevice()
 				guard !Task.isCancelled else { return }
 				isMicrophoneInitializing = false
 			case .engineRestart:
@@ -777,13 +805,16 @@ extension AudioManager {
 		isRecording = true
 		timer.start()
 		playFeedbackSound(start: true)
-		whisperKitTranscriber.clearLiveTranscriptionState()
-		whisperKitTranscriber.beginLiveTranscriptionWaitingUI()
+		let engine = transcriber
+		sessionTranscriber = engine
+		engine.onLiveAudioSamples = liveAudioSampleHandler()
+		engine.resetStreamingSession()
+		LiveTranscriptionState.shared.beginWaiting()
 
 		deviceActivationTask = Task {
 			let activationUID = deviceManager.persistedDeviceUID
 			do {
-				try await whisperKitTranscriber.liveStream()
+				try await engine.startStreaming(options: dictationOptions(translate: enableTranslation))
 				// A cancelled live start means stopLiveTranscription already ran, and
 				// that path owns the state reset and the media resume.
 				guard !Task.isCancelled else {
@@ -822,7 +853,8 @@ extension AudioManager {
 		timer.stop()
 		playFeedbackSound(start: false)
 
-		whisperKitTranscriber.stopLiveStream()
+		(sessionTranscriber ?? transcriber).stopStreaming()
+		sessionTranscriber = nil
 		levelMonitor.reset()
 		SystemAudioMuter.shared.restoreAfterDictation()
 		AppLogger.shared.audioManager.info("Live transcription stopped")
@@ -838,8 +870,8 @@ extension AudioManager {
 		transcriptionError = nil
 
 		do {
-			let transcription = try await whisperKitTranscriber.transcribeAudioArray(
-				audioArray, enableTranslation: enableTranslation)
+			let transcription = try await transcriber.transcribe(
+				samples: audioArray, options: dictationOptions(translate: enableTranslation))
 			await applyAndPaste(transcription)
 		} catch {
 			await MainActor.run {
@@ -854,8 +886,8 @@ extension AudioManager {
 		transcriptionError = nil
 
 		do {
-			let transcription = try await whisperKitTranscriber.transcribe(
-				audioURL: fileURL, enableTranslation: enableTranslation)
+			let transcription = try await transcriber.transcribe(
+				fileAt: fileURL, options: dictationOptions(translate: enableTranslation))
 			await applyAndPaste(transcription)
 		} catch {
 			await MainActor.run {

--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -16,10 +16,14 @@ enum AudioState {
 }
 
 // Both recording windows route through this policy so they can never disagree
-// via separate preferences: exactly one surface is eligible per recording mode.
+// via separate preferences. The listening pill is the persistent home for
+// recording/transcribing status in both modes; the live-transcription window
+// layers above it and only shows in live mode, and only once there is
+// something transient to say (words, a waiting-for-model status, or an
+// error) — see PillAnchor for how the two stay glued together on screen.
 enum RecordingWindowPolicy {
-	static func shouldShowListeningWindow(state: AudioState, mode: RecordingMode) -> Bool {
-		state != .idle && mode == .text
+	static func shouldShowListeningWindow(state: AudioState) -> Bool {
+		state != .idle
 	}
 
 	static func shouldShowLiveTranscriptionWindow(

--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -857,13 +857,38 @@ extension AudioManager {
 		timer.stop()
 		playFeedbackSound(start: false)
 
-		(sessionTranscriber ?? transcriber).stopStreaming()
+		let engine = sessionTranscriber ?? transcriber
 		sessionTranscriber = nil
 		levelMonitor.reset()
 		SystemAudioMuter.shared.restoreAfterDictation()
 		AppLogger.shared.audioManager.info("Live transcription stopped")
 
+		// The transcript is not final until the engine's stream actually closes
+		// (a network round trip for the remote engine), so the paste-once-at-stop
+		// behaviour has to wait for that rather than pasting whatever was on
+		// screen the instant the shortcut fired.
+		isTranscribing = true
+		Task {
+			let transcript = await engine.stopStreaming()
+			guard let toPaste = Self.textToPaste(afterLiveDictationFinished: transcript) else {
+				isTranscribing = false
+				return
+			}
+			await applyAndPaste(toPaste)
+		}
+
 		scheduleTimerReset()
+	}
+
+	/// What a finished live dictation should paste, if anything. Cancelling
+	/// during startup (`cancelCaptureStartup`) and a failed `startStreaming`
+	/// never reach `stopStreaming` at all, so they never reach this function
+	/// either — the only case left to decide is whether the engine actually
+	/// produced words. An empty or whitespace-only transcript is not an error:
+	/// the user said nothing, or a stream closed before confirming anything.
+	nonisolated static func textToPaste(afterLiveDictationFinished transcript: String) -> String? {
+		let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+		return trimmed.isEmpty ? nil : trimmed
 	}
 }
 
@@ -905,12 +930,14 @@ extension AudioManager {
 	}
 
 	/// Runs the transcription through the dictation processor (recipe matching +
-	/// execution) when in text mode, then pastes the result. WHI-41.
+	/// execution), then pastes the result once. WHI-41. Shared by text mode's
+	/// one-shot transcription and live mode's final flush at
+	/// `stopLiveTranscription` — recipes apply the same way regardless of which
+	/// mode produced the words. See WHI-58.
 	@MainActor
 	fileprivate func applyAndPaste(_ transcription: String) async {
-		let mode = currentRecordingMode
 		let toPaste: String?
-		if mode == .text, let processor = dictationProcessor {
+		if let processor = dictationProcessor {
 			toPaste = await processor(transcription)
 		} else {
 			toPaste = transcription
@@ -918,7 +945,7 @@ extension AudioManager {
 
 		lastTranscription = transcription
 		isTranscribing = false
-		if mode == .text, let toPaste {
+		if let toPaste, !toPaste.isEmpty {
 			pasteToFocusedApp(toPaste)
 		}
 	}

--- a/AudioManager/AudioManager.swift
+++ b/AudioManager/AudioManager.swift
@@ -863,10 +863,12 @@ extension AudioManager {
 		SystemAudioMuter.shared.restoreAfterDictation()
 		AppLogger.shared.audioManager.info("Live transcription stopped")
 
-		// The transcript is not final until the engine's stream actually closes
-		// (a network round trip for the remote engine), so the paste-once-at-stop
-		// behaviour has to wait for that rather than pasting whatever was on
-		// screen the instant the shortcut fired.
+		// Every engine's stopStreaming returns the transcript it has already
+		// accumulated locally, without waiting on any network close handshake —
+		// a stop that gated the paste on the socket going down hung past its own
+		// deadline in QA and never pasted at all. isTranscribing brackets only
+		// the recipe processing applyAndPaste may still run, so it always comes
+		// back down in bounded time.
 		isTranscribing = true
 		Task {
 			let transcript = await engine.stopStreaming()

--- a/BRIEF-polish.md
+++ b/BRIEF-polish.md
@@ -1,0 +1,100 @@
+# Brief: make server and direct transcription reliable, usable, and up to house standard
+
+Both paths already work end to end — proven by driving the real app. This brief is about making them
+good enough to ship.
+
+## Where you are
+
+You may edit **two** worktrees, and nothing else:
+
+- App: `/Users/uzi/Developer/whispera-worktrees/whi-58` — branch `ismatulla/whi-58-engine-protocol`
+- Package: `/Users/uzi/Developer/whispera-components-worktrees/dictation` — branch `feat/swift-dictation-component`
+
+Commit in both. **Do not push, merge, or open a PR.** Do not touch any other repo or worktree.
+
+## Verified ground truth — do not re-derive
+
+Driving the real signed app produced these, twice each:
+
+```
+Streaming through speaches-lan (…); audio pcm16 at 24000 Hz     ← via backend
+connecting → listening (29 ms) → finalTranscript("Testing one, two, three.")
+
+Streaming direct to http://192.168.50.140:8000/v1 — no backend  ← direct
+connecting → listening (73 ms) → finalTranscript("Testing one, two, three.")
+```
+
+Environment, all live right now:
+- Backend: `http://127.0.0.1:3000`, started by `run-local.sh` in the backend worktree, tmux `whispera-api`. `NODE_ENV=test`, so the bearer token **is** the user id — use `demo-user`.
+- Engine: speaches at `http://192.168.50.140:8000/v1`, model `Systran/faster-distil-whisper-large-v3`.
+- Settings keys: `whisperaTranscriptionEngine` (`whisperKit` | `whisperViaBYOK` | `whisperaStreaming` | `realtimeDirect`), `whisperaTranscriptionServerURL`, `whisperaTranscriptionServerId`, `whisperaTranscriptionDirectModel`, `enableStreaming`.
+- The app can be driven headlessly: `open -a /Applications/Whispera.app --env WHISPERA_AUTOSTART_DICTATION=<seconds>`. Speech can be injected acoustically with `say`, but **only if `whisperaPauseMediaWhileDictating` is false** — the app mutes system output while dictating, which silences your own test audio. Restore it afterwards.
+- No Xcode on this Mac. Build on `192.168.50.89` (use the IP; the DNS name is flaky) via rsync + `xcodebuild … CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO`. Known pre-existing flake: "Early unexpected exit, never finished bootstrapping" can turn the summary red while every assertion passed — count assertions.
+
+## 1. Reliability — the two measured failures
+
+### speaches kills the session after one utterance
+
+Both successful runs died ~1.5 s after the first transcript:
+
+```
+closed(failed(server(message: "InternalServerError: Internal Server Error")))
+```
+
+speaches' own logs show an unhandled `ExceptionGroup` in a Starlette TaskGroup. **It is an engine bug, not ours** — but a dictation that transcribes one phrase and then silently stops is unusable, so the client has to survive it.
+
+Make the session recover: on a *recoverable* server-side close mid-dictation, reconnect and keep capturing, rather than ending the dictation. Audio spoken during the gap is lost — that is acceptable and must be visible in the UI, not hidden. What is not acceptable is the current behaviour, where the user keeps talking to a dead socket with no indication.
+
+Distinguish recoverable from terminal. A rejected credential after the permitted retry, a missing server, and a cancelled session are terminal. A server error, an unexpected close, and a dropped connection are worth one bounded retry with backoff. Do not retry forever, and never retry silently in a way that hides a persistent failure.
+
+### First connect intermittently fails offline
+
+One direct connect failed instantly with `connectionFailed("The Internet connection appears to be offline.")` and the immediate retry succeeded. Treat a first-connect transport failure as retryable, with a short backoff, before surfacing it.
+
+### Where the retry belongs
+
+The package already has a one-shot retry for 4401 in `DictationSession`. Extend that machinery rather than bolting a second retry path into the app — the app should not know how a socket recovers.
+
+## 2. Usability — three real gaps
+
+1. **Direct mode has no settings UI.** `SettingsView` only shows URL and model fields when the engine is `whisperaStreaming`. Selecting "OpenAI-Realtime server (direct)" gives the user no way to say *which* engine or *which* model, so it can only be configured with `defaults write`. Unacceptable for a shipped feature — give it its fields.
+
+2. **Live streaming is off by default.** With a server engine selected but `enableStreaming` false, the app records first and transcribes at the end — which looks like the feature is broken. Either turn it on when the user picks a server engine, or state plainly in the UI that words arrive at the end until they enable it. Pick one and make it obvious.
+
+3. **Connection state is invisible.** `LiveTranscriptionState` already carries `isWaitingForModel` and `waitingForModelStatusText`, and the HUD renders them. Use them: connecting, listening, reconnecting, and failure should each read clearly. A user must never be left talking into a session that is not listening.
+
+Error text must say what to do. "The transcription server did not start listening. Check that it is reachable." is the right register. "InternalServerError" is not.
+
+## 3. UI, UX and animation — follow the house style
+
+`design-language.md` is the source of truth. It is 299 lines; read it. The parts that bind here:
+
+- **Spacing scale**: 4 / 8 / 12 / 16 / 20 / 24 pt. Settings rows are 20 pt horizontal, 16 pt vertical.
+- **State transitions**: `.animation(.easeInOut(duration: 0.2), value:)`. Button presses `.easeOut(duration: 0.1)`.
+- Match the existing `SettingsSection` and `InfoBox` composition already in `SettingsView.swift` — do not invent a new section style.
+- **From `CLAUDE.md`, and it contradicts a tempting shortcut**: use `.alert()` for errors, not an inline `InfoBox`. `InfoBox` is for guidance. Use the `presenting:` data pattern for alerts driven by optional state.
+- Respect `prefers-reduced-motion`. Anything that pulses while connecting must settle, not throb indefinitely.
+- No emojis in code or log messages. They are allowed only in user-facing strings where deliberately chosen.
+
+## 4. Code cleanliness
+
+- `AppLogger.shared.<category>` only — never `print` or `os.log`.
+- Comments explain **why**, not what. Delete any comment that narrates the next line.
+- Commitlint commit messages, logical commits, no Anthropic or Claude Code references.
+- Tests for the new behaviour: the recoverable-vs-terminal decision deserves a unit test with no network. The package has `DictationChecks` plus a fake engine in `tests/fake-realtime-server.ts`-style Swift form — use them.
+- The app's package reference is currently an `XCLocalSwiftPackageReference` with `relativePath = ../../whispera-components-worktrees/dictation/apple`. That only resolves on machines with this exact layout. **Leave it as-is for now** — switching it to the pushed branch is a release step and would break the build rig mid-flight — but note it in `RESULT.md` as required before merge.
+- `WHISPERA_AUTOSTART_DICTATION` in `WhisperaApp.swift` is a test affordance. Keep it, but make sure it reads as one and cannot fire in a normal launch.
+
+## Definition of done
+
+1. A dictation survives speaches' post-utterance error and keeps transcribing, or fails with a message that says what happened. Demonstrate it by driving the real app, not by reasoning about the code.
+2. Direct mode is fully configurable from Settings — no `defaults write` required.
+3. Choosing a server engine leaves the user in a working state, live transcription included.
+4. Connection state is legible throughout, and errors are actionable and use `.alert()`.
+5. Spacing, motion and composition match `design-language.md`.
+6. Builds clean on the build Mac; existing suites still pass; new behaviour has tests.
+7. `RESULT.md` in the app worktree: what changed in each repo, exactly what you drove and what came back, what you could not fix and why, and any decision you want the owner to confirm.
+
+## Start by
+
+Reading `design-language.md`, then `Client/StreamingTranscriber.swift`, `Client/TranscriptionRouter.swift`, `Client/LiveTranscriptionState.swift`, the Transcription section of `SettingsView.swift`, and the package's `DictationSession.swift` retry logic. Write your plan into `RESULT.md` before you change behaviour.

--- a/BRIEF-whi-58.md
+++ b/BRIEF-whi-58.md
@@ -1,0 +1,101 @@
+# Brief: WHI-58 — generalize the transcription engine, then wire streaming into the app
+
+You are in an **isolated git worktree**. Do not touch any path outside it.
+
+- Worktree: `/Users/uzi/Developer/whispera-worktrees/whi-58`
+- Branch: `ismatulla/whi-58-engine-protocol`
+- Based on: `ismatulla/whi-50-pill-motion` (`098bf9b`) — **not `main`**
+
+**This is a stacked branch.** `origin/main` has no `Client/` directory at all; the client code exists only on this stack. Do not rebase onto `main`, do not push, do not merge, do not open a PR.
+
+## The two jobs, in order
+
+### 1. WHI-58 — the keystone
+
+Linear WHI-58 is marked Urgent and blocks five other issues. Read it if you can; its substance is below.
+
+`Client/RemoteTranscriber.swift` today holds:
+
+```swift
+enum TranscriptionEngine: String, CaseIterable, Sendable {
+    case whisperKit
+    case whisperViaBYOK
+}
+struct RemoteTranscriber { func transcribeViaWhispera(...); func transcribeViaBYOK(...) }
+```
+
+That is a **switch-based router, not a pluggable interface**. A new engine means editing the enum and every switch over it, and remote and local are separate code paths, so every future capability gets written twice.
+
+Verified facts you can rely on:
+- `RemoteTranscriber` has **zero production call sites** — only tests reference it.
+- `transcriptionEngine` is **hard-pinned** to `.whisperKit` by a getter that ignores the stored value. The comment says to restore the stored lookup alongside the picker.
+- `WhisperKitTranscriber` conforms to **nothing**. `AudioManager` calls it directly — `liveStream()` around line 448, `transcribeAudioArray` around 484, `transcribe` around 508.
+
+Extract **one protocol** — audio in, text out — covering load/unload, model listing and download, file transcription, **streaming**, decoding options, progress reporting and cancellation. Conformers: WhisperKit (local) and a remote one.
+
+**Remote is not a special case.** An HTTP or WebSocket call and an on-device CoreML model are the same shape behind the right interface. Collapsing those paths is the whole point.
+
+**Design the interface against two engines, not one.** An interface written while WhisperKit is the only conformer will encode WhisperKit's assumptions and the second engine will not fit. Sketch both conformers before you finalize the protocol.
+
+**Acceptance, verbatim from the ticket:** `WhisperKitTranscriber` conforms with **no behaviour change**, provable against the existing tests. If behaviour moves, the protocol is wrong.
+
+Mirror the existing pattern rather than inventing a second one: `Client/RecipeRouter.swift` already has a `RecipeExecuting` protocol plus a `@MainActor` router selecting an implementation from settings. That shape is the precedent.
+
+### 2. Wire streaming into the app
+
+The backend and a Swift client package already exist and are proven working.
+
+- Add `whispera-components` as a Swift package dependency, **pinned to the branch `feat/swift-dictation-component`** (it is not merged and has no tag yet). Repo: `https://github.com/sapoepsilon/whispera-components.git`, private, and the build Mac can already fetch it — verified.
+- Use its `WhisperaDictation` product for transport. Do not reimplement the socket, the resampling, or the credential handling.
+- The remote streaming engine becomes a **conformer of the protocol from job 1**, not a branch beside WhisperKit in `AudioManager`.
+
+**Reuse the existing live UI. Do not build a second one.** `WhisperKitTranscriber` already drives on-screen text through `stableDisplayText`, `pendingText`, `confirmedText` and `shouldShowLiveTranscriptionWindow`, rendered by `LiveTranscription/{LiveTranscriptionView,LiveTranscriptionWindow,DictationView}`. The two-segment confirmation buffer that stops flicker and duplication is already solved there. A remote source must feed **those same properties**. If the remote path grows its own view, the design is wrong.
+
+Settings: no UserDefaults key exists for a custom transcription endpoint. `whisperaServerURL` points at the Whispera backend; `whisperaLocalServerURL` is LLM-only.
+
+## Environment — verified today, do not re-derive
+
+**This Mac has no Xcode.** You cannot build the app here. Build on the other Mac over passwordless SSH:
+
+```
+rsync -a --delete --exclude .git --exclude build --exclude .derived \
+  /Users/uzi/Developer/whispera-worktrees/whi-58/ \
+  ismatullamansurov@192.168.50.89:~/Developer/whispera-worktrees/whi-58-sync/
+
+ssh ismatullamansurov@192.168.50.89 'cd ~/Developer/whispera-worktrees/whi-58-sync && \
+  xcodebuild test -scheme Whispera -project Whispera.xcodeproj \
+  -only-testing:WhisperaUnitTests/<Suite> -destination "platform=macOS,arch=arm64" \
+  -derivedDataPath build/test-derived CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO'
+```
+
+- The DNS name `macbook-pro-5` fails intermittently — **use the IP**.
+- Ad-hoc signing avoids a locked-keychain codesign failure. Do not try to sign properly.
+- A known pre-existing flake, "Early unexpected exit, never finished bootstrapping", can turn the overall status red while every assertion passed. **Count assertions, not the summary line.**
+- `-only-testing:WhisperaUnitTests/AudioManagerLifecycleTests` matches nothing — that file holds suites named `DeviceSwitchRouteTests`, `FailedActivationHealingTests`, `RecordingSegmentLoadingTests`. Filter by suite name.
+
+**A live backend is running for you.** Do not start your own.
+
+- `http://192.168.50.184:3000` — this Mac, reachable from the build Mac (verified HTTP 200).
+- Auth: `NODE_ENV=test`, so the bearer token **is** the user id. Use `Bearer demo-user`.
+- `GET /transcription/servers` returns the engine, its capabilities, the WebSocket path, and the audio format (`pcm16`, 24000 Hz, mono, base64-json). **Read those from the response; do not hardcode them.**
+- Known engine quirk, not your bug: speaches ignores the model query parameter on the realtime path and always transcribes with `faster-distil-whisper-small.en`.
+
+## Constraints
+
+- **Existing tests must pass.** They are the proof that WhisperKit's behaviour did not move.
+- Follow repo conventions in `CLAUDE.md`: `AppLogger.shared.<category>` for logging, never `print` or `os.log`; no emojis in code or logs; comments explain why, not what; commitlint commit messages.
+- Never mention Anthropic or Claude Code in commits.
+- Do not edit anything outside this worktree. Reading the other repos is fine and encouraged — the backend at `/Users/uzi/Developer/whispera-backend-worktrees/realtime-proxy` and the Swift package at `/Users/uzi/Developer/whispera-components-worktrees/dictation` both have a `RESULT.md` worth reading.
+
+## Definition of done
+
+1. One protocol, with WhisperKit and a remote engine both conforming.
+2. `WhisperKitTranscriber` behaviour unchanged, proven by the existing suites passing.
+3. The app builds on the other Mac.
+4. Dictation through the backend reaches the existing live-transcription UI — same properties, no second view.
+5. The engine picker question resolved: either restore the stored lookup and expose the picker, or state plainly why you left it pinned.
+6. `RESULT.md`: what you built, the protocol's shape, exactly what you ran and what came back, what is unfinished, and any decision you want the owner to confirm.
+
+## Start by
+
+Reading `Client/RemoteTranscriber.swift`, `Client/RecipeRouter.swift`, `WhisperKitTranscriber.swift`, and `AudioManager/AudioManager.swift`. Then sketch **both** conformers in `RESULT.md` before you write the protocol.

--- a/Client/AutoTranscriber.swift
+++ b/Client/AutoTranscriber.swift
@@ -39,6 +39,10 @@ enum StreamingGranularity: String, Sendable, Equatable {
 struct DiscoveredServer: Sendable, Equatable {
 	let id: String
 	let label: String
+	/// What the server runs, for the Settings server list. The policy never
+	/// ranks on it — granularity is the quality signal — but a user pinning a
+	/// server picks by model name as much as by label.
+	let model: String
 	let isOnline: Bool
 	let supportsRealtime: Bool
 	let isDefault: Bool
@@ -61,6 +65,7 @@ enum ServerDiscoveryProbe {
 			struct Realtime: Decodable { let granularity: String? }
 			let id: String
 			let label: String
+			let model: String?
 			let capabilities: [String]
 			let status: String?
 			let realtime: Realtime?
@@ -104,6 +109,7 @@ enum ServerDiscoveryProbe {
 			DiscoveredServer(
 				id: $0.id,
 				label: $0.label,
+				model: $0.model ?? "",
 				isOnline: $0.status == nil || $0.status == "online",
 				supportsRealtime: $0.capabilities.contains("realtime"),
 				isDefault: $0.default ?? false,

--- a/Client/AutoTranscriber.swift
+++ b/Client/AutoTranscriber.swift
@@ -320,6 +320,12 @@ final class AutoTranscriber: SpeechTranscribing {
 	@discardableResult
 	func stopStreaming() async -> String { await delegate.stopStreaming() }
 
+	/// Forwarded, not re-resolved: the pass belongs to the session the current
+	/// delegate just stopped, and resolution only ever moves at dictation start.
+	func finalizeDictation(draft: String) async -> String? {
+		await delegate.finalizeDictation(draft: draft)
+	}
+
 	// MARK: - Resolution
 
 	/// A one-line caption for Settings: what `auto` currently resolves to,

--- a/Client/AutoTranscriber.swift
+++ b/Client/AutoTranscriber.swift
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import WhisperaDictation
+
+/// How close to real-time a server's words arrive. Ranked so `auto` can prefer
+/// the best available delta quality when the user hasn't pinned a specific
+/// server — a native streaming engine beats one whose deltas are synthesized
+/// by the proxy, which beats a server that only hands back whole utterances.
+///
+/// Absent or unrecognised reads as `.utterance`, the worst case: an older
+/// backend, or one whose delta-synthesis work hasn't landed yet, simply looks
+/// like it has no live words rather than being assumed to have the best kind.
+/// See AUTOCHOOSE-RESULT.md.
+enum StreamingGranularity: String, Sendable, Equatable {
+	case nativeDelta = "native-delta"
+	case synthesizedDelta = "synthesized-delta"
+	case utterance
+
+	static func from(_ raw: String?) -> StreamingGranularity {
+		raw.flatMap(StreamingGranularity.init(rawValue:)) ?? .utterance
+	}
+
+	/// Lower sorts first: native beats synthesized beats utterance-only.
+	var rank: Int {
+		switch self {
+		case .nativeDelta: return 0
+		case .synthesizedDelta: return 1
+		case .utterance: return 2
+		}
+	}
+}
+
+/// One server as `auto` needs to see it to rank and pick — a local mirror of
+/// `WhisperaDictation.DictationServer` plus the one field that package does not
+/// decode yet. See `ServerDiscoveryProbe` for why this exists instead of
+/// reusing the package's type.
+struct DiscoveredServer: Sendable, Equatable {
+	let id: String
+	let label: String
+	let isOnline: Bool
+	let supportsRealtime: Bool
+	let isDefault: Bool
+	let granularity: StreamingGranularity
+}
+
+/// Talks to `GET /transcription/servers` directly rather than through
+/// `WhisperaDictation.DictationServerDirectory`, because that package's
+/// `DictationServer` does not decode `realtime.granularity` — the field this
+/// whole feature ranks on — and this worktree does not touch the package (see
+/// AUTOCHOOSE-RESULT.md for the one-struct change that would let this go away).
+///
+/// The request is built the same way `DictationServerDirectory.servers()`
+/// builds its own — same path, same credential placement — so the two only
+/// ever drift if the backend's contract changes, not because this drifted from
+/// it by accident.
+enum ServerDiscoveryProbe {
+	private struct Response: Decodable {
+		struct Server: Decodable {
+			struct Realtime: Decodable { let granularity: String? }
+			let id: String
+			let label: String
+			let capabilities: [String]
+			let status: String?
+			let realtime: Realtime?
+			let `default`: Bool?
+		}
+		let servers: [Server]
+	}
+
+	static func fetch(
+		baseURL: URL,
+		credentials: DictationCredentialProvider,
+		session: URLSession,
+		timeout: TimeInterval
+	) async throws -> [DiscoveredServer] {
+		let credential = try await credentials.credential()
+
+		guard
+			var components = URLComponents(
+				url: baseURL.appendingPathComponent("transcription/servers"),
+				resolvingAgainstBaseURL: false)
+		else {
+			throw StreamingTranscriberError.invalidServerURL
+		}
+		if !credential.queryItems.isEmpty {
+			components.queryItems = (components.queryItems ?? []) + credential.queryItems
+		}
+		guard let url = components.url else {
+			throw StreamingTranscriberError.invalidServerURL
+		}
+
+		var request = URLRequest(url: url, timeoutInterval: timeout)
+		for (name, value) in credential.headers { request.setValue(value, forHTTPHeaderField: name) }
+
+		let (data, response) = try await session.data(for: request)
+		if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+			throw StreamingTranscriberError.engineUnreachable(baseURL.host ?? baseURL.absoluteString)
+		}
+
+		let decoded = try JSONDecoder().decode(Response.self, from: data)
+		return decoded.servers.map {
+			DiscoveredServer(
+				id: $0.id,
+				label: $0.label,
+				isOnline: $0.status == nil || $0.status == "online",
+				supportsRealtime: $0.capabilities.contains("realtime"),
+				isDefault: $0.default ?? false,
+				granularity: .from($0.realtime?.granularity))
+		}
+	}
+}
+
+/// What discovery produced, kept separate from *why* it produced nothing so the
+/// policy below can say something more useful than "unavailable" when it logs.
+enum AutoDiscoveryOutcome: Equatable {
+	case unavailable(reason: String)
+	case servers([DiscoveredServer])
+}
+
+/// What `auto` decided, and — for a remote pick — which server and how good its
+/// deltas are, so the caller can both connect and explain the choice.
+enum AutoEngineResolution: Equatable {
+	case local(reason: String)
+	case server(id: String, label: String, granularity: StreamingGranularity)
+
+	/// One line naming the choice and why. Logged, and shown once as the
+	/// streaming HUD's status text — see `AutoTranscriber.apply(_:)`.
+	var summary: String {
+		switch self {
+		case .local(let reason):
+			return "auto: local WhisperKit (\(reason))"
+		case .server(_, let label, let granularity):
+			return "auto: server \(label) (\(granularity.rawValue))"
+		}
+	}
+}
+
+/// The resolution policy itself, pure and synchronous: given what discovery
+/// found (or why it didn't), decide local vs. a specific server. Kept apart
+/// from the network and the caching around it so the whole decision table is
+/// exercisable without a backend — see `AutoEnginePolicyTests`.
+enum AutoEnginePolicy {
+	static func resolve(
+		serverURLConfigured: Bool,
+		pinnedServerId: String,
+		discovery: AutoDiscoveryOutcome
+	) -> AutoEngineResolution {
+		guard serverURLConfigured else {
+			return .local(reason: "no transcription server configured")
+		}
+		guard case .servers(let servers) = discovery else {
+			if case .unavailable(let reason) = discovery {
+				return .local(reason: reason)
+			}
+			return .local(reason: "backend unreachable")
+		}
+
+		let usable = servers.filter { $0.isOnline && $0.supportsRealtime }
+		guard !usable.isEmpty else {
+			return .local(reason: "no realtime server available")
+		}
+
+		if !pinnedServerId.isEmpty, let pinned = usable.first(where: { $0.id == pinnedServerId }) {
+			return .server(id: pinned.id, label: pinned.label, granularity: pinned.granularity)
+		}
+
+		// No pin — or a pin that isn't currently usable — falls through to
+		// picking the best granularity among what is usable, tie-broken by the
+		// backend's own default flag and then id, so the choice is deterministic.
+		let best = usable.sorted { lhs, rhs in
+			if lhs.granularity.rank != rhs.granularity.rank {
+				return lhs.granularity.rank < rhs.granularity.rank
+			}
+			if lhs.isDefault != rhs.isDefault { return lhs.isDefault }
+			return lhs.id < rhs.id
+		}.first!
+		return .server(id: best.id, label: best.label, granularity: best.granularity)
+	}
+}
+
+/// The `auto` conformer: decides between `WhisperKitTranscriber` and the
+/// streaming conformer at the top of every call, then delegates to whichever
+/// it picked. Its own `engine` reads `.auto` — it is not "the streaming
+/// conformer" the way `StreamingTranscriber` is, even on a call it delegates
+/// to a socket — which is what keeps `TranscriptionRouter.transcriber(for:)`
+/// exhaustive without reopening a switch anywhere else. See WHI-58.
+///
+/// Resolution is cached for a short window rather than re-run on every call:
+/// "at dictation start, not per frame" from the brief means a rapid
+/// stop/start shouldn't double the network round trip a user is already
+/// waiting on, but a session that runs for a while should eventually notice a
+/// server that came back up.
+@MainActor
+final class AutoTranscriber: SpeechTranscribing {
+	static let shared = AutoTranscriber()
+
+	nonisolated var engine: TranscriptionEngine { .auto }
+
+	/// The union of what either candidate can do. Honest per-call capability
+	/// reporting would mean this changes after every resolution, but nothing
+	/// reads `capabilities` mid-dictation to react to a change — the router and
+	/// the settings UI both read it once, up front.
+	nonisolated var capabilities: TranscriptionCapabilities {
+		[.fileTranscription, .bufferTranscription, .timestamps, .streaming, .managedModels, .translation]
+	}
+
+	var onLiveAudioSamples: (@MainActor ([Float]) -> Void)? {
+		didSet { delegate.onLiveAudioSamples = onLiveAudioSamples }
+	}
+
+	/// A reference box rather than a stored property read by `remote`'s
+	/// `serverIdProvider`, because that closure is built during `init`, before
+	/// `self` exists to capture.
+	private final class ServerIdBox: @unchecked Sendable {
+		var value = ""
+	}
+
+	private let local: SpeechTranscribing
+	private let remote: StreamingTranscriber
+	private let serverIdBox: ServerIdBox
+	private let baseURLProvider: () -> URL?
+	private let pinnedServerIdProvider: () -> String
+	private let credentials: DictationCredentialProvider
+	private let urlSession: URLSession
+
+	/// Which conformer calls land on right now. Starts pointed at on-device
+	/// WhisperKit — the safe assumption before the first resolution ever runs,
+	/// and exactly the fallback `auto` would pick anyway with no server
+	/// configured, which is the common fresh-install case.
+	private var delegate: SpeechTranscribing
+	private var lastResolution: (at: Date, resolution: AutoEngineResolution)?
+
+	private static let discoveryTimeout: TimeInterval = 3
+	private static let cacheTTL: TimeInterval = 20
+
+	init(
+		local: SpeechTranscribing = WhisperKitTranscriber.shared,
+		baseURLProvider: @escaping () -> URL? = { WhisperaSettings.transcriptionServerURL },
+		pinnedServerIdProvider: @escaping () -> String = { WhisperaSettings.transcriptionServerId },
+		tokenStore: AuthTokenStore = .shared,
+		urlSession: URLSession = .shared
+	) {
+		self.local = local
+		self.baseURLProvider = baseURLProvider
+		self.pinnedServerIdProvider = pinnedServerIdProvider
+		self.urlSession = urlSession
+		self.credentials = .refreshingBearer {
+			(try? tokenStore.load()).flatMap { $0.isEmpty ? nil : $0 } ?? ""
+		}
+		let serverIdBox = ServerIdBox()
+		self.serverIdBox = serverIdBox
+		self.remote = StreamingTranscriber(
+			baseURLProvider: baseURLProvider,
+			serverIdProvider: { serverIdBox.value })
+		self.delegate = local
+	}
+
+	// MARK: - Lifecycle
+
+	func prepare() async throws {
+		_ = await resolve()
+		try await delegate.prepare()
+	}
+
+	func shutdown() { delegate.shutdown() }
+
+	var state: TranscriptionEngineState { delegate.state }
+
+	// MARK: - Models
+	// Model management always addresses the on-device bank Whispera already
+	// manages regardless of engine, the same way the Settings "Whisper Model"
+	// section is unconditional on the engine picker — there is no server
+	// pinned by `auto` for a user to manage models against even when a
+	// dictation happens to run remote.
+
+	var activeModel: String? { local.activeModel }
+	func models() async throws -> [TranscriptionModelInfo] { try await local.models() }
+	func selectModel(_ id: String) async throws { try await local.selectModel(id) }
+	func downloadModel(_ id: String) async throws { try await local.downloadModel(id) }
+	func cancelModelDownload() { local.cancelModelDownload() }
+
+	// MARK: - One-shot
+
+	func transcribe(fileAt url: URL, options: TranscriptionOptions) async throws -> String {
+		_ = await resolve()
+		return try await delegate.transcribe(fileAt: url, options: options)
+	}
+
+	func transcribe(samples: [Float], options: TranscriptionOptions) async throws -> String {
+		_ = await resolve()
+		return try await delegate.transcribe(samples: samples, options: options)
+	}
+
+	func transcribeWithTimestamps(fileAt url: URL, options: TranscriptionOptions) async throws
+		-> [TranscriptionSegment]
+	{
+		_ = await resolve()
+		return try await delegate.transcribeWithTimestamps(fileAt: url, options: options)
+	}
+
+	// MARK: - Streaming
+
+	func resetStreamingSession() { delegate.resetStreamingSession() }
+
+	func startStreaming(options: TranscriptionOptions) async throws {
+		_ = await resolve()
+		try await delegate.startStreaming(options: options)
+	}
+
+	func switchStreamingDevice() async { await delegate.switchStreamingDevice() }
+
+	@discardableResult
+	func stopStreaming() async -> String { await delegate.stopStreaming() }
+
+	// MARK: - Resolution
+
+	/// A one-line caption for Settings: what `auto` currently resolves to,
+	/// using the same cache a dictation would. Reading it does not skip the
+	/// cache — opening Settings should not itself trigger a discovery round
+	/// trip more often than starting a dictation would.
+	func resolutionCaption() async -> String {
+		switch await resolve() {
+		case .local(let reason):
+			return "Currently on-device (WhisperKit) — \(reason)."
+		case .server(_, let label, let granularity):
+			return "Currently streaming through \(label) (\(granularity.rawValue))."
+		}
+	}
+
+	private func resolve() async -> AutoEngineResolution {
+		if let lastResolution, Date().timeIntervalSince(lastResolution.at) < Self.cacheTTL {
+			return lastResolution.resolution
+		}
+
+		let resolution = await Self.computeResolution(
+			baseURL: baseURLProvider(),
+			pinnedServerId: pinnedServerIdProvider(),
+			credentials: credentials,
+			session: urlSession,
+			timeout: Self.discoveryTimeout)
+
+		apply(resolution)
+		lastResolution = (Date(), resolution)
+		return resolution
+	}
+
+	private static func computeResolution(
+		baseURL: URL?,
+		pinnedServerId: String,
+		credentials: DictationCredentialProvider,
+		session: URLSession,
+		timeout: TimeInterval
+	) async -> AutoEngineResolution {
+		guard let baseURL else {
+			return AutoEnginePolicy.resolve(
+				serverURLConfigured: false,
+				pinnedServerId: pinnedServerId,
+				discovery: .unavailable(reason: "no transcription server configured"))
+		}
+		do {
+			let servers = try await ServerDiscoveryProbe.fetch(
+				baseURL: baseURL, credentials: credentials, session: session, timeout: timeout)
+			return AutoEnginePolicy.resolve(
+				serverURLConfigured: true, pinnedServerId: pinnedServerId, discovery: .servers(servers))
+		} catch {
+			AppLogger.shared.transcriber.debug(
+				"auto: discovery failed, falling back to local: \(error)")
+			return AutoEnginePolicy.resolve(
+				serverURLConfigured: true,
+				pinnedServerId: pinnedServerId,
+				discovery: .unavailable(reason: "backend unreachable"))
+		}
+	}
+
+	private func apply(_ resolution: AutoEngineResolution) {
+		switch resolution {
+		case .local:
+			delegate = local
+		case .server(let id, _, _):
+			serverIdBox.value = id
+			delegate = remote
+		}
+		delegate.onLiveAudioSamples = onLiveAudioSamples
+		// Set once, here, at the top of resolution — not on every event. The
+		// delegate's own startStreaming immediately refines this with its own
+		// connecting/loading text, which is expected: this is only the first
+		// word on which engine `auto` picked and why.
+		LiveTranscriptionState.shared.waitingForModelStatusText = resolution.summary
+		AppLogger.shared.transcriber.info(resolution.summary)
+	}
+}

--- a/Client/DictationCoordinator.swift
+++ b/Client/DictationCoordinator.swift
@@ -94,9 +94,11 @@ final class DictationCoordinator {
 			} catch is CancellationError {
 				return nil
 			} catch {
-				// Don't lose the user's words: fall back to the raw transcription
-				// and surface why the recipe didn't run.
-				self.flashError((error as? LocalizedError)?.errorDescription ?? error.localizedDescription)
+				// Don't lose the user's words: fall back to the raw transcription,
+				// and say so — the HUD message must match what actually happens.
+				let reason =
+					(error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+				self.flashError("\(reason) Pasted your words unchanged.")
 				return transcription
 			}
 		}

--- a/Client/DictationHUDWidth.swift
+++ b/Client/DictationHUDWidth.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025-2026 Ismatulla Mansurov
 
+import AppKit
 import Foundation
 
 /// The one rule for how wide the live-words HUD may be at any moment.
@@ -39,17 +40,74 @@ enum DictationHUDWidth {
 		return min(max(quantized, current), ceiling)
 	}
 
-	/// Width estimate for the trailing run of words the HUD shows. One flat
-	/// per-character price, deliberately: the old estimate priced the last
-	/// word above the rest (it renders emphasized), so every word changed its
-	/// cost the moment the next word arrived and the width wobbled on each
-	/// update. A flat price slightly above the body-font average covers the
-	/// one emphasized word too, and the step grid above absorbs the remaining
-	/// error.
+	/// Width of the trailing run of words the HUD shows, measured off the same
+	/// type `PillWordFlow` renders — body rounded for the run, title3 rounded
+	/// semibold for the emphasized last word — instead of priced per character.
+	/// The QA session showed why: a flat 9pt/char sat ~30% above what the text
+	/// actually needs, and with the never-shrink rule that error only ever
+	/// accumulated, leaving half the capsule blank. The step grid above still
+	/// absorbs word-to-word wobble; this only has to be honest about the total.
 	static func estimatedWidth(words: [String], hasEllipsis: Bool) -> CGFloat {
-		let characters = words.reduce(0) { $0 + $1.count }
-		let spacing = CGFloat(max(0, words.count - 1)) * 4
-		let ellipsis: CGFloat = hasEllipsis ? 20 : 0
-		return CGFloat(characters) * 9 + spacing + ellipsis + 32
+		var items: [CGFloat] = []
+		if hasEllipsis {
+			items.append(measure("...", font: Fonts.ellipsis) + 2)
+		}
+		for (index, word) in words.enumerated() {
+			let isLast = index == words.count - 1
+			items.append(measure(word, font: isLast ? Fonts.emphasizedWord : Fonts.word))
+		}
+		let spacing = CGFloat(max(0, items.count - 1)) * 4
+		return (items.reduce(0, +) + spacing + horizontalPadding).rounded(.up)
+	}
+
+	/// Width of a one-line status row (waiting for model, recipe error): a
+	/// 20pt indicator, its 8pt gap, then the text at caption size.
+	static func statusWidth(_ text: String) -> CGFloat {
+		(measure(text, font: Fonts.status) + 20 + 8 + horizontalPadding).rounded(.up)
+	}
+
+	/// DictationView's `.padding(.horizontal, PillSpacing.md)`, both sides.
+	private static let horizontalPadding: CGFloat = 24
+
+	private static func measure(_ text: String, font: NSFont) -> CGFloat {
+		(text as NSString).size(withAttributes: [.font: font]).width
+	}
+
+	/// AppKit equivalents of `PillTypography`: same text styles, same rounded
+	/// design, so the measurement tracks what the SwiftUI content lays out.
+	private enum Fonts {
+		static let word = rounded(.body, weight: .regular)
+		static let emphasizedWord = rounded(.title3, weight: .semibold)
+		static let ellipsis = rounded(.body, weight: .regular)
+		static let status = rounded(.caption1, weight: .regular)
+
+		private static func rounded(_ style: NSFont.TextStyle, weight: NSFont.Weight) -> NSFont {
+			let size = NSFont.preferredFont(forTextStyle: style).pointSize
+			let base = NSFont.systemFont(ofSize: size, weight: weight)
+			guard let descriptor = base.fontDescriptor.withDesign(.rounded),
+				let font = NSFont(descriptor: descriptor, size: size)
+			else { return base }
+			return font
+		}
+	}
+}
+
+/// Whether the HUD has anything to say right now. The window must never sit on
+/// screen as an empty capsule — the QA session caught exactly that: a session
+/// whose words had not arrived yet held a wide blank surface above the pill.
+/// Before the first word the HUD either shows a status line or stays hidden;
+/// once words have shown, a momentarily blank transcript keeps the window (and
+/// DictationView keeps the held words) until the session ends.
+enum DictationHUDContent {
+	static func hasSomethingToSay(
+		overlayError: String?,
+		isWaitingForModel: Bool,
+		waitingStatusText: String,
+		displayText: String,
+		hasShownWordsThisSession: Bool
+	) -> Bool {
+		if overlayError != nil { return true }
+		if isWaitingForModel { return !waitingStatusText.isEmpty }
+		return !displayText.isEmpty || hasShownWordsThisSession
 	}
 }

--- a/Client/DictationHUDWidth.swift
+++ b/Client/DictationHUDWidth.swift
@@ -6,10 +6,8 @@ import Foundation
 
 /// The one rule for how wide the live-words HUD may be at any moment.
 /// Extracted from `LiveTranscriptionWindow` so the calm-motion contract from
-/// the WHI-58 QA session — while a dictation runs the frame may grow, in
-/// coarse steps, and never shrinks or hides — is an ordinary unit-tested
-/// function instead of something only visible in a screen recording. See
-/// DictationHUDWidthTests.
+/// the WHI-58 QA sessions is an ordinary unit-tested function instead of
+/// something only visible in a screen recording. See DictationHUDWidthTests.
 enum DictationHUDWidth {
 	/// Where every session starts. Matches the window's historical floor.
 	static let compact: CGFloat = 120
@@ -19,34 +17,19 @@ enum DictationHUDWidth {
 	/// text has outgrown a whole step, not on every word.
 	static let step: CGFloat = 48
 
-	/// The width the window should adopt right now.
-	///
-	/// - `current`: the window's width, nil while it is off screen. A hidden
-	///   window has no width to preserve, which is what resets the growth
-	///   between dictations.
-	/// - `estimated`: the content's estimated natural width.
-	/// - `maximum`: the screen-derived ceiling. Once growth reaches it the
-	///   frame stops changing entirely and the content handles its own
-	///   overflow.
-	/// - `isDictating`: while true the result never drops below `current` —
-	///   the never-shrink half of the contract.
-	static func width(
-		current: CGFloat?, estimated: CGFloat, maximum: CGFloat, isDictating: Bool
-	) -> CGFloat {
-		let ceiling = max(compact, maximum)
+	/// The estimate snapped up onto the growth grid.
+	static func quantized(_ estimated: CGFloat) -> CGFloat {
 		let steps = max(0, ((estimated - compact) / step).rounded(.up))
-		let quantized = min(compact + steps * step, ceiling)
-		guard isDictating, let current else { return quantized }
-		return min(max(quantized, current), ceiling)
+		return compact + steps * step
 	}
 
 	/// Width of the trailing run of words the HUD shows, measured off the same
 	/// type `PillWordFlow` renders — body rounded for the run, title3 rounded
 	/// semibold for the emphasized last word — instead of priced per character.
 	/// The QA session showed why: a flat 9pt/char sat ~30% above what the text
-	/// actually needs, and with the never-shrink rule that error only ever
-	/// accumulated, leaving half the capsule blank. The step grid above still
-	/// absorbs word-to-word wobble; this only has to be honest about the total.
+	/// actually needs, and the width rule turned that error into a capsule whose
+	/// left half stayed blank. The step grid above still absorbs word-to-word
+	/// wobble; this only has to be honest about the total.
 	static func estimatedWidth(words: [String], hasEllipsis: Bool) -> CGFloat {
 		var items: [CGFloat] = []
 		if hasEllipsis {
@@ -92,12 +75,91 @@ enum DictationHUDWidth {
 	}
 }
 
+/// The frame's motion contract, one session at a time: grow fast, shrink slow.
+///
+/// Growth is immediate and quantized, exactly as before. But the ticker's
+/// displayed text — a trailing window of at most five words — is not monotonic:
+/// a run of long words scrolls out and the rendered line gets narrower again.
+/// Under the old never-shrink rule the frame kept the widest window it had ever
+/// seen and the trailing-aligned text left a permanent blank leading edge ("it
+/// shows up when it grows", WHI-58 QA follow-up). So a width the content has
+/// stopped needing now decays: only after the measured need has sat a full step
+/// below the frame for `shrinkDelay`, and then one quantum per further delay,
+/// so a momentary short window of words never wiggles the frame but a
+/// persistent gap closes itself calmly.
+///
+/// Time is injected (`now`), never read inside the rule, so the hysteresis is
+/// testable at any speed. Unchanged from before: a session starts compact,
+/// `reset()` (the window hiding) is what forgets the growth, the frame freezes
+/// entirely at the screen-derived ceiling, and outside a dictation the width is
+/// free to snap straight to the need.
+struct DictationHUDFrame {
+	/// How long the need must stay a full step below the frame before the first
+	/// shrink, and between consecutive shrink steps.
+	static let shrinkDelay: TimeInterval = 1.5
+
+	private(set) var width: CGFloat?
+	private var narrowSince: TimeInterval?
+
+	mutating func update(
+		estimated: CGFloat, maximum: CGFloat, isDictating: Bool, now: TimeInterval
+	) -> CGFloat {
+		let ceiling = max(DictationHUDWidth.compact, maximum)
+		let need = min(DictationHUDWidth.quantized(estimated), ceiling)
+
+		guard isDictating, let current = width else {
+			width = need
+			narrowSince = nil
+			return need
+		}
+
+		// At the ceiling the frame stops changing entirely; the content handles
+		// its own overflow.
+		guard current < ceiling else {
+			narrowSince = nil
+			width = ceiling
+			return ceiling
+		}
+
+		if need > current {
+			width = need
+			narrowSince = nil
+			return need
+		}
+
+		if need < current {
+			guard let since = narrowSince else {
+				narrowSince = now
+				return current
+			}
+			guard now - since >= Self.shrinkDelay else { return current }
+			// One quantum, then re-arm: the next step needs the gap to persist
+			// through another delay, which paces a multi-step shrink calmly and
+			// keeps a 60Hz caller (a pill drag) from draining it in one gesture.
+			let next = max(need, current - DictationHUDWidth.step)
+			width = next
+			narrowSince = now
+			return next
+		}
+
+		narrowSince = nil
+		return current
+	}
+
+	/// The hidden window: nothing to preserve, so the next session starts from
+	/// compact no matter how far this one grew.
+	mutating func reset() {
+		width = nil
+		narrowSince = nil
+	}
+}
+
 /// Whether the HUD has anything to say right now. The window must never sit on
-/// screen as an empty capsule — the QA session caught exactly that: a session
-/// whose words had not arrived yet held a wide blank surface above the pill.
-/// Before the first word the HUD either shows a status line or stays hidden;
-/// once words have shown, a momentarily blank transcript keeps the window (and
-/// DictationView keeps the held words) until the session ends.
+/// screen as an empty capsule — the QA session photographed exactly that: a
+/// session whose words had not arrived yet held a wide blank surface above the
+/// pill. Before the first word the HUD either shows a status line or stays
+/// hidden; once words have shown, a momentarily blank transcript keeps the
+/// window (and DictationView keeps the held words) until the session ends.
 enum DictationHUDContent {
 	static func hasSomethingToSay(
 		overlayError: String?,

--- a/Client/DictationHUDWidth.swift
+++ b/Client/DictationHUDWidth.swift
@@ -14,8 +14,13 @@ enum DictationHUDWidth {
 
 	/// Growth quantum. Word-by-word width estimates wobble by a few points on
 	/// every update; snapping to this grid means the frame only moves once the
-	/// text has outgrown a whole step, not on every word.
-	static let step: CGFloat = 48
+	/// text has outgrown a whole step, not on every word. Half the original
+	/// 48pt: the dwell-and-decay hysteresis in `DictationHUDFrame` is what
+	/// keeps the frame calm now, and a coarser grid only paid for that twice —
+	/// each grid line left up to a step of visible slack around the text
+	/// (10.png in the WHI-58 QA follow-up: 39pt of it), where this grid caps
+	/// the remainder at 23pt before the decay even runs.
+	static let step: CGFloat = 24
 
 	/// The estimate snapped up onto the growth grid.
 	static func quantized(_ estimated: CGFloat) -> CGFloat {

--- a/Client/DictationHUDWidth.swift
+++ b/Client/DictationHUDWidth.swift
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// The one rule for how wide the live-words HUD may be at any moment.
+/// Extracted from `LiveTranscriptionWindow` so the calm-motion contract from
+/// the WHI-58 QA session — while a dictation runs the frame may grow, in
+/// coarse steps, and never shrinks or hides — is an ordinary unit-tested
+/// function instead of something only visible in a screen recording. See
+/// DictationHUDWidthTests.
+enum DictationHUDWidth {
+	/// Where every session starts. Matches the window's historical floor.
+	static let compact: CGFloat = 120
+
+	/// Growth quantum. Word-by-word width estimates wobble by a few points on
+	/// every update; snapping to this grid means the frame only moves once the
+	/// text has outgrown a whole step, not on every word.
+	static let step: CGFloat = 48
+
+	/// The width the window should adopt right now.
+	///
+	/// - `current`: the window's width, nil while it is off screen. A hidden
+	///   window has no width to preserve, which is what resets the growth
+	///   between dictations.
+	/// - `estimated`: the content's estimated natural width.
+	/// - `maximum`: the screen-derived ceiling. Once growth reaches it the
+	///   frame stops changing entirely and the content handles its own
+	///   overflow.
+	/// - `isDictating`: while true the result never drops below `current` —
+	///   the never-shrink half of the contract.
+	static func width(
+		current: CGFloat?, estimated: CGFloat, maximum: CGFloat, isDictating: Bool
+	) -> CGFloat {
+		let ceiling = max(compact, maximum)
+		let steps = max(0, ((estimated - compact) / step).rounded(.up))
+		let quantized = min(compact + steps * step, ceiling)
+		guard isDictating, let current else { return quantized }
+		return min(max(quantized, current), ceiling)
+	}
+
+	/// Width estimate for the trailing run of words the HUD shows. One flat
+	/// per-character price, deliberately: the old estimate priced the last
+	/// word above the rest (it renders emphasized), so every word changed its
+	/// cost the moment the next word arrived and the width wobbled on each
+	/// update. A flat price slightly above the body-font average covers the
+	/// one emphasized word too, and the step grid above absorbs the remaining
+	/// error.
+	static func estimatedWidth(words: [String], hasEllipsis: Bool) -> CGFloat {
+		let characters = words.reduce(0) { $0 + $1.count }
+		let spacing = CGFloat(max(0, words.count - 1)) * 4
+		let ellipsis: CGFloat = hasEllipsis ? 20 : 0
+		return CGFloat(characters) * 9 + spacing + ellipsis + 32
+	}
+}

--- a/Client/LLMModeSettingsView.swift
+++ b/Client/LLMModeSettingsView.swift
@@ -3,30 +3,29 @@
 
 import SwiftUI
 
-/// Settings tab to pick where recipe LLM steps run (Local / BYOK) and configure
-/// each mode. See WHI-39.
-struct LLMModeSettingsView: View {
+/// The "LLM Servers" group inside the Servers tab: pick where recipe LLM steps
+/// run (Local / BYOK) and configure each mode. Formerly its own "AI Mode" tab;
+/// the host view owns the scroll and the group heading, so this is only the
+/// picker and the per-mode config. See WHI-39.
+struct LLMServersGroupView: View {
 	@AppStorage("whisperaLLMMode") private var modeRaw = LLMMode.local.rawValue
 
 	private var mode: LLMMode { LLMMode(rawValue: modeRaw) ?? .local }
 
 	var body: some View {
-		ScrollView {
-			VStack(spacing: 24) {
-				Picker("Run recipe steps using", selection: $modeRaw) {
-					ForEach(LLMMode.allCases, id: \.rawValue) { mode in
-						Text(mode.displayName).tag(mode.rawValue)
-					}
-				}
-				.pickerStyle(.segmented)
-				.frame(maxWidth: .infinity, alignment: .leading)
-
-				switch mode {
-				case .local: LocalModeConfig()
-				case .byok: ByokModeConfig()
+		VStack(alignment: .leading, spacing: 16) {
+			Picker("Run recipe steps using", selection: $modeRaw) {
+				ForEach(LLMMode.allCases, id: \.rawValue) { mode in
+					Text(mode.displayName).tag(mode.rawValue)
 				}
 			}
-			.padding(20)
+			.pickerStyle(.segmented)
+			.frame(maxWidth: .infinity, alignment: .leading)
+
+			switch mode {
+			case .local: LocalModeConfig()
+			case .byok: ByokModeConfig()
+			}
 		}
 		// A raw value the picker no longer offers would leave it with nothing
 		// selected, so rewrite it to the fallback the router already uses.

--- a/Client/LiveTranscriptionState.swift
+++ b/Client/LiveTranscriptionState.swift
@@ -81,6 +81,10 @@ final class LiveTranscriptionState {
 		lastDisplayedPendingText = ""
 		confirmedText = ""
 		failure = nil
+		// A session that begins waiting is a fresh stream: a confirmation count
+		// left over from the previous session would silently swallow the first
+		// segments of this one.
+		lastConfirmedSegmentCount = 0
 		shouldShowLiveTranscriptionWindow = true
 		isWaitingForModel = true
 		waitingForModelStatusText = "Waiting for model..."

--- a/Client/LiveTranscriptionState.swift
+++ b/Client/LiveTranscriptionState.swift
@@ -137,12 +137,30 @@ final class LiveTranscriptionState {
 	/// For an engine that already distinguishes what it has committed from what
 	/// is still in flight, so there is nothing to buffer — but the same flicker
 	/// filter still decides when the display is allowed to move.
+	///
+	/// The HUD renders `stableDisplayText` alone, so the committed words have to
+	/// be part of it. Displaying only the draft meant every utterance boundary
+	/// wiped the whole sentence and restarted from the next utterance's first
+	/// word — the disappear-and-reappear the WHI-58 QA session reported. With the
+	/// full transcript composed here, the display only ever grows during a
+	/// dictation: committed words never leave it, and only the draft tail is
+	/// still allowed to be rewritten in flight.
 	func ingest(committed: String, draft: String) {
 		if committed != confirmedText {
 			confirmedText = committed
 		}
-		setPending(draft)
+		pendingText = draft
+		let combined = Self.joined(committed: committed, draft: draft)
+		if shouldUpdatePendingText(newText: combined) {
+			stableDisplayText = combined
+			lastDisplayedPendingText = combined
+		}
 		shouldShowLiveTranscriptionWindow = !stableDisplayText.isEmpty || !confirmedText.isEmpty
+	}
+
+	/// One transcript out of the two halves a committed/draft engine reports.
+	static func joined(committed: String, draft: String) -> String {
+		[committed, draft].filter { !$0.isEmpty }.joined(separator: " ")
 	}
 
 	/// Sets the in-flight text, moving the display only when the words changed

--- a/Client/LiveTranscriptionState.swift
+++ b/Client/LiveTranscriptionState.swift
@@ -30,6 +30,14 @@ final class LiveTranscriptionState {
 	var isTranscribing: Bool = false
 	var isWaitingForModel: Bool = false
 	var waitingForModelStatusText: String = ""
+	/// The stopped dictation's finalize pass (the two-pass "Polishing…" wait) is
+	/// still running. Deliberately a separate channel from `isWaitingForModel`:
+	/// that one belongs to the words window for mid-session statuses (waiting for
+	/// model, reconnecting), while this one belongs to the listening pill alone —
+	/// routing the polish through the waiting channel made both surfaces collapse
+	/// into identical "Polishing…" chips at once.
+	var isFinalizing: Bool = false
+	var finalizingStatusText: String = ""
 	var shouldShowDebugWindow: Bool = false
 	/// The last failure that needs the user to do something. Presented as an
 	/// `.alert()`, never inline: the HUD is one line and the recovery step does not
@@ -53,11 +61,23 @@ final class LiveTranscriptionState {
 	/// output as more audio arrives, so confirming it early duplicates words.
 	static let requiredSegmentsForConfirmation = 2
 
+	/// A dictation session is running: the engine is transcribing, or holding
+	/// the session open behind a status line (waiting for model, reconnecting).
+	/// The words window keys its visibility off this. The post-stop finalize
+	/// pass is deliberately not part of it — the dictation is over and its words
+	/// are final, so the words window must not linger (or come back) to show the
+	/// polish; the listening pill is the surface that announces it.
+	var isSessionActive: Bool {
+		isTranscribing || isWaitingForModel
+	}
+
 	// MARK: - Session boundaries
 
 	func reset() {
 		isWaitingForModel = false
 		waitingForModelStatusText = ""
+		isFinalizing = false
+		finalizingStatusText = ""
 		pendingText = ""
 		stableDisplayText = ""
 		lastDisplayedPendingText = ""
@@ -85,9 +105,29 @@ final class LiveTranscriptionState {
 		// left over from the previous session would silently swallow the first
 		// segments of this one.
 		lastConfirmedSegmentCount = 0
+		// A new dictation supersedes any pass still pending from the previous
+		// one; its status must not survive into this session's pill.
+		isFinalizing = false
+		finalizingStatusText = ""
 		shouldShowLiveTranscriptionWindow = true
 		isWaitingForModel = true
 		waitingForModelStatusText = "Waiting for model..."
+	}
+
+	/// Marks the post-stop finalize pass as running. It touches neither
+	/// `isWaitingForModel` nor `shouldShowLiveTranscriptionWindow` on purpose:
+	/// the words window has already dismissed at stop, exactly as it does with
+	/// the finalizer off, and only the pill renders this channel.
+	func beginFinalizing(statusText: String) {
+		isFinalizing = true
+		finalizingStatusText = statusText
+	}
+
+	/// The pass ended — pasted or fell back to the draft — so the pill resumes
+	/// its normal end-of-dictation dismissal.
+	func endFinalizing() {
+		isFinalizing = false
+		finalizingStatusText = ""
 	}
 
 	/// Promotes whatever is still pending at the end of a session.

--- a/Client/LiveTranscriptionState.swift
+++ b/Client/LiveTranscriptionState.swift
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// Everything the live-transcription HUD reads, owned in one place so every
+/// engine feeds the same surface. Extracted from `WhisperKitTranscriber`
+/// unchanged: the two-segment confirmation buffer and the flicker filter below
+/// are the ones that were already tuned there, and a remote engine reuses them
+/// rather than growing a second display path. See WHI-58.
+///
+/// `WhisperKitTranscriber` forwards its own live properties here, so callers
+/// and tests that still speak to the transcriber see exactly what they saw
+/// before.
+@MainActor
+@Observable
+final class LiveTranscriptionState {
+	static let shared = LiveTranscriptionState()
+
+	/// Text the engine will not revise again. Whoever is typing it into the
+	/// focused app watches this.
+	var confirmedText: String = "" {
+		didSet {
+			onConfirmedTextChange?(confirmedText)
+		}
+	}
+	/// UI-facing stable property: only moves when the words meaningfully change.
+	var stableDisplayText: String = ""
+	var shouldShowLiveTranscriptionWindow: Bool = false
+	var isTranscribing: Bool = false
+	var isWaitingForModel: Bool = false
+	var waitingForModelStatusText: String = ""
+	var currentText: String = ""
+	var shouldShowDebugWindow: Bool = false
+
+	@ObservationIgnored
+	var onConfirmedTextChange: ((String) -> Void)?
+
+	/// Internal working property: the words still in flight.
+	var pendingText: String = ""
+	private var lastDisplayedPendingText: String = ""
+	private var lastConfirmedSegmentCount: Int = 0
+
+	var latestWord: String {
+		let words = stableDisplayText.split(separator: " ")
+		return words.last?.description ?? ""
+	}
+
+	/// How many trailing segments stay pending. Whisper revises the tail of its
+	/// output as more audio arrives, so confirming it early duplicates words.
+	static let requiredSegmentsForConfirmation = 2
+
+	// MARK: - Session boundaries
+
+	func reset() {
+		isWaitingForModel = false
+		waitingForModelStatusText = ""
+		pendingText = ""
+		stableDisplayText = ""
+		lastDisplayedPendingText = ""
+		shouldShowLiveTranscriptionWindow = false
+		isTranscribing = false
+		confirmedText = ""
+		shouldShowDebugWindow = false
+		lastConfirmedSegmentCount = 0
+	}
+
+	/// Forgets how much of the segment history has been confirmed, so a fresh
+	/// stream starts counting from its first segment again.
+	func resetSegmentConfirmation() {
+		lastConfirmedSegmentCount = 0
+	}
+
+	func beginWaiting() {
+		pendingText = ""
+		stableDisplayText = ""
+		lastDisplayedPendingText = ""
+		confirmedText = ""
+		shouldShowLiveTranscriptionWindow = true
+		isWaitingForModel = true
+		waitingForModelStatusText = "Waiting for model..."
+	}
+
+	/// Promotes whatever is still pending at the end of a session.
+	func confirmPending() {
+		guard !pendingText.isEmpty else { return }
+
+		// Sync all display properties before confirming to prevent double transcription
+		stableDisplayText = pendingText
+		lastDisplayedPendingText = pendingText
+
+		// The engine hands back its complete transcription history in pendingText,
+		// so we replace confirmedText entirely rather than appending
+		confirmedText = pendingText
+		pendingText = ""
+	}
+
+	// MARK: - Ingest
+
+	/// For an engine that re-transcribes its whole buffer each pass and hands
+	/// back the full segment history, WhisperKit-style. Everything but the last
+	/// two segments is confirmed, exactly once each.
+	func ingest(segmentTexts: [String]) {
+		guard !segmentTexts.isEmpty else { return }
+
+		let required = Self.requiredSegmentsForConfirmation
+
+		if segmentTexts.count > required {
+			let numberOfSegmentsToConfirm = segmentTexts.count - required
+
+			// Only confirm new segments that haven't been confirmed before
+			if numberOfSegmentsToConfirm > lastConfirmedSegmentCount {
+				let startIndex = lastConfirmedSegmentCount
+				let endIndex = numberOfSegmentsToConfirm
+				let newConfirmedText = segmentTexts[startIndex..<endIndex].joined(separator: " ")
+
+				if !newConfirmedText.isEmpty {
+					confirmedText =
+						confirmedText.isEmpty ? newConfirmedText : confirmedText + " " + newConfirmedText
+					lastConfirmedSegmentCount = numberOfSegmentsToConfirm
+				}
+			}
+
+			setPending(segmentTexts.suffix(required).joined(separator: " "))
+		} else {
+			setPending(segmentTexts.joined(separator: " "))
+		}
+
+		shouldShowLiveTranscriptionWindow = !stableDisplayText.isEmpty || !confirmedText.isEmpty
+	}
+
+	/// For an engine that already distinguishes what it has committed from what
+	/// is still in flight, so there is nothing to buffer — but the same flicker
+	/// filter still decides when the display is allowed to move.
+	func ingest(committed: String, draft: String) {
+		if committed != confirmedText {
+			confirmedText = committed
+		}
+		setPending(draft)
+		shouldShowLiveTranscriptionWindow = !stableDisplayText.isEmpty || !confirmedText.isEmpty
+	}
+
+	/// Sets the in-flight text, moving the display only when the words changed
+	/// enough to be worth a redraw.
+	func setPending(_ newPendingText: String) {
+		pendingText = newPendingText
+
+		if shouldUpdatePendingText(newText: newPendingText) {
+			stableDisplayText = newPendingText
+			lastDisplayedPendingText = newPendingText
+		}
+	}
+
+	/// Suppresses redraws for a tail the engine is only nudging. Whisper rewrites
+	/// its last words constantly, and repainting each rewrite makes the HUD
+	/// flicker.
+	func shouldUpdatePendingText(newText: String) -> Bool {
+		// If the text is empty or previous text was non-empty, always update (to handle clearing)
+		if newText.isEmpty || lastDisplayedPendingText.isEmpty {
+			return true
+		}
+
+		let newWords = newText.split(separator: " ").map(String.init)
+		let oldWords = lastDisplayedPendingText.split(separator: " ").map(String.init)
+
+		let wordCountDiff = abs(newWords.count - oldWords.count)
+		if wordCountDiff > 1 { return true }
+
+		let wordsToCompare = min(3, min(newWords.count, oldWords.count))
+		if wordsToCompare > 0 {
+			let newLastWords = Array(newWords.suffix(wordsToCompare))
+			let oldLastWords = Array(oldWords.suffix(wordsToCompare))
+
+			if newLastWords != oldLastWords {
+				return true
+			}
+		}
+
+		return false
+	}
+}

--- a/Client/LiveTranscriptionState.swift
+++ b/Client/LiveTranscriptionState.swift
@@ -32,6 +32,10 @@ final class LiveTranscriptionState {
 	var waitingForModelStatusText: String = ""
 	var currentText: String = ""
 	var shouldShowDebugWindow: Bool = false
+	/// The last failure that needs the user to do something. Presented as an
+	/// `.alert()`, never inline: the HUD is one line and the recovery step does not
+	/// fit on it. Cleared when the alert is dismissed and when a new session starts.
+	var failure: TranscriptionFailure?
 
 	@ObservationIgnored
 	var onConfirmedTextChange: ((String) -> Void)?
@@ -63,6 +67,7 @@ final class LiveTranscriptionState {
 		confirmedText = ""
 		shouldShowDebugWindow = false
 		lastConfirmedSegmentCount = 0
+		failure = nil
 	}
 
 	/// Forgets how much of the segment history has been confirmed, so a fresh
@@ -76,6 +81,7 @@ final class LiveTranscriptionState {
 		stableDisplayText = ""
 		lastDisplayedPendingText = ""
 		confirmedText = ""
+		failure = nil
 		shouldShowLiveTranscriptionWindow = true
 		isWaitingForModel = true
 		waitingForModelStatusText = "Waiting for model..."

--- a/Client/LiveTranscriptionState.swift
+++ b/Client/LiveTranscriptionState.swift
@@ -202,3 +202,33 @@ final class LiveTranscriptionState {
 		return false
 	}
 }
+
+/// The draft of the utterance currently in flight, built out of an engine's
+/// partial-transcript events. This accumulator exists because those partials
+/// are deltas: the OpenAI-Realtime contract
+/// (`conversation.item.input_audio_transcription.delta`) sends only the new
+/// fragment since the previous event, so handing one fragment straight to the
+/// display replaced the pill's tail with the latest few words instead of
+/// growing it — the nemo-stream WHI-58 QA bug. Fragments concatenate with no
+/// separator injected: the engine carries its own spacing, and a mid-word
+/// split like "work" + "ing" must stay one word.
+struct UtteranceDraftAccumulator {
+	private var fragments = ""
+
+	/// The utterance so far, trimmed only at the edges. A fragment often opens
+	/// with the space that separates it from the previous one, and a leading
+	/// space here would double up against the separator
+	/// `LiveTranscriptionState.joined` inserts between the committed text and
+	/// this draft. Interior spacing is the engine's own and stays untouched.
+	var draft: String {
+		fragments.trimmingCharacters(in: .whitespaces)
+	}
+
+	mutating func append(_ delta: String) {
+		fragments += delta
+	}
+
+	mutating func clear() {
+		fragments = ""
+	}
+}

--- a/Client/LiveTranscriptionState.swift
+++ b/Client/LiveTranscriptionState.swift
@@ -30,7 +30,6 @@ final class LiveTranscriptionState {
 	var isTranscribing: Bool = false
 	var isWaitingForModel: Bool = false
 	var waitingForModelStatusText: String = ""
-	var currentText: String = ""
 	var shouldShowDebugWindow: Bool = false
 	/// The last failure that needs the user to do something. Presented as an
 	/// `.alert()`, never inline: the HUD is one line and the recovery step does not

--- a/Client/LocalLLMExecutor.swift
+++ b/Client/LocalLLMExecutor.swift
@@ -28,6 +28,7 @@ extension WhisperaSettings {
 
 enum LocalLLMError: LocalizedError {
 	case unavailable
+	case unreachable(url: String, reason: String, retried: Bool)
 	case noModel
 	case http(status: Int, body: String)
 	case empty
@@ -35,13 +36,52 @@ enum LocalLLMError: LocalizedError {
 	var errorDescription: String? {
 		switch self {
 		case .unavailable:
-			return "Local mode unavailable — start a local model server or switch to BYOK."
+			return "No model server URL configured — set one in Settings or switch to BYOK."
+		case .unreachable(let url, let reason, let retried):
+			return "Couldn't reach the model server at \(url) — \(reason)."
+				+ (retried ? " Retried once." : "")
 		case .noModel:
-			return "No local model set. Choose a model in Settings or set one on the recipe."
+			return "No model set. Choose a model in Settings or set one on the recipe."
 		case .http(let status, let body):
-			return "Local model error (HTTP \(status))\(body.isEmpty ? "" : ": \(body)")"
+			return "Model server error (HTTP \(status))\(body.isEmpty ? "" : ": \(body)")"
 		case .empty:
-			return "Local model returned an empty response."
+			return "The model returned an empty response."
+		}
+	}
+}
+
+/// Classifies transport failures on the recipe LLM hop: which ones earn the
+/// single retry, and the short phrase the HUD shows for them. Pure — no
+/// network, no state — so the decision is unit-testable on its own.
+enum LLMTransportRetryPolicy {
+	/// Transient conditions where the server may simply be waking up or the
+	/// route flickered — the exact failure the user hit against a proxy on
+	/// another machine. HTTP status codes never come through here (they are
+	/// real answers from a reachable server), and cancellation, TLS refusals,
+	/// bad URLs and the like are not transient, so none of them retry.
+	static let retryableCodes: Set<URLError.Code> = [
+		.timedOut,
+		.cannotConnectToHost,
+		.cannotFindHost,
+		.dnsLookupFailed,
+		.networkConnectionLost,
+		.notConnectedToInternet,
+	]
+
+	static func shouldRetry(_ code: URLError.Code) -> Bool {
+		retryableCodes.contains(code)
+	}
+
+	/// HUD-sized phrasing for the common transport failures; anything else
+	/// falls back to the system's own description.
+	static func shortReason(for error: URLError) -> String {
+		switch error.code {
+		case .timedOut: return "the request timed out"
+		case .cannotConnectToHost: return "the connection was refused"
+		case .cannotFindHost, .dnsLookupFailed: return "the host was not found"
+		case .networkConnectionLost: return "the connection was lost"
+		case .notConnectedToInternet: return "the network is offline"
+		default: return error.localizedDescription
 		}
 	}
 }
@@ -55,10 +95,23 @@ enum LocalLLMError: LocalizedError {
 /// now (no model footprint on this machine). Any OpenAI-compatible local
 /// runtime (ollama / llama-server / vLLM / LM Studio) works today. WHI-38.
 struct LocalLLMExecutor {
+	/// A recipe runs while the user watches the HUD. URLSession's default 60s
+	/// would leave them staring at a spinner for a minute before the fallback
+	/// paste; 20s is long enough for a server to return a full (non-streamed)
+	/// completion for recipe-sized prompts, and short enough that a dead hop
+	/// fails while the user is still looking. Worst case with the one retry:
+	/// ~41s, still under a single default timeout.
+	static let requestTimeout: TimeInterval = 20
+
+	/// Backoff before the single retry — enough for a sleeping proxy or a
+	/// dropped route to come back, short enough to not add a visible stall.
+	static let defaultRetryDelayNanoseconds: UInt64 = 1_000_000_000
+
 	private let session: URLSession
 	private let serverURLProvider: @Sendable () -> URL?
 	private let defaultModelProvider: @Sendable () -> String
 	private let apiKeyProvider: @Sendable () -> String?
+	private let retryDelayNanoseconds: UInt64
 
 	init(
 		session: URLSession = .shared,
@@ -68,12 +121,14 @@ struct LocalLLMExecutor {
 		// empty/absent means no Authorization header, exactly as before.
 		apiKeyProvider: @escaping @Sendable () -> String? = {
 			(try? ByokKeyStore.shared.loadLocalServerKey()) ?? nil
-		}
+		},
+		retryDelayNanoseconds: UInt64 = LocalLLMExecutor.defaultRetryDelayNanoseconds
 	) {
 		self.session = session
 		self.serverURLProvider = serverURLProvider
 		self.defaultModelProvider = defaultModelProvider
 		self.apiKeyProvider = apiKeyProvider
+		self.retryDelayNanoseconds = retryDelayNanoseconds
 	}
 
 	/// Runs each step in order, feeding each step's output into the next.
@@ -105,19 +160,14 @@ struct LocalLLMExecutor {
 
 		var request = URLRequest(url: base.appendingPathComponent("chat/completions"))
 		request.httpMethod = "POST"
+		request.timeoutInterval = Self.requestTimeout
 		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 		if let key = apiKeyProvider(), !key.isEmpty {
 			request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 		}
 		request.httpBody = try JSONSerialization.data(withJSONObject: payload)
 
-		let data: Data
-		let response: URLResponse
-		do {
-			(data, response) = try await session.data(for: request)
-		} catch {
-			throw LocalLLMError.unavailable
-		}
+		let (data, response) = try await send(request, server: base.absoluteString)
 
 		guard let http = response as? HTTPURLResponse else { throw LocalLLMError.empty }
 		guard (200..<300).contains(http.statusCode) else {
@@ -126,6 +176,41 @@ struct LocalLLMExecutor {
 
 		guard let content = Self.parseContent(data), !content.isEmpty else { throw LocalLLMError.empty }
 		return content
+	}
+
+	/// Sends the request with one bounded retry on transient transport failures
+	/// (see `LLMTransportRetryPolicy`). HTTP error statuses never reach this
+	/// path — the server answered, so the caller reports them as-is. The
+	/// wording deliberately says "model server", not "local": the configured
+	/// endpoint may be a proxy on another machine.
+	private func send(_ request: URLRequest, server: String) async throws -> (Data, URLResponse) {
+		do {
+			return try await session.data(for: request)
+		} catch {
+			let urlError = error as? URLError
+			if urlError?.code == .cancelled { throw CancellationError() }
+			guard let urlError, LLMTransportRetryPolicy.shouldRetry(urlError.code) else {
+				let reason = urlError.map { LLMTransportRetryPolicy.shortReason(for: $0) }
+					?? error.localizedDescription
+				AppLogger.shared.network.error(
+					"Model server request to \(server) failed, not retryable: \(reason)")
+				throw LocalLLMError.unreachable(url: server, reason: reason, retried: false)
+			}
+			AppLogger.shared.network.info(
+				"Model server request to \(server) failed (\(LLMTransportRetryPolicy.shortReason(for: urlError))); retrying once")
+			try? await Task.sleep(nanoseconds: retryDelayNanoseconds)
+			try Task.checkCancellation()
+			do {
+				return try await session.data(for: request)
+			} catch {
+				if (error as? URLError)?.code == .cancelled { throw CancellationError() }
+				let reason = (error as? URLError).map { LLMTransportRetryPolicy.shortReason(for: $0) }
+					?? error.localizedDescription
+				AppLogger.shared.network.error(
+					"Model server request to \(server) failed again after retry: \(reason)")
+				throw LocalLLMError.unreachable(url: server, reason: reason, retried: true)
+			}
+		}
 	}
 
 	private func nonEmpty(_ s: String) -> String? { s.isEmpty ? nil : s }

--- a/Client/RemoteBatchTranscriber.swift
+++ b/Client/RemoteBatchTranscriber.swift
@@ -96,7 +96,9 @@ final class RemoteBatchTranscriber: SpeechTranscribing {
 
 	/// Wraps mono float samples in a 16-bit PCM WAV container. The upload
 	/// endpoints want a file, and the capture path hands us a raw buffer.
-	static func wav(from samples: [Float], sampleRate: Int = 16000) -> Data {
+	/// Nonisolated because the two-pass finalizer wraps up to ten minutes of
+	/// audio off the main actor, where a per-sample loop has no business.
+	nonisolated static func wav(from samples: [Float], sampleRate: Int = 16000) -> Data {
 		let bitsPerSample = 16
 		let channels = 1
 		let byteRate = sampleRate * channels * bitsPerSample / 8

--- a/Client/RemoteBatchTranscriber.swift
+++ b/Client/RemoteBatchTranscriber.swift
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// The upload-a-whole-recording conformer, over the user's own OpenAI key.
+///
+/// It exists so the BYOK engine is reached through the same interface as
+/// WhisperKit rather than through a `switch` in the caller. The HTTP work stays
+/// in `RemoteTranscriber`, which is unchanged and still has its own tests; this
+/// type only adapts it to `SpeechTranscribing`. See WHI-42, WHI-58.
+@MainActor
+final class RemoteBatchTranscriber: SpeechTranscribing {
+	static let byok = RemoteBatchTranscriber()
+
+	nonisolated var engine: TranscriptionEngine { .whisperViaBYOK }
+
+	/// No streaming: the endpoint takes one finished recording. No managed
+	/// models either — the model lives on the provider's side.
+	nonisolated var capabilities: TranscriptionCapabilities {
+		[.fileTranscription, .bufferTranscription]
+	}
+
+	var onLiveAudioSamples: (@MainActor ([Float]) -> Void)?
+
+	private let remote: RemoteTranscriber
+	private let keyStore: ByokKeyStore
+
+	init(remote: RemoteTranscriber = RemoteTranscriber(), keyStore: ByokKeyStore = .shared) {
+		self.remote = remote
+		self.keyStore = keyStore
+	}
+
+	var state: TranscriptionEngineState {
+		let key = try? keyStore.load(provider: .openai)
+		guard let key, !key.isEmpty else {
+			return .unavailable(RemoteTranscriberError.missingOpenAIKey.errorDescription ?? "")
+		}
+		return .ready
+	}
+
+	func prepare() async throws {
+		guard let key = try keyStore.load(provider: .openai), !key.isEmpty else {
+			throw RemoteTranscriberError.missingOpenAIKey
+		}
+	}
+
+	var activeModel: String? { WhisperaSettings.byokTranscriptionModel }
+
+	func models() async throws -> [TranscriptionModelInfo] {
+		[TranscriptionModelInfo(id: WhisperaSettings.byokTranscriptionModel)]
+	}
+
+	func transcribe(fileAt url: URL, options: TranscriptionOptions) async throws -> String {
+		try requireTranscribeOnly(options)
+		let audio = try Data(contentsOf: url)
+		return try await remote.transcribeViaBYOK(
+			audio: audio,
+			filename: url.lastPathComponent,
+			mimetype: Self.mimetype(for: url),
+			language: options.language,
+			model: WhisperaSettings.byokTranscriptionModel)
+	}
+
+	func transcribe(samples: [Float], options: TranscriptionOptions) async throws -> String {
+		try requireTranscribeOnly(options)
+		guard !samples.isEmpty else { return "No audio data provided" }
+		return try await remote.transcribeViaBYOK(
+			audio: Self.wav(from: samples),
+			filename: "dictation.wav",
+			mimetype: "audio/wav",
+			language: options.language,
+			model: WhisperaSettings.byokTranscriptionModel)
+	}
+
+	/// OpenAI splits transcription and translation across two endpoints, so a
+	/// translate request cannot be honoured here. It fails loudly rather than
+	/// returning untranslated text that looks like a success.
+	private func requireTranscribeOnly(_ options: TranscriptionOptions) throws {
+		guard options.mode == .transcribe else {
+			throw TranscriptionEngineError.unsupported(
+				engine: engine.displayName, capability: "translate")
+		}
+	}
+
+	private static func mimetype(for url: URL) -> String {
+		switch url.pathExtension.lowercased() {
+		case "mp3": return "audio/mpeg"
+		case "m4a", "mp4": return "audio/mp4"
+		case "flac": return "audio/flac"
+		case "ogg": return "audio/ogg"
+		case "webm": return "audio/webm"
+		default: return "audio/wav"
+		}
+	}
+
+	/// Wraps mono float samples in a 16-bit PCM WAV container. The upload
+	/// endpoints want a file, and the capture path hands us a raw buffer.
+	static func wav(from samples: [Float], sampleRate: Int = 16000) -> Data {
+		let bitsPerSample = 16
+		let channels = 1
+		let byteRate = sampleRate * channels * bitsPerSample / 8
+		let blockAlign = channels * bitsPerSample / 8
+		let dataBytes = samples.count * bitsPerSample / 8
+
+		var data = Data(capacity: 44 + dataBytes)
+		func appendASCII(_ text: String) { data.append(contentsOf: Array(text.utf8)) }
+		func appendUInt32(_ value: Int) { withUnsafeBytes(of: UInt32(value).littleEndian) { data.append(contentsOf: $0) } }
+		func appendUInt16(_ value: Int) { withUnsafeBytes(of: UInt16(value).littleEndian) { data.append(contentsOf: $0) } }
+
+		appendASCII("RIFF")
+		appendUInt32(36 + dataBytes)
+		appendASCII("WAVE")
+		appendASCII("fmt ")
+		appendUInt32(16)
+		appendUInt16(1)  // PCM
+		appendUInt16(channels)
+		appendUInt32(sampleRate)
+		appendUInt32(byteRate)
+		appendUInt16(blockAlign)
+		appendUInt16(bitsPerSample)
+		appendASCII("data")
+		appendUInt32(dataBytes)
+
+		for sample in samples {
+			let clamped = max(-1.0, min(1.0, sample))
+			let scaled = Int16(clamped * Float(Int16.max))
+			withUnsafeBytes(of: scaled.littleEndian) { data.append(contentsOf: $0) }
+		}
+
+		return data
+	}
+}
+
+extension WhisperaSettings {
+	private static let byokTranscriptionModelKey = "whisperaByokTranscriptionModel"
+
+	static let defaultByokTranscriptionModel = "whisper-1"
+
+	/// Model name the BYOK transcription endpoint expects. Separate from
+	/// `byokModel`, which names the chat model recipes run on.
+	static var byokTranscriptionModel: String {
+		get {
+			let stored = UserDefaults.standard.string(forKey: byokTranscriptionModelKey) ?? ""
+			return stored.isEmpty ? defaultByokTranscriptionModel : stored
+		}
+		set { UserDefaults.standard.set(newValue, forKey: byokTranscriptionModelKey) }
+	}
+}

--- a/Client/RemoteTranscriber.swift
+++ b/Client/RemoteTranscriber.swift
@@ -3,33 +3,6 @@
 
 import Foundation
 
-/// Where speech-to-text runs. WhisperKit stays the default (on-device, no
-/// network). See WHI-42.
-enum TranscriptionEngine: String, CaseIterable, Sendable {
-	case whisperKit
-	case whisperViaBYOK
-
-	var displayName: String {
-		switch self {
-		case .whisperKit: return "WhisperKit (on-device)"
-		case .whisperViaBYOK: return "OpenAI Whisper via your key"
-		}
-	}
-}
-
-extension WhisperaSettings {
-	private static let engineKey = "whisperaTranscriptionEngine"
-
-	/// Hard-pinned while the engine picker is parked and the app ships
-	/// WhisperKit-only: any persisted value — including a still-valid
-	/// "whisperViaBYOK" — degrades on-device. Restore the stored lookup below
-	/// alongside the picker.
-	static var transcriptionEngine: TranscriptionEngine {
-		get { .whisperKit }
-		set { UserDefaults.standard.set(newValue.rawValue, forKey: engineKey) }
-	}
-}
-
 enum RemoteTranscriberError: LocalizedError {
 	case notSignedIn
 	case missingOpenAIKey

--- a/Client/ServersSettingsView.swift
+++ b/Client/ServersSettingsView.swift
@@ -357,7 +357,7 @@ struct ServersSettingsView: View {
 				}
 				// Same credential shape the dictation socket uses; an empty token is
 				// fine against a self-hosted backend that requires none.
-				let credentials = DictationCredentialProvider.refreshingBearer {
+				let credentials = RefreshingCredential.refreshingBearer {
 					(try? AuthTokenStore.shared.load()).flatMap { $0.isEmpty ? nil : $0 } ?? ""
 				}
 				discoveredServers = try await ServerDiscoveryProbe.fetch(

--- a/Client/ServersSettingsView.swift
+++ b/Client/ServersSettingsView.swift
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import SwiftUI
+import WhisperaDictation
+
+extension StreamingGranularity {
+	/// Plain words for the server list — a user choosing a server should not
+	/// need to know what a delta is, only how soon words show up.
+	var plainWords: String {
+		switch self {
+		case .nativeDelta: return "word-by-word"
+		case .synthesizedDelta: return "near-live"
+		case .utterance: return "at the end"
+		}
+	}
+}
+
+/// The Servers tab: every remote endpoint Whispera talks to, in one place —
+/// speech servers (the transcription engine and whatever URL/model it needs)
+/// and LLM servers (where recipe steps run). Grew out of the engine picker
+/// that used to hide inside General → Transcription and the separate "AI Mode"
+/// tab; the user-visible model is now "these are my servers".
+struct ServersSettingsView: View {
+	@AppStorage(WhisperaSettings.transcriptionEngineKey) private var transcriptionEngineRaw =
+		TranscriptionEngine.auto.rawValue
+	@AppStorage(WhisperaSettings.transcriptionBackendURLKey) private var backendURL = ""
+	@AppStorage(WhisperaSettings.transcriptionDirectURLKey) private var directURL = ""
+	@AppStorage(WhisperaSettings.transcriptionServerIdKey) private var pinnedServerId = ""
+	@AppStorage(WhisperaSettings.transcriptionDirectModelKey) private var directModel = ""
+	@AppStorage("enableStreaming") private var enableStreaming = Constants.enableStreamingDefault
+
+	/// Falls back to `auto` for the same reason `WhisperaSettings` does: a stored
+	/// engine from a build that shipped one we no longer do must degrade, not trap.
+	private var selectedEngine: TranscriptionEngine {
+		TranscriptionEngine(rawValue: transcriptionEngineRaw) ?? .auto
+	}
+
+	// Discovery list for the backend engines (auto + whisperaStreaming). Empty
+	// with no error means "not fetched yet"; a failed fetch keeps the pin row
+	// visible so a stale pin stays clearable even when the backend is down.
+	@State private var discoveredServers: [DiscoveredServer] = []
+	@State private var isFetchingServers = false
+	@State private var serverFetchError: String?
+
+	// Direct-mode ("realtimeDirect") model list: fetched from the engine's own
+	// /models endpoint rather than typed by hand. Empty + no error means "not
+	// fetched yet", which is also the state a failed fetch falls back to, so the
+	// free-text field underneath stays reachable either way.
+	@State private var directModelOptions: [TranscriptionModelInfo] = []
+	@State private var isFetchingDirectModels = false
+	@State private var directModelFetchError: String?
+
+	// Automatic engine: what it currently resolves to, refreshed whenever the
+	// picker lands on it. Same shape as the model fetches above.
+	@State private var autoResolutionCaption = "Deciding…"
+	@State private var isResolvingAutoEngine = false
+
+	private var usesBackendServers: Bool {
+		selectedEngine == .auto || selectedEngine == .whisperaStreaming
+	}
+
+	var body: some View {
+		ScrollView {
+			VStack(spacing: 24) {
+				SettingsSection("Speech Servers") {
+					enginePicker
+
+					switch selectedEngine {
+					case .auto:
+						autoCaption
+						backendServerConfig
+					case .whisperaStreaming:
+						Text(
+							"Streams audio to a Whispera transcription server over a WebSocket. Leave the server blank to use the backend's own default."
+						)
+						.font(.caption)
+						.foregroundColor(.secondary)
+						backendServerConfig
+					case .realtimeDirect:
+						directEngineConfig
+					case .whisperKit:
+						Text(
+							"Runs entirely on this Mac with the model chosen under General → Whisper Model. No server and no network involved."
+						)
+						.font(.caption)
+						.foregroundColor(.secondary)
+					case .whisperViaBYOK:
+						Text(
+							"Sends each recording to OpenAI's transcription API with your own key, straight from this Mac. No Whispera server involved."
+						)
+						.font(.caption)
+						.foregroundColor(.secondary)
+					}
+
+					// `auto` is included alongside the server engines: it may resolve to
+					// one, and the wording below is already engine-agnostic — the
+					// caveat is exactly as true when `auto` lands on WhisperKit.
+					if selectedEngine.streamsFromAServer || selectedEngine == .auto {
+						InfoBox(style: .info) {
+							Text(
+								enableStreaming
+									? "Live transcription is on, so words appear while you speak. Turning it off under General → Live Transcription Mode makes Whispera record first and transcribe at the end."
+									: "Live Transcription Mode is off, so nothing appears until you stop speaking and the whole recording is transcribed. Turn it on under General to see words as you say them."
+							)
+							.font(.caption)
+							.foregroundColor(.secondary)
+						}
+					}
+				}
+
+				Divider()
+
+				SettingsSection("LLM Servers") {
+					Text(
+						"Where recipe steps run when a dictation matches a recipe or a default command post-processes it."
+					)
+					.font(.caption)
+					.foregroundColor(.secondary)
+					LLMServersGroupView()
+				}
+			}
+			.padding(20)
+		}
+	}
+
+	// MARK: - Engine picker
+
+	private var enginePicker: some View {
+		SettingRow(
+			"Engine",
+			description: "Where speech-to-text runs. On-device needs no network."
+		) {
+			Picker("Transcription engine", selection: $transcriptionEngineRaw) {
+				ForEach(TranscriptionEngine.allCases, id: \.rawValue) { engine in
+					Text(engine.displayName).tag(engine.rawValue)
+				}
+			}
+			.labelsHidden()
+			.frame(width: 240)
+			.accessibilityIdentifier("transcriptionEnginePicker")
+			// A server engine with live transcription off records first and
+			// transcribes at the end, which reads as the engine not working.
+			// Choosing one turns it on; the box below says so, and the
+			// toggle stays the user's.
+			.onChange(of: transcriptionEngineRaw) { _, raw in
+				guard TranscriptionEngine(rawValue: raw)?.streamsFromAServer == true,
+					!enableStreaming
+				else { return }
+				enableStreaming = true
+				AppLogger.shared.general.info(
+					"Live transcription turned on because a server engine was selected: \(raw)")
+			}
+		}
+	}
+
+	private var autoCaption: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			Text(
+				"Streams through a transcription server when one is configured and reachable, preferring the one with the best live-word quality. Falls back to WhisperKit on-device otherwise. Nothing else to set up."
+			)
+			.font(.caption)
+			.foregroundColor(.secondary)
+			HStack(spacing: 6) {
+				if isResolvingAutoEngine {
+					ProgressView()
+						.scaleEffect(0.5)
+				}
+				Text(autoResolutionCaption)
+					.font(.caption)
+					.foregroundColor(.secondary)
+					.accessibilityIdentifier("autoEngineResolutionCaption")
+			}
+			.animation(.easeInOut(duration: 0.2), value: isResolvingAutoEngine)
+		}
+		.task(id: transcriptionEngineRaw) {
+			guard selectedEngine == .auto else { return }
+			isResolvingAutoEngine = true
+			autoResolutionCaption = await AutoTranscriber.shared.resolutionCaption()
+			isResolvingAutoEngine = false
+		}
+	}
+
+	// MARK: - Backend engines (auto + whisperaStreaming)
+
+	private var backendServerConfig: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			HStack(spacing: 8) {
+				TextField(
+					WhisperaSettings.serverURLString + " (leave blank to reuse the account server)",
+					text: $backendURL
+				)
+				.textFieldStyle(.roundedBorder)
+				.autocorrectionDisabled()
+				.accessibilityIdentifier("transcriptionServerURLField")
+
+				Button {
+					refreshDiscoveredServers()
+				} label: {
+					Image(systemName: "arrow.clockwise")
+				}
+				.buttonStyle(.bordered)
+				.controlSize(.small)
+				.disabled(isFetchingServers)
+				.accessibilityIdentifier("transcriptionServersRefreshButton")
+				.help("Ask the backend which speech servers it offers")
+			}
+
+			serverList
+
+			if let serverFetchError {
+				HStack(spacing: 6) {
+					Image(systemName: "exclamationmark.triangle.fill")
+						.foregroundColor(.orange)
+						.font(.caption)
+					Text(serverFetchError)
+						.font(.caption)
+						.foregroundColor(.orange)
+				}
+				.transition(.opacity)
+			}
+
+			stalePinNotice
+		}
+		.animation(.easeInOut(duration: 0.2), value: serverFetchError)
+		.animation(.easeInOut(duration: 0.2), value: discoveredServers)
+		// One task keyed on engine + URL: switching to a backend engine fetches,
+		// and editing the URL re-fetches after a short pause so we do not probe
+		// on every keystroke.
+		.task(id: "\(transcriptionEngineRaw)|\(backendURL)") {
+			try? await Task.sleep(for: .milliseconds(400))
+			guard !Task.isCancelled else { return }
+			refreshDiscoveredServers()
+		}
+	}
+
+	@ViewBuilder
+	private var serverList: some View {
+		if isFetchingServers && discoveredServers.isEmpty {
+			HStack(spacing: 8) {
+				ProgressView()
+					.scaleEffect(0.6)
+				Text("Asking the backend which servers it offers…")
+					.font(.caption)
+					.foregroundColor(.secondary)
+			}
+		} else if !discoveredServers.isEmpty {
+			VStack(alignment: .leading, spacing: 4) {
+				serverChoiceRow(
+					isSelected: pinnedServerId.isEmpty,
+					title: "Automatic (best available)",
+					// Empty pin means different things per engine: `auto` ranks the
+					// list itself, `whisperaStreaming` defers to the backend's default.
+					detail: selectedEngine == .auto
+						? "Whispera picks the server with the best live-word quality"
+						: "The backend picks its own default server",
+					isOnline: nil
+				) {
+					pinnedServerId = ""
+				}
+				ForEach(discoveredServers, id: \.id) { server in
+					serverChoiceRow(
+						isSelected: pinnedServerId == server.id,
+						title: server.label,
+						detail: serverDetail(for: server),
+						isOnline: server.isOnline
+					) {
+						pinnedServerId = server.id
+					}
+				}
+			}
+		}
+	}
+
+	private func serverDetail(for server: DiscoveredServer) -> String {
+		var parts: [String] = []
+		if !server.model.isEmpty { parts.append(server.model) }
+		parts.append("words \(server.granularity.plainWords)")
+		return parts.joined(separator: " • ")
+	}
+
+	private func serverChoiceRow(
+		isSelected: Bool,
+		title: String,
+		detail: String,
+		isOnline: Bool?,
+		select: @escaping () -> Void
+	) -> some View {
+		Button(action: select) {
+			HStack(spacing: 8) {
+				Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+					.foregroundColor(isSelected ? .blue : .secondary)
+				VStack(alignment: .leading, spacing: 2) {
+					Text(title)
+						.font(.subheadline)
+						.foregroundColor(.primary)
+					Text(detail)
+						.font(.caption)
+						.foregroundColor(.secondary)
+				}
+				Spacer()
+				if let isOnline {
+					HStack(spacing: 6) {
+						Circle()
+							.fill(isOnline ? Color.green : Color.secondary)
+							.frame(width: 8, height: 8)
+						Text(isOnline ? "Online" : "Offline")
+							.font(.caption)
+							.foregroundColor(.secondary)
+					}
+				}
+			}
+			.padding(8)
+			.background(
+				isSelected ? Color.blue.opacity(0.1) : Color.clear,
+				in: RoundedRectangle(cornerRadius: 8)
+			)
+		}
+		.buttonStyle(.plain)
+		.animation(.easeInOut(duration: 0.2), value: isSelected)
+	}
+
+	/// A pin that names a server the current list does not — renamed, removed,
+	/// or the whole list unreachable — must stay visible and clearable: an
+	/// invisible leftover pin has already silently steered `auto` before.
+	@ViewBuilder
+	private var stalePinNotice: some View {
+		if !pinnedServerId.isEmpty, !isFetchingServers,
+			!discoveredServers.contains(where: { $0.id == pinnedServerId })
+		{
+			HStack(spacing: 6) {
+				Image(systemName: "pin.fill")
+					.foregroundColor(.orange)
+					.font(.caption)
+				Text("Pinned to “\(pinnedServerId)”, which is not in the list above.")
+					.font(.caption)
+					.foregroundColor(.orange)
+				Button("Clear pin") {
+					pinnedServerId = ""
+				}
+				.buttonStyle(.bordered)
+				.controlSize(.small)
+				.accessibilityIdentifier("clearServerPinButton")
+			}
+			.transition(.opacity)
+		}
+	}
+
+	private func refreshDiscoveredServers() {
+		guard usesBackendServers else { return }
+		isFetchingServers = true
+		serverFetchError = nil
+		Task { @MainActor in
+			do {
+				guard let baseURL = WhisperaSettings.transcriptionBackendURL else {
+					throw StreamingTranscriberError.invalidServerURL
+				}
+				// Same credential shape the dictation socket uses; an empty token is
+				// fine against a self-hosted backend that requires none.
+				let credentials = DictationCredentialProvider.refreshingBearer {
+					(try? AuthTokenStore.shared.load()).flatMap { $0.isEmpty ? nil : $0 } ?? ""
+				}
+				discoveredServers = try await ServerDiscoveryProbe.fetch(
+					baseURL: baseURL,
+					credentials: credentials,
+					session: .shared,
+					timeout: 5)
+				serverFetchError = nil
+			} catch {
+				AppLogger.shared.general.error(
+					"Failed to list transcription servers: \(error.localizedDescription)")
+				discoveredServers = []
+				serverFetchError = "Server unreachable — check the URL."
+			}
+			isFetchingServers = false
+		}
+	}
+
+	// MARK: - Direct engine (realtimeDirect)
+
+	private var directEngineConfig: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			Text(
+				"Streams audio straight to an OpenAI-Realtime engine, with no Whispera backend in between. The engine holds its own credentials, so use this only on a network you trust."
+			)
+			.font(.caption)
+			.foregroundColor(.secondary)
+			TextField("http://192.168.0.10:8000/v1", text: $directURL)
+				.textFieldStyle(.roundedBorder)
+				.autocorrectionDisabled()
+				.accessibilityIdentifier("directEngineURLField")
+
+			HStack(spacing: 8) {
+				if isFetchingDirectModels {
+					ProgressView()
+						.scaleEffect(0.6)
+					Text("Checking the engine for installed models…")
+						.font(.caption)
+						.foregroundColor(.secondary)
+				} else if !directModelOptions.isEmpty {
+					Picker("Model", selection: $directModel) {
+						ForEach(directModelOptions) { model in
+							Text(model.displayName).tag(model.id)
+						}
+					}
+					.labelsHidden()
+					.frame(width: 260)
+					.accessibilityIdentifier("directEngineModelPicker")
+				} else {
+					// Fallback: the fetch never ran or it failed. Typing a
+					// model by hand keeps the engine reachable even when
+					// Whispera cannot list what it has installed.
+					TextField(
+						"Model (e.g. Systran/faster-distil-whisper-large-v3)",
+						text: $directModel
+					)
+					.textFieldStyle(.roundedBorder)
+					.autocorrectionDisabled()
+					.accessibilityIdentifier("directEngineModelField")
+				}
+
+				Button {
+					refreshDirectModels()
+				} label: {
+					Image(systemName: "arrow.clockwise")
+				}
+				.buttonStyle(.bordered)
+				.controlSize(.small)
+				.disabled(isFetchingDirectModels)
+				.accessibilityIdentifier("directEngineModelsRefreshButton")
+				.help("Ask the engine what speech-to-text models it has installed")
+			}
+			.animation(.easeInOut(duration: 0.2), value: isFetchingDirectModels)
+			.animation(.easeInOut(duration: 0.2), value: directModelOptions)
+
+			if let directModelFetchError {
+				HStack(spacing: 6) {
+					Image(systemName: "exclamationmark.triangle.fill")
+						.foregroundColor(.orange)
+						.font(.caption)
+					Text(directModelFetchError)
+						.font(.caption)
+						.foregroundColor(.orange)
+				}
+				.transition(.opacity)
+			}
+
+			Text(
+				"The URL is the engine's OpenAI-compatible base, ending in /v1. Refresh to list the models it already has installed, or type one directly if it cannot be reached right now."
+			)
+			.font(.caption)
+			.foregroundColor(.secondary)
+		}
+		.animation(.easeInOut(duration: 0.2), value: directModelFetchError)
+		.task(id: transcriptionEngineRaw) {
+			guard directModelOptions.isEmpty, directModelFetchError == nil else { return }
+			refreshDirectModels()
+		}
+	}
+
+	/// Asks the directly-addressed engine what speech-to-text models it has
+	/// installed. A failure keeps whatever model string is already saved and
+	/// falls back to the free-text field rather than clearing the selection —
+	/// an engine that is briefly unreachable should not cost the user their
+	/// configured model.
+	private func refreshDirectModels() {
+		isFetchingDirectModels = true
+		directModelFetchError = nil
+		Task { @MainActor in
+			do {
+				let models = try await StreamingTranscriber.direct.models()
+				directModelOptions = models
+				isFetchingDirectModels = false
+			} catch {
+				AppLogger.shared.general.error(
+					"Failed to list direct-engine models: \(error.localizedDescription)")
+				directModelOptions = []
+				// StreamingTranscriberError distinguishes "unreachable" from
+				// "reachable but no speech models", and both messages already say
+				// what to check — keep them instead of flattening to one line.
+				directModelFetchError = error.localizedDescription
+				isFetchingDirectModels = false
+			}
+		}
+	}
+}

--- a/Client/ServersSettingsView.swift
+++ b/Client/ServersSettingsView.swift
@@ -29,6 +29,8 @@ struct ServersSettingsView: View {
 	@AppStorage(WhisperaSettings.transcriptionServerIdKey) private var pinnedServerId = ""
 	@AppStorage(WhisperaSettings.transcriptionDirectModelKey) private var directModel = ""
 	@AppStorage("enableStreaming") private var enableStreaming = Constants.enableStreamingDefault
+	@AppStorage(WhisperaSettings.twoPassFinalizerKey) private var twoPassFinalizerRaw =
+		TwoPassFinalizerMode.off.rawValue
 
 	/// Falls back to `auto` for the same reason `WhisperaSettings` does: a stored
 	/// engine from a build that shipped one we no longer do must degrade, not trap.
@@ -97,6 +99,7 @@ struct ServersSettingsView: View {
 					// one, and the wording below is already engine-agnostic — the
 					// caveat is exactly as true when `auto` lands on WhisperKit.
 					if selectedEngine.streamsFromAServer || selectedEngine == .auto {
+						finalPassRow
 						InfoBox(style: .info) {
 							Text(
 								enableStreaming
@@ -122,6 +125,28 @@ struct ServersSettingsView: View {
 			}
 			.padding(20)
 		}
+	}
+
+	// MARK: - Final pass (two-pass dictation)
+
+	/// Shown only for the engines that stream: the second pass polishes a
+	/// streaming engine's low-latency draft, while the on-device engine already
+	/// re-reads its whole buffer as it goes and has nothing to gain from one.
+	private var finalPassRow: some View {
+		SettingRow(
+			"Final pass",
+			description: "More accurate paste, adds a short wait after you stop."
+		) {
+			Picker("Final pass", selection: $twoPassFinalizerRaw) {
+				ForEach(TwoPassFinalizerMode.allCases, id: \.rawValue) { mode in
+					Text(mode.displayName).tag(mode.rawValue)
+				}
+			}
+			.labelsHidden()
+			.frame(width: 240)
+			.accessibilityIdentifier("twoPassFinalizerPicker")
+		}
+		.animation(.easeInOut(duration: 0.2), value: twoPassFinalizerRaw)
 	}
 
 	// MARK: - Engine picker

--- a/Client/SpeechTranscribing.swift
+++ b/Client/SpeechTranscribing.swift
@@ -133,7 +133,14 @@ protocol SpeechTranscribing: AnyObject {
 	func startStreaming(options: TranscriptionOptions) async throws
 	/// Moves an established stream onto the input device the user just picked.
 	func switchStreamingDevice() async
-	func stopStreaming()
+	/// Ends the stream and hands back the finished transcript, trimmed. Partial
+	/// text never leaves this method while it is still arriving — only what
+	/// `LiveTranscriptionState` had confirmed by the time the stream closed.
+	/// AudioManager pastes this once, if non-empty: the only place a live
+	/// dictation's words reach the focused app now that per-segment pasting is
+	/// gone. See WHI-58.
+	@discardableResult
+	func stopStreaming() async -> String
 }
 
 /// Defaults so a conformer writes only what it can actually do. Anything it
@@ -177,5 +184,6 @@ extension SpeechTranscribing {
 
 	func switchStreamingDevice() async {}
 
-	func stopStreaming() {}
+	@discardableResult
+	func stopStreaming() async -> String { "" }
 }

--- a/Client/SpeechTranscribing.swift
+++ b/Client/SpeechTranscribing.swift
@@ -141,6 +141,14 @@ protocol SpeechTranscribing: AnyObject {
 	/// gone. See WHI-58.
 	@discardableResult
 	func stopStreaming() async -> String
+	/// The second, slower pass of a two-pass dictation: re-reads the whole
+	/// session's retained audio after `stopStreaming` and returns the polished
+	/// transcript to paste in place of the draft. Nil means "paste the draft" —
+	/// finalizer off, nothing retained, failure, deadline, or a newer dictation
+	/// superseding the pass — and the conformer logs which. Bounded: it resolves
+	/// within the finalizer's deadline, so the caller's spinner always comes
+	/// back down.
+	func finalizeDictation(draft: String) async -> String?
 }
 
 /// Defaults so a conformer writes only what it can actually do. Anything it
@@ -186,4 +194,8 @@ extension SpeechTranscribing {
 
 	@discardableResult
 	func stopStreaming() async -> String { "" }
+
+	/// Instant path: an engine that keeps no session audio has no second pass,
+	/// so the draft is pasted exactly as it was before two-pass existed.
+	func finalizeDictation(draft: String) async -> String? { nil }
 }

--- a/Client/SpeechTranscribing.swift
+++ b/Client/SpeechTranscribing.swift
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// One model an engine can run. A local engine downloads these; a remote engine
+/// lists what its server already holds, which is why `isDownloaded` is `true`
+/// for everything a server offers.
+struct TranscriptionModelInfo: Identifiable, Hashable, Sendable {
+	let id: String
+	let displayName: String
+	let isDownloaded: Bool
+
+	init(id: String, displayName: String? = nil, isDownloaded: Bool = true) {
+		self.id = id
+		self.displayName = displayName ?? id
+		self.isDownloaded = isDownloaded
+	}
+}
+
+/// What an engine can actually do. Callers branch on capability, never on which
+/// engine is selected: a `switch` over engine identity is what WHI-58 removed,
+/// and re-introducing one would put it straight back.
+struct TranscriptionCapabilities: OptionSet, Sendable, Hashable {
+	let rawValue: Int
+
+	init(rawValue: Int) { self.rawValue = rawValue }
+
+	static let fileTranscription = TranscriptionCapabilities(rawValue: 1 << 0)
+	static let bufferTranscription = TranscriptionCapabilities(rawValue: 1 << 1)
+	static let timestamps = TranscriptionCapabilities(rawValue: 1 << 2)
+	static let streaming = TranscriptionCapabilities(rawValue: 1 << 3)
+	/// The engine owns model files, so listing, downloading and download
+	/// progress mean something. A server-side engine leaves this off.
+	static let managedModels = TranscriptionCapabilities(rawValue: 1 << 4)
+	static let translation = TranscriptionCapabilities(rawValue: 1 << 5)
+}
+
+/// An engine-neutral transcription request. Engine-specific tuning — WhisperKit's
+/// sample length, prefill caches, temperature fallbacks — stays inside the
+/// conformer that understands it, so a second engine never has to widen this.
+struct TranscriptionOptions: Sendable, Equatable {
+	enum Mode: String, Sendable {
+		case transcribe
+		case translate
+	}
+
+	var mode: Mode
+	/// Language code the engine understands, or nil to let the engine decide.
+	var language: String?
+
+	init(mode: Mode = .transcribe, language: String? = nil) {
+		self.mode = mode
+		self.language = language
+	}
+
+	/// The options a dictation should run with. `language` stays nil so each
+	/// engine applies its own default; WhisperKit reads the user's saved
+	/// language itself, exactly as it did before the protocol existed.
+	static func dictation(translate: Bool) -> Self {
+		TranscriptionOptions(mode: translate ? .translate : .transcribe)
+	}
+}
+
+/// Lifecycle as the UI needs it, rather than as any one engine implements it.
+enum TranscriptionEngineState: Equatable, Sendable {
+	/// Needs setup before it can run: no model downloaded, no key, no endpoint.
+	case unavailable(String)
+	case preparing(progress: Double, status: String)
+	case ready
+}
+
+enum TranscriptionEngineError: LocalizedError, Equatable {
+	case unsupported(engine: String, capability: String)
+	case notConfigured(String)
+	case failed(String)
+
+	var errorDescription: String? {
+		switch self {
+		case .unsupported(let engine, let capability):
+			return "\(engine) cannot \(capability)."
+		case .notConfigured(let message):
+			return message
+		case .failed(let message):
+			return message
+		}
+	}
+}
+
+/// Audio in, text out.
+///
+/// One interface over an on-device CoreML model and a socket to a server: which
+/// of the two is running is the router's business and the conformer's, never the
+/// caller's. Mirrors `RecipeExecuting` + `RecipeRouter`. See WHI-58.
+///
+/// Streaming conformers publish into `LiveTranscriptionState.shared` rather than
+/// owning any view, so every engine reaches the one live-transcription HUD.
+@MainActor
+protocol SpeechTranscribing: AnyObject {
+	nonisolated var engine: TranscriptionEngine { get }
+	nonisolated var capabilities: TranscriptionCapabilities { get }
+
+	var state: TranscriptionEngineState { get }
+
+	/// Brings the engine to `.ready`, or throws saying why it cannot get there.
+	func prepare() async throws
+	/// Releases whatever `prepare()` acquired: an unloaded model, a closed socket.
+	func shutdown()
+
+	// MARK: Models
+
+	var activeModel: String? { get }
+	func models() async throws -> [TranscriptionModelInfo]
+	func selectModel(_ id: String) async throws
+	func downloadModel(_ id: String) async throws
+	func cancelModelDownload()
+
+	// MARK: One-shot transcription
+
+	func transcribe(fileAt url: URL, options: TranscriptionOptions) async throws -> String
+	func transcribe(samples: [Float], options: TranscriptionOptions) async throws -> String
+	func transcribeWithTimestamps(fileAt url: URL, options: TranscriptionOptions) async throws
+		-> [TranscriptionSegment]
+
+	// MARK: Streaming
+
+	/// Raw capture buffers, for level metering. Set by whoever drives the engine.
+	var onLiveAudioSamples: (@MainActor ([Float]) -> Void)? { get set }
+	/// Drops everything left over from a previous streaming session.
+	func resetStreamingSession()
+	/// Shows the waiting UI, brings capture up, and starts publishing into
+	/// `LiveTranscriptionState.shared`. Returns once capture is established.
+	func startStreaming(options: TranscriptionOptions) async throws
+	/// Moves an established stream onto the input device the user just picked.
+	func switchStreamingDevice() async
+	func stopStreaming()
+}
+
+/// Defaults so a conformer writes only what it can actually do. Anything it
+/// cannot do throws a message naming the engine, which is what the caller
+/// surfaces — WHI-42's rule that a failure never silently degrades to another
+/// engine holds here too.
+extension SpeechTranscribing {
+	var activeModel: String? { nil }
+
+	func models() async throws -> [TranscriptionModelInfo] { [] }
+
+	func selectModel(_ id: String) async throws {
+		throw TranscriptionEngineError.unsupported(
+			engine: engine.displayName, capability: "choose a model")
+	}
+
+	func downloadModel(_ id: String) async throws {
+		throw TranscriptionEngineError.unsupported(
+			engine: engine.displayName, capability: "download models")
+	}
+
+	func cancelModelDownload() {}
+
+	func shutdown() {}
+
+	func transcribeWithTimestamps(fileAt url: URL, options: TranscriptionOptions) async throws
+		-> [TranscriptionSegment]
+	{
+		throw TranscriptionEngineError.unsupported(
+			engine: engine.displayName, capability: "produce timestamps")
+	}
+
+	func resetStreamingSession() {
+		LiveTranscriptionState.shared.reset()
+	}
+
+	func startStreaming(options: TranscriptionOptions) async throws {
+		throw TranscriptionEngineError.unsupported(
+			engine: engine.displayName, capability: "transcribe live")
+	}
+
+	func switchStreamingDevice() async {}
+
+	func stopStreaming() {}
+}

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -49,6 +49,12 @@ final class StreamingTranscriber: SpeechTranscribing {
 
 	private var session: DictationSession?
 	private var eventTask: Task<Void, Never>?
+	/// The previous session's close, still running behind the stop that returned
+	/// immediately. The next start awaits it (bounded) before opening capture:
+	/// in QA, back-to-back dictations opened the new AVAudioEngine while the old
+	/// one still held the input device, and the new session heard only silence —
+	/// or failed with -10868 once the engine gave up.
+	private var closingTask: Task<Void, Never>?
 	private var wordTracker: DictationWordTracker?
 	/// Builds the in-flight utterance out of `.partialTranscript` deltas before
 	/// they reach the live state; see the accumulator's own comment for why a
@@ -239,6 +245,11 @@ final class StreamingTranscriber: SpeechTranscribing {
 		utteranceDraft.clear()
 
 		do {
+			// The previous session's microphone engine must be fully down before
+			// this one opens its own, or the new capture starts against a device
+			// the old engine still holds and delivers nothing.
+			await awaitPreviousSessionClosed()
+
 			let configuration = try await configuration(for: options)
 
 			// The input device the user picked has to be the system default before
@@ -346,7 +357,7 @@ final class StreamingTranscriber: SpeechTranscribing {
 		// session's own microphone engine is down — switching the default device
 		// under a still-running AVAudioEngine is the main-thread wedge suspected
 		// in the QA hang — and only while no newer dictation has claimed it.
-		Task.detached { [weak self] in
+		closingTask = Task.detached { [weak self] in
 			await session.cancel()
 			await MainActor.run {
 				guard self?.session == nil else { return }
@@ -589,9 +600,36 @@ final class StreamingTranscriber: SpeechTranscribing {
 		wordTracker = nil
 		finishStartIfPending(throwing: CancellationError())
 		if let closing {
-			Task { await closing.cancel() }
+			closingTask = Task { await closing.cancel() }
 		}
 	}
+
+	/// Waits for the previous session's close to finish, bounded: the microphone
+	/// half of a close is local and quick — and it is the half the next capture
+	/// needs done — while the socket half may take as long as the network wants,
+	/// and a slow server must not hold the user's next dictation hostage.
+	///
+	/// Not a task group: awaiting a never-failing task's `value` cannot be
+	/// interrupted, and a group would wait for that child anyway at its scope's
+	/// end. Two independent observers race to resume one continuation instead;
+	/// whichever loses resumes into nothing.
+	private func awaitPreviousSessionClosed() async {
+		guard let closing = closingTask else { return }
+		closingTask = nil
+		await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+			let handoff = ResumeOnce(continuation)
+			Task.detached {
+				await closing.value
+				handoff.resume()
+			}
+			Task.detached {
+				try? await Task.sleep(nanoseconds: UInt64(Self.closeHandoverTimeout * 1_000_000_000))
+				handoff.resume()
+			}
+		}
+	}
+
+	private static let closeHandoverTimeout: Double = 2
 
 	// MARK: - Server resolution
 
@@ -646,6 +684,25 @@ final class StreamingTranscriber: SpeechTranscribing {
 		let server = try await resolveServer()
 		return .backend(
 			baseURL, server: server.id, model: server.model, language: options.language)
+	}
+}
+
+/// Resumes a continuation exactly once, whichever of two racing observers gets
+/// there first. See `StreamingTranscriber.awaitPreviousSessionClosed`.
+private final class ResumeOnce: @unchecked Sendable {
+	private let lock = NSLock()
+	private var continuation: CheckedContinuation<Void, Never>?
+
+	init(_ continuation: CheckedContinuation<Void, Never>) {
+		self.continuation = continuation
+	}
+
+	func resume() {
+		lock.lock()
+		let continuation = self.continuation
+		self.continuation = nil
+		lock.unlock()
+		continuation?.resume()
 	}
 }
 

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -292,17 +292,51 @@ final class StreamingTranscriber: SpeechTranscribing {
 			return live.confirmedText.trimmingCharacters(in: .whitespacesAndNewlines)
 		}
 		self.session = nil
-
-		let transcript = await session.finish()
-		let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-		if !trimmed.isEmpty {
-			live.ingest(committed: trimmed, draft: "")
-		}
-		live.setPending("")
-		wordTracker?.endSession()
+		// Snapshot this dictation's plumbing before any await. The user can start
+		// a new dictation while the finish below is still waiting; from that
+		// moment the instance fields belong to the new session, and this stop's
+		// epilogue must only ever touch what it snapshotted — a late cleanup that
+		// cancels the new session's event task reads as "dictation randomly dies
+		// two seconds in", which is exactly the bug this shipped with.
+		let tracker = wordTracker
 		wordTracker = nil
-		eventTask?.cancel()
+		let events = eventTask
 		eventTask = nil
+
+		// A stop with nothing said must return in bounded time. finish() waits
+		// trailing silence plus the final-transcript timeout (~17 s) for an
+		// utterance that never existed; racing it against a deadline keeps the
+		// honest case (final lands ~0.6–1.3 s after the last word) and turns the
+		// silent case into a fast cancel.
+		let finished: String? = await withTaskGroup(of: String?.self) { group in
+			group.addTask { await session.finish() }
+			group.addTask {
+				try? await Task.sleep(nanoseconds: 3_500_000_000)
+				return nil
+			}
+			let first = await group.next() ?? nil
+			group.cancelAll()
+			return first
+		}
+		if finished == nil {
+			AppLogger.shared.transcriber.info(
+				"Stop deadline hit with no final transcript; cancelling the session")
+			await session.cancel()
+		}
+
+		let transcript = finished ?? live.confirmedText
+		let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+		// A new dictation may already own the shared live state; only the stop
+		// that is still current writes to it.
+		let superseded = self.session != nil
+		if !superseded {
+			if !trimmed.isEmpty {
+				live.ingest(committed: trimmed, draft: "")
+			}
+			live.setPending("")
+		}
+		tracker?.endSession()
+		events?.cancel()
 		AppLogger.shared.transcriber.info("Remote live streaming stopped")
 		return trimmed
 	}

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -278,7 +278,8 @@ final class StreamingTranscriber: SpeechTranscribing {
 			"Input device selection applied; the running remote stream keeps its original input until it is restarted")
 	}
 
-	func stopStreaming() {
+	@discardableResult
+	func stopStreaming() async -> String {
 		isStopping = true
 		live.isWaitingForModel = false
 		live.waitingForModelStatusText = ""
@@ -288,24 +289,22 @@ final class StreamingTranscriber: SpeechTranscribing {
 
 		guard let session else {
 			teardown()
-			return
+			return live.confirmedText.trimmingCharacters(in: .whitespacesAndNewlines)
 		}
 		self.session = nil
 
-		Task { @MainActor [weak self] in
-			let transcript = await session.finish()
-			guard let self else { return }
-			let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-			if !trimmed.isEmpty {
-				self.live.ingest(committed: trimmed, draft: "")
-			}
-			self.live.setPending("")
-			self.wordTracker?.endSession()
-			self.wordTracker = nil
-			self.eventTask?.cancel()
-			self.eventTask = nil
-			AppLogger.shared.transcriber.info("Remote live streaming stopped")
+		let transcript = await session.finish()
+		let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+		if !trimmed.isEmpty {
+			live.ingest(committed: trimmed, draft: "")
 		}
+		live.setPending("")
+		wordTracker?.endSession()
+		wordTracker = nil
+		eventTask?.cancel()
+		eventTask = nil
+		AppLogger.shared.transcriber.info("Remote live streaming stopped")
+		return trimmed
 	}
 
 	// MARK: - Events

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -56,9 +56,6 @@ final class StreamingTranscriber: SpeechTranscribing {
 	/// continuation below is installed. Recording the outcome means that start
 	/// resolves immediately instead of waiting on a resume that already happened.
 	private var startOutcome: Result<Void, Error>?
-	/// The newest committed utterance, so the HUD can show the words that just
-	/// landed. The package emits it just before the whole-transcript event.
-	private var lastUtterance = ""
 	private var didTranscribeAnything = false
 	/// Set while the package is replacing a socket, so the `.connecting` that
 	/// follows a reconnect reads as recovery rather than as a fresh start.
@@ -228,7 +225,6 @@ final class StreamingTranscriber: SpeechTranscribing {
 	func startStreaming(options: TranscriptionOptions) async throws {
 		live.beginWaiting()
 		live.waitingForModelStatusText = "Connecting to \(destinationName)…"
-		lastUtterance = ""
 		didTranscribeAnything = false
 		isRecovering = false
 		isStopping = false
@@ -355,15 +351,15 @@ final class StreamingTranscriber: SpeechTranscribing {
 		case .partialTranscript(let draft):
 			live.ingest(committed: live.confirmedText, draft: draft)
 
-		case .finalTranscript(let utterance):
-			// Remembered only so the HUD can show the words that just landed.
-			// `.transcript` immediately after carries the whole transcript, and
-			// consuming both would double-count.
-			lastUtterance = utterance
+		case .finalTranscript:
 			didTranscribeAnything = true
 
 		case .transcript(let whole):
-			live.ingest(committed: whole, draft: lastUtterance)
+			// The whole transcript already contains the utterance that just
+			// finalized. Carrying that utterance forward as the draft — which this
+			// used to do — put it in both halves at once, and the HUD showed it
+			// twice until the next utterance's first partial replaced it.
+			live.ingest(committed: whole, draft: "")
 
 		case .audioLevel(let level):
 			// The level meter wants samples, not an RMS. Spreading the reported

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -50,6 +50,10 @@ final class StreamingTranscriber: SpeechTranscribing {
 	private var session: DictationSession?
 	private var eventTask: Task<Void, Never>?
 	private var wordTracker: DictationWordTracker?
+	/// Builds the in-flight utterance out of `.partialTranscript` deltas before
+	/// they reach the live state; see the accumulator's own comment for why a
+	/// partial cannot be displayed on its own.
+	private var utteranceDraft = UtteranceDraftAccumulator()
 	private var cachedServer: DictationServer?
 	private var startContinuation: CheckedContinuation<Void, Error>?
 	/// The session can reach `.listening` — or fail outright — before the
@@ -219,6 +223,7 @@ final class StreamingTranscriber: SpeechTranscribing {
 
 	func resetStreamingSession() {
 		teardown()
+		utteranceDraft.clear()
 		live.reset()
 	}
 
@@ -229,6 +234,9 @@ final class StreamingTranscriber: SpeechTranscribing {
 		isRecovering = false
 		isStopping = false
 		startOutcome = nil
+		// A stale draft from the previous session must not prefix this one's
+		// first partial.
+		utteranceDraft.clear()
 
 		do {
 			let configuration = try await configuration(for: options)
@@ -362,17 +370,29 @@ final class StreamingTranscriber: SpeechTranscribing {
 		case .connectionState(let connectionState):
 			handle(connectionState)
 
-		case .partialTranscript(let draft):
-			live.ingest(committed: live.confirmedText, draft: draft)
+		case .partialTranscript(let delta):
+			// A partial is a delta — only the fragment since the previous event, per
+			// the OpenAI-Realtime contract — so it is appended to the utterance's
+			// accumulator first. Passing the fragment alone as the draft made each
+			// event replace the pill's tail with the latest few words instead of
+			// growing it (nemo-stream QA, WHI-58). The accumulated draft also lands
+			// in `pendingText`, which is what stop pastes for words still in flight.
+			utteranceDraft.append(delta)
+			live.ingest(committed: live.confirmedText, draft: utteranceDraft.draft)
 
 		case .finalTranscript:
 			didTranscribeAnything = true
+			// The utterance is settled; its deltas must not leak into the next one.
+			utteranceDraft.clear()
 
 		case .transcript(let whole):
 			// The whole transcript already contains the utterance that just
 			// finalized. Carrying that utterance forward as the draft — which this
 			// used to do — put it in both halves at once, and the HUD showed it
-			// twice until the next utterance's first partial replaced it.
+			// twice until the next utterance's first partial replaced it. Clearing
+			// the accumulator here as well covers an engine that emits the whole
+			// transcript without a preceding final.
+			utteranceDraft.clear()
 			live.ingest(committed: whole, draft: "")
 
 		case .audioLevel(let level):

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -73,6 +73,25 @@ final class StreamingTranscriber: SpeechTranscribing {
 	/// Set the moment the user asks to stop, so a session that fails on the way
 	/// down after handing back words does not raise an alert about it.
 	private var isStopping = false
+	/// Counts dictations. A pending second pass carries the generation it was
+	/// snapshotted under and compares it against this to learn that a newer
+	/// dictation owns the HUD — the same reason the close epilogue checks
+	/// `self?.session == nil` before restoring the input device.
+	private var dictationGeneration = 0
+	/// The finalizer mode this session started with. Held rather than re-read at
+	/// stop so flipping the setting mid-recording cannot promise a second pass
+	/// over audio that was never retained.
+	private var sessionTwoPassMode: TwoPassFinalizerMode = .off
+	/// The options the running session started with, for the second pass to
+	/// transcribe under the same language and mode.
+	private var sessionOptions = TranscriptionOptions()
+	/// Everything the second pass needs, snapshotted by `stopStreaming` with no
+	/// suspension in between, so no newer dictation can slip in before the
+	/// snapshot exists. Consumed by `finalizeDictation`.
+	private var pendingTwoPass: TwoPassContext?
+	/// The in-flight second pass, kept so the next dictation can end the wait
+	/// promptly instead of letting a stale pass run out its deadline.
+	private var finalizeTask: (generation: Int, task: Task<TwoPassOutcome, Never>)?
 
 	private(set) var state: TranscriptionEngineState = .unavailable(
 		"Not connected to a transcription server yet.")
@@ -240,6 +259,19 @@ final class StreamingTranscriber: SpeechTranscribing {
 		isRecovering = false
 		isStopping = false
 		startOutcome = nil
+		// A dictation starting is what supersedes a pending second pass: the
+		// pass belongs to the previous session's snapshot and the user has moved
+		// on, so its wait ends now and its caller pastes the draft it already has.
+		dictationGeneration += 1
+		if let finalizeTask {
+			AppLogger.shared.transcriber.info(
+				"A new dictation superseded the pending two-pass finalize")
+			finalizeTask.task.cancel()
+		}
+		finalizeTask = nil
+		pendingTwoPass = nil
+		sessionTwoPassMode = WhisperaSettings.twoPassFinalizer
+		sessionOptions = options
 		// A stale draft from the previous session must not prefix this one's
 		// first partial.
 		utteranceDraft.clear()
@@ -250,7 +282,10 @@ final class StreamingTranscriber: SpeechTranscribing {
 			// the old engine still holds and delivers nothing.
 			await awaitPreviousSessionClosed()
 
-			let configuration = try await configuration(for: options)
+			var configuration = try await configuration(for: options)
+			// Retention costs memory (the package caps it at ten minutes), so it
+			// is paid only when a second pass will read the audio back.
+			configuration.retainAudio = sessionTwoPassMode.isOn
 
 			// The input device the user picked has to be the system default before
 			// the package opens its own capture, which follows the default.
@@ -365,9 +400,143 @@ final class StreamingTranscriber: SpeechTranscribing {
 			}
 		}
 
+		if sessionTwoPassMode.isOn {
+			// Snapshotted before this method returns — it still has no suspension
+			// point — so the pass can never bind to a newer dictation's session.
+			pendingTwoPass = TwoPassContext(
+				session: session,
+				closing: closingTask,
+				mode: sessionTwoPassMode,
+				options: sessionOptions,
+				generation: dictationGeneration)
+			// The paste is now waiting on the second pass. Saying so reuses the
+			// waiting channel the HUD already renders (and whose width rules
+			// already handle status text) instead of growing a new one.
+			live.isWaitingForModel = true
+			live.waitingForModelStatusText = "Polishing…"
+			live.shouldShowLiveTranscriptionWindow = true
+			AppLogger.shared.transcriber.info(
+				"Remote live streaming stopped; draft held for the two-pass finalizer (\(sessionTwoPassMode.rawValue))")
+			return transcript
+		}
+
 		AppLogger.shared.transcriber.info(
 			"Remote live streaming stopped; returning the locally accumulated transcript")
 		return transcript
+	}
+
+	/// Consumes the snapshot `stopStreaming` left behind and runs the second
+	/// pass over the session's retained audio, bounded by the mode's deadline.
+	/// Returns the polished transcript, or nil when the caller should paste the
+	/// streaming draft — and logs which way it went and why.
+	func finalizeDictation(draft: String) async -> String? {
+		guard let pending = pendingTwoPass else { return nil }
+		pendingTwoPass = nil
+
+		AppLogger.shared.transcriber.info(
+			"Two-pass finalize started (\(pending.mode.rawValue)); deadline \(pending.mode.deadline)s, draft \(draft.count) chars")
+
+		let operation = finalizeOperation(for: pending)
+		let race = Task { await TwoPassDeadline.race(seconds: pending.mode.deadline, operation: operation) }
+		finalizeTask = (pending.generation, race)
+		let outcome = await race.value
+		// Guarded by generation: a rapid stop of the *next* dictation may have
+		// installed its own pass here while this one was still resuming.
+		if finalizeTask?.generation == pending.generation { finalizeTask = nil }
+
+		// The polishing status belongs to this dictation alone; if a newer one
+		// has started, it owns the HUD and nothing here may touch it.
+		if pending.generation == dictationGeneration {
+			live.isWaitingForModel = false
+			live.waitingForModelStatusText = ""
+			live.shouldShowLiveTranscriptionWindow = false
+		}
+
+		if let text = TwoPassPolicy.finalizedText(from: outcome) {
+			AppLogger.shared.transcriber.info(
+				"Two-pass finalize produced \(text.count) chars; pasting the polished transcript")
+			return text
+		}
+		let reason = TwoPassPolicy.fallbackReason(for: outcome) ?? "unknown"
+		switch outcome {
+		case .failed, .deadlineExpired:
+			AppLogger.shared.transcriber.error(
+				"Two-pass finalize failed; pasting the streaming draft: \(reason)")
+		default:
+			AppLogger.shared.transcriber.info(
+				"Two-pass finalize skipped; pasting the streaming draft: \(reason)")
+		}
+		return nil
+	}
+
+	/// The pass itself, as a closure the deadline race can run off the main
+	/// actor. Everything it needs is captured up front from the snapshot; it
+	/// never reads instance state, which a newer dictation may own by the time
+	/// it runs.
+	private func finalizeOperation(for pending: TwoPassContext) -> @Sendable () async -> TwoPassOutcome {
+		let session = pending.session
+		let closing = pending.closing
+		let mode = pending.mode
+		let options = pending.options
+		let direct = isDirect()
+		// Built here, on the actor, so the closure below stays free of
+		// main-actor hops: the transcription backend is where discovery
+		// advertises the batch capability, and its batch endpoint is the
+		// existing POST /transcribe plumbing.
+		let batchUploader = RemoteTranscriber(
+			serverURLProvider: { WhisperaSettings.transcriptionBackendURL })
+
+		return {
+			// The microphone half of the close is what stops frames being
+			// retained; waiting for it makes capturedAudio() the whole utterance
+			// rather than a prefix. It sits inside the deadline race, so a close
+			// that hangs on the socket cannot hang the paste.
+			if let closing { await closing.value }
+
+			let audio = await session.capturedAudio()
+			guard !audio.isEmpty else { return .noAudio }
+			if await session.capturedAudioWasTruncated {
+				// Finalize anyway: the buffer holds the most recent ten minutes,
+				// and pasting an accurate tail beats failing the dictation.
+				// Nothing user-visible is prepended.
+				AppLogger.shared.transcriber.info(
+					"Two-pass audio hit the retention cap; finalizing the retained tail only")
+			}
+
+			let samples = PCM16Resampler.float32Samples(
+				fromPCM16LittleEndian: audio,
+				sourceHz: DictationAudioFormat.engine.sampleRate,
+				targetHz: 16_000)
+
+			switch mode {
+			case .off:
+				// Unreachable: stopStreaming only snapshots when the mode is on.
+				return .failed("the finalizer is off")
+			case .local:
+				do {
+					let text = try await WhisperKitTranscriber.shared.transcribe(
+						samples: samples, options: options)
+					return .finalized(text)
+				} catch {
+					return .failed("the on-device pass failed: \(error.localizedDescription)")
+				}
+			case .server:
+				guard !direct else {
+					// The batch upload is a backend route; a directly-addressed
+					// realtime engine has no backend in the path to receive it.
+					return .failed("the direct engine has no backend batch endpoint")
+				}
+				do {
+					let wav = RemoteBatchTranscriber.wav(from: samples)
+					let text = try await batchUploader.transcribeViaWhispera(
+						audio: wav, filename: "dictation.wav", mimetype: "audio/wav",
+						language: options.language)
+					return .finalized(text)
+				} catch {
+					return .failed("the batch upload failed: \(error.localizedDescription)")
+				}
+			}
+		}
 	}
 
 	// MARK: - Events
@@ -685,6 +854,19 @@ final class StreamingTranscriber: SpeechTranscribing {
 		return .backend(
 			baseURL, server: server.id, model: server.model, language: options.language)
 	}
+}
+
+/// One stopped dictation's claim on a second pass: the session whose retained
+/// audio to read, the close to wait out first, and the generation that says
+/// whether the dictation it belongs to is still the current one. A snapshot,
+/// deliberately — the pass must never read instance fields a newer dictation
+/// owns, the same rule the close epilogue follows.
+private struct TwoPassContext {
+	let session: DictationSession
+	let closing: Task<Void, Never>?
+	let mode: TwoPassFinalizerMode
+	let options: TranscriptionOptions
+	let generation: Int
 }
 
 /// Resumes a continuation exactly once, whichever of two racing observers gets

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -61,11 +61,12 @@ final class StreamingTranscriber: SpeechTranscribing {
 		self.serverIdProvider = serverIdProvider
 		// Read at connect time and dropped afterwards, and re-read on the one
 		// unauthorized retry, so a short-lived session token survives it.
+		// A missing token is not fatal: a self-hosted proxy on a trusted network
+		// may not require one, and refusing to connect would make the app harder
+		// to bring up than the server it talks to. If the server does want a
+		// credential it answers 4401, which surfaces as a real error.
 		self.credentials = .refreshingBearer {
-			guard let token = try tokenStore.load(), !token.isEmpty else {
-				throw StreamingTranscriberError.notSignedIn
-			}
-			return token
+			(try? tokenStore.load()).flatMap { $0.isEmpty ? nil : $0 } ?? ""
 		}
 	}
 
@@ -222,6 +223,10 @@ final class StreamingTranscriber: SpeechTranscribing {
 	// MARK: - Events
 
 	private func handle(_ event: DictationEvent) {
+		// Every event, at debug level. A remote session that stalls used to leave
+		// no trace at all between "connecting" and silence, which made a stuck
+		// socket and a silent microphone look identical from the log.
+		AppLogger.shared.transcriber.debug("Remote dictation event: \(String(describing: event))")
 		switch event {
 		case .connectionState(let connectionState):
 			handle(connectionState)
@@ -303,15 +308,30 @@ final class StreamingTranscriber: SpeechTranscribing {
 	}
 
 	/// Waits for the session to reach `.listening`, or for the first failure.
+	/// Capture is established when the engine says it is listening. Without a
+	/// deadline a session that never reaches that state hangs this call forever:
+	/// the continuation is only resumed by an event, so a socket that stalls or a
+	/// microphone that never yields frames leaves dictation silently wedged with
+	/// nothing logged. Fail loudly instead.
 	private func awaitCaptureEstablished() async throws {
 		if let outcome = startOutcome {
 			startOutcome = nil
 			return try outcome.get()
 		}
+		let deadline = Task { @MainActor [weak self] in
+			try await Task.sleep(nanoseconds: UInt64(Self.captureTimeout * 1_000_000_000))
+			guard !Task.isCancelled else { return }
+			AppLogger.shared.transcriber.error(
+				"Remote capture did not start within \(Self.captureTimeout)s; giving up")
+			self?.finishStartIfPending(throwing: StreamingTranscriberError.captureTimedOut)
+		}
+		defer { deadline.cancel() }
 		try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
 			startContinuation = continuation
 		}
 	}
+
+	private static let captureTimeout: Double = 15
 
 	private func teardown() {
 		eventTask?.cancel()
@@ -381,9 +401,12 @@ enum StreamingTranscriberError: LocalizedError, Equatable {
 	case invalidServerURL
 	case noRealtimeServer(requested: String)
 	case serverCannotStream(String)
+	case captureTimedOut
 
 	var errorDescription: String? {
 		switch self {
+		case .captureTimedOut:
+			return "The transcription server did not start listening. Check that it is reachable."
 		case .notSignedIn:
 			return "Streaming transcription needs an auth token (Account settings)."
 		case .invalidServerURL:

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -42,6 +42,10 @@ final class StreamingTranscriber: SpeechTranscribing {
 	private let credentials: DictationCredentialProvider
 	private let isDirect: () -> Bool
 	private let directModel: () -> String
+	/// Injectable so `models()`'s direct-mode fetch can be exercised against a
+	/// mock in tests without a real engine on the network. Named apart from
+	/// `session` below, which is the dictation socket, not an HTTP session.
+	private let urlSession: URLSession
 
 	private var session: DictationSession?
 	private var eventTask: Task<Void, Never>?
@@ -75,12 +79,14 @@ final class StreamingTranscriber: SpeechTranscribing {
 		// shape available to a host that has no backend at all.
 		directProvider: @escaping () -> Bool = { false },
 		modelProvider: @escaping () -> String = { WhisperaSettings.transcriptionDirectModel },
-		tokenStore: AuthTokenStore = .shared
+		tokenStore: AuthTokenStore = .shared,
+		urlSession: URLSession = .shared
 	) {
 		self.baseURLProvider = baseURLProvider
 		self.serverIdProvider = serverIdProvider
 		self.isDirect = directProvider
 		self.directModel = modelProvider
+		self.urlSession = urlSession
 		self.engineCase = directProvider() ? .realtimeDirect : .whisperaStreaming
 		// Read at connect time and dropped afterwards, and re-read on the one
 		// unauthorized retry, so a short-lived session token survives it.
@@ -112,16 +118,62 @@ final class StreamingTranscriber: SpeechTranscribing {
 
 	var activeModel: String? { isDirect() ? directModel() : cachedServer?.model }
 
-	/// The backend lists one model per server, so the model list is the server
-	/// list. Selecting one records which server to stream through.
+	/// Backend mode lists one model per server, so the model list is the server
+	/// list. Direct mode has no server registry to ask, so it asks the engine
+	/// itself what it can run. Selecting one records which server/model to
+	/// stream through.
 	func models() async throws -> [TranscriptionModelInfo] {
 		if isDirect() {
-			let model = directModel()
-			return [TranscriptionModelInfo(id: model, displayName: model)]
+			return try await directModels()
 		}
 		return try await directory().servers()
 			.filter { $0.supportsRealtime && $0.isOnline }
 			.map { TranscriptionModelInfo(id: $0.id, displayName: "\($0.label) — \($0.model)") }
+	}
+
+	private struct DirectModelsResponse: Decodable {
+		struct Model: Decodable {
+			let id: String
+			let task: String?
+		}
+		let data: [Model]
+	}
+
+	/// `GET <baseURL>/models`, OpenAI-compatible. The endpoint lists every model
+	/// the engine serves — LLMs, TTS, embeddings on a multi-purpose host — so this
+	/// filters to the ones that can transcribe, the same way backend mode filters
+	/// servers to ones that support realtime. No credentials: direct mode is
+	/// deliberately for a trusted network with no proxy in front to hold one.
+	private func directModels() async throws -> [TranscriptionModelInfo] {
+		guard let baseURL = baseURLProvider() else {
+			throw StreamingTranscriberError.invalidServerURL
+		}
+		let destination = baseURL.host ?? baseURL.absoluteString
+
+		let data: Data
+		let response: URLResponse
+		do {
+			(data, response) = try await urlSession.data(
+				for: URLRequest(url: baseURL.appendingPathComponent("models")))
+		} catch {
+			throw StreamingTranscriberError.engineUnreachable(destination)
+		}
+		guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+			throw StreamingTranscriberError.engineUnreachable(destination)
+		}
+
+		let decoded: DirectModelsResponse
+		do {
+			decoded = try JSONDecoder().decode(DirectModelsResponse.self, from: data)
+		} catch {
+			throw StreamingTranscriberError.engineUnreachable(destination)
+		}
+
+		let asrModels = decoded.data.filter { $0.task == "automatic-speech-recognition" }
+		guard !asrModels.isEmpty else {
+			throw StreamingTranscriberError.noModelsInstalled(destination)
+		}
+		return asrModels.map { TranscriptionModelInfo(id: $0.id) }
 	}
 
 	func selectModel(_ id: String) async throws {
@@ -540,6 +592,8 @@ enum StreamingTranscriberError: LocalizedError, Equatable {
 	case noRealtimeServer(requested: String)
 	case serverCannotStream(String)
 	case captureTimedOut
+	case engineUnreachable(String)
+	case noModelsInstalled(String)
 
 	var errorDescription: String? {
 		switch self {
@@ -555,6 +609,11 @@ enum StreamingTranscriberError: LocalizedError, Equatable {
 				: "Transcription server '\(requested)' was not found on the backend."
 		case .serverCannotStream(let label):
 			return "\(label) does not support streaming transcription."
+		case .engineUnreachable(let destination):
+			return
+				"Could not reach \(destination) to list its models. Check that the engine is running and reachable at the configured URL."
+		case .noModelsInstalled(let destination):
+			return "\(destination) is reachable but reports no installed speech-to-text models."
 		}
 	}
 }

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import WhisperaDictation
+
+/// The streaming conformer: a WebSocket to the Whispera transcription proxy,
+/// behind the same interface as the on-device model.
+///
+/// The socket, the resampling to the engine's format and the credential
+/// handling all live in the `WhisperaDictation` package — this type only
+/// resolves which server to talk to, turns that package's events into the
+/// shared `LiveTranscriptionState`, and hands the same lifecycle back to
+/// `AudioManager` that WhisperKit hands it. See WHI-58.
+///
+/// Server capabilities, the realtime path and the audio format are read from
+/// `GET /transcription/servers` rather than hardcoded, so a new engine on the
+/// backend needs no client change.
+@MainActor
+final class StreamingTranscriber: SpeechTranscribing {
+	static let shared = StreamingTranscriber()
+
+	nonisolated var engine: TranscriptionEngine { .whisperaStreaming }
+
+	/// One-shot transcription runs the same socket with a file or buffer source
+	/// instead of the microphone, so text mode works on this engine too.
+	nonisolated var capabilities: TranscriptionCapabilities {
+		[.streaming, .fileTranscription, .bufferTranscription]
+	}
+
+	var onLiveAudioSamples: (@MainActor ([Float]) -> Void)?
+
+	private let live = LiveTranscriptionState.shared
+	private let baseURLProvider: () -> URL?
+	private let serverIdProvider: () -> String
+	private let credentials: DictationCredentialProvider
+
+	private var session: DictationSession?
+	private var eventTask: Task<Void, Never>?
+	private var wordTracker: DictationWordTracker?
+	private var cachedServer: DictationServer?
+	private var startContinuation: CheckedContinuation<Void, Error>?
+	/// The session can reach `.listening` — or fail outright — before the
+	/// continuation below is installed. Recording the outcome means that start
+	/// resolves immediately instead of waiting on a resume that already happened.
+	private var startOutcome: Result<Void, Error>?
+	/// The newest committed utterance, so the HUD can show the words that just
+	/// landed. The package emits it just before the whole-transcript event.
+	private var lastUtterance = ""
+	private var didTranscribeAnything = false
+
+	private(set) var state: TranscriptionEngineState = .unavailable(
+		"Not connected to a transcription server yet.")
+
+	init(
+		baseURLProvider: @escaping () -> URL? = { WhisperaSettings.transcriptionServerURL },
+		serverIdProvider: @escaping () -> String = { WhisperaSettings.transcriptionServerId },
+		tokenStore: AuthTokenStore = .shared
+	) {
+		self.baseURLProvider = baseURLProvider
+		self.serverIdProvider = serverIdProvider
+		// Read at connect time and dropped afterwards, and re-read on the one
+		// unauthorized retry, so a short-lived session token survives it.
+		self.credentials = .refreshingBearer {
+			guard let token = try tokenStore.load(), !token.isEmpty else {
+				throw StreamingTranscriberError.notSignedIn
+			}
+			return token
+		}
+	}
+
+	// MARK: - Lifecycle
+
+	func prepare() async throws {
+		_ = try await resolveServer()
+	}
+
+	func shutdown() {
+		teardown()
+		cachedServer = nil
+		state = .unavailable("Not connected to a transcription server yet.")
+	}
+
+	// MARK: - Models
+
+	var activeModel: String? { cachedServer?.model }
+
+	/// The backend lists one model per server, so the model list is the server
+	/// list. Selecting one records which server to stream through.
+	func models() async throws -> [TranscriptionModelInfo] {
+		try await directory().servers()
+			.filter { $0.supportsRealtime && $0.isOnline }
+			.map { TranscriptionModelInfo(id: $0.id, displayName: "\($0.label) — \($0.model)") }
+	}
+
+	func selectModel(_ id: String) async throws {
+		WhisperaSettings.transcriptionServerId = id
+		cachedServer = nil
+		_ = try await resolveServer()
+	}
+
+	// MARK: - One-shot
+
+	func transcribe(fileAt url: URL, options: TranscriptionOptions) async throws -> String {
+		let source = try AudioFileSource(url: url)
+		return try await runOneShot(audio: source, options: options)
+	}
+
+	func transcribe(samples: [Float], options: TranscriptionOptions) async throws -> String {
+		guard !samples.isEmpty else { return "No audio data provided" }
+
+		// Declare the capture format and let the package resample; it owns the
+		// conversion to whatever the engine wants.
+		let source = PushAudioSource(
+			format: DictationAudioFormat(sampleRate: 16000, channels: 1, encoding: .float32))
+		samples.withUnsafeBufferPointer { buffer in
+			source.push(Data(buffer: buffer))
+		}
+		source.finish()
+
+		return try await runOneShot(audio: source, options: options)
+	}
+
+	private func runOneShot(audio: DictationAudioSource, options: TranscriptionOptions) async throws
+		-> String
+	{
+		let configuration = try await configuration(for: options)
+		let text = try await DictationSession.transcribe(
+			configuration: configuration, credentials: credentials, audio: audio)
+		let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+		return trimmed.isEmpty ? "No speech detected" : trimmed
+	}
+
+	// MARK: - Streaming
+
+	func resetStreamingSession() {
+		teardown()
+		live.reset()
+	}
+
+	func startStreaming(options: TranscriptionOptions) async throws {
+		live.beginWaiting()
+		live.waitingForModelStatusText = "Connecting to \(serverIdProvider().isEmpty ? "transcription server" : serverIdProvider())..."
+		lastUtterance = ""
+		didTranscribeAnything = false
+		startOutcome = nil
+
+		do {
+			let configuration = try await configuration(for: options)
+
+			// The input device the user picked has to be the system default before
+			// the package opens its own capture, which follows the default.
+			await AudioDeviceManager.shared.activateSelectedDevice()
+
+			wordTracker = DictationWordTracker()
+			wordTracker?.startNewSession()
+
+			let session = DictationSession(
+				configuration: configuration, credentials: credentials, audio: MicrophoneSource())
+			self.session = session
+
+			eventTask = Task { @MainActor [weak self] in
+				for await event in session.events {
+					self?.handle(event)
+				}
+				self?.finishStartIfPending(throwing: nil)
+			}
+
+			await session.start()
+			try await awaitCaptureEstablished()
+		} catch {
+			live.isWaitingForModel = false
+			live.isTranscribing = false
+			if live.waitingForModelStatusText.isEmpty {
+				live.waitingForModelStatusText = "Unable to start dictation."
+			}
+			live.shouldShowLiveTranscriptionWindow = true
+			teardown()
+			AppLogger.shared.transcriber.error("Failed to start remote live stream: \(error)")
+			throw error
+		}
+	}
+
+	/// AVAudioEngine pins its input at start, so an established remote stream
+	/// keeps the device it opened on. The selection is activated here and takes
+	/// effect on the next dictation.
+	func switchStreamingDevice() async {
+		await AudioDeviceManager.shared.activateSelectedDevice()
+		AppLogger.shared.transcriber.info(
+			"Input device selection applied; the running remote stream keeps its original input until it is restarted")
+	}
+
+	func stopStreaming() {
+		live.isWaitingForModel = false
+		live.waitingForModelStatusText = ""
+		live.isTranscribing = false
+		live.shouldShowLiveTranscriptionWindow = false
+		AudioDeviceManager.shared.restoreSystemDefault()
+
+		guard let session else {
+			teardown()
+			return
+		}
+		self.session = nil
+
+		Task { @MainActor [weak self] in
+			let transcript = await session.finish()
+			guard let self else { return }
+			let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+			if !trimmed.isEmpty {
+				self.live.ingest(committed: trimmed, draft: "")
+			}
+			self.live.setPending("")
+			self.wordTracker?.endSession()
+			self.wordTracker = nil
+			self.eventTask?.cancel()
+			self.eventTask = nil
+			AppLogger.shared.transcriber.info("Remote live streaming stopped")
+		}
+	}
+
+	// MARK: - Events
+
+	private func handle(_ event: DictationEvent) {
+		switch event {
+		case .connectionState(let connectionState):
+			handle(connectionState)
+
+		case .partialTranscript(let draft):
+			live.ingest(committed: live.confirmedText, draft: draft)
+
+		case .finalTranscript(let utterance):
+			// Remembered only so the HUD can show the words that just landed.
+			// `.transcript` immediately after carries the whole transcript, and
+			// consuming both would double-count.
+			lastUtterance = utterance
+			didTranscribeAnything = true
+
+		case .transcript(let whole):
+			live.ingest(committed: whole, draft: lastUtterance)
+
+		case .audioLevel(let level):
+			// The level meter wants samples, not an RMS. Spreading the reported
+			// level across a short window is what the file-recorder path already
+			// does with AVAudioRecorder's average power.
+			onLiveAudioSamples?((0..<700).map { _ in level + Float.random(in: -0.02...0.02) })
+
+		case .failed(let error):
+			AppLogger.shared.transcriber.error("Remote dictation failed: \(error.localizedDescription)")
+			state = .unavailable(error.localizedDescription)
+			live.isWaitingForModel = true
+			live.waitingForModelStatusText = error.localizedDescription
+			live.shouldShowLiveTranscriptionWindow = true
+			finishStartIfPending(throwing: error)
+		}
+	}
+
+	private func handle(_ connectionState: DictationConnectionState) {
+		switch connectionState {
+		case .idle, .connecting, .finishing:
+			break
+
+		case .listening:
+			state = .ready
+			live.isWaitingForModel = false
+			live.waitingForModelStatusText = ""
+			live.isTranscribing = true
+			live.shouldShowLiveTranscriptionWindow = true
+			finishStartIfPending(throwing: nil)
+
+		case .closed(let reason):
+			live.isTranscribing = false
+			switch reason {
+			case .finished, .cancelled:
+				break
+			case .failed(let error):
+				// The engine tears the socket down right after it commits an
+				// utterance, so a failure that arrives with words already in hand
+				// is the end of a good dictation, not a lost one.
+				if didTranscribeAnything {
+					AppLogger.shared.transcriber.info(
+						"Remote session closed after transcribing: \(error.localizedDescription)")
+				} else {
+					AppLogger.shared.transcriber.error(
+						"Remote session closed without a transcript: \(error.localizedDescription)")
+					finishStartIfPending(throwing: error)
+				}
+			}
+		}
+	}
+
+	private func finishStartIfPending(throwing error: Error?) {
+		let outcome: Result<Void, Error> = error.map { .failure($0) } ?? .success(())
+		guard let continuation = startContinuation else {
+			// Nobody is waiting yet. Keep the first outcome so the waiter that
+			// arrives next resolves on it rather than hanging.
+			if startOutcome == nil { startOutcome = outcome }
+			return
+		}
+		startContinuation = nil
+		startOutcome = nil
+		continuation.resume(with: outcome)
+	}
+
+	/// Waits for the session to reach `.listening`, or for the first failure.
+	private func awaitCaptureEstablished() async throws {
+		if let outcome = startOutcome {
+			startOutcome = nil
+			return try outcome.get()
+		}
+		try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+			startContinuation = continuation
+		}
+	}
+
+	private func teardown() {
+		eventTask?.cancel()
+		eventTask = nil
+		let closing = session
+		session = nil
+		wordTracker?.endSession()
+		wordTracker = nil
+		finishStartIfPending(throwing: CancellationError())
+		if let closing {
+			Task { await closing.cancel() }
+		}
+	}
+
+	// MARK: - Server resolution
+
+	private func directory() throws -> DictationServerDirectory {
+		guard let baseURL = baseURLProvider() else {
+			throw StreamingTranscriberError.invalidServerURL
+		}
+		return DictationServerDirectory(baseURL: baseURL, credentials: credentials)
+	}
+
+	/// Picks the server to stream through: the one the user named, otherwise the
+	/// backend's own default among those that report realtime support and are
+	/// online.
+	private func resolveServer() async throws -> DictationServer {
+		if let cachedServer { return cachedServer }
+
+		let directory = try directory()
+		let wanted = serverIdProvider()
+		let server: DictationServer?
+		if wanted.isEmpty {
+			server = try await directory.preferredRealtimeServer()
+		} else {
+			server = try await directory.servers().first { $0.id == wanted }
+		}
+
+		guard let server else {
+			throw StreamingTranscriberError.noRealtimeServer(requested: wanted)
+		}
+		guard server.supportsRealtime else {
+			throw StreamingTranscriberError.serverCannotStream(server.label)
+		}
+
+		cachedServer = server
+		state = .ready
+		AppLogger.shared.transcriber.info(
+			"Streaming through \(server.id) (\(server.model)); audio \(server.realtime?.audio?.encoding ?? "unknown") at \(server.realtime?.audio?.sampleRate ?? 0) Hz")
+		return server
+	}
+
+	private func configuration(for options: TranscriptionOptions) async throws
+		-> DictationConfiguration
+	{
+		guard let baseURL = baseURLProvider() else {
+			throw StreamingTranscriberError.invalidServerURL
+		}
+		let server = try await resolveServer()
+		return .backend(
+			baseURL, server: server.id, model: server.model, language: options.language)
+	}
+}
+
+enum StreamingTranscriberError: LocalizedError, Equatable {
+	case notSignedIn
+	case invalidServerURL
+	case noRealtimeServer(requested: String)
+	case serverCannotStream(String)
+
+	var errorDescription: String? {
+		switch self {
+		case .notSignedIn:
+			return "Streaming transcription needs an auth token (Account settings)."
+		case .invalidServerURL:
+			return "Invalid transcription server URL"
+		case .noRealtimeServer(let requested):
+			return requested.isEmpty
+				? "No transcription server on the backend supports streaming."
+				: "Transcription server '\(requested)' was not found on the backend."
+		case .serverCannotStream(let label):
+			return "\(label) does not support streaming transcription."
+		}
+	}
+}

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -56,6 +56,12 @@ final class StreamingTranscriber: SpeechTranscribing {
 	/// landed. The package emits it just before the whole-transcript event.
 	private var lastUtterance = ""
 	private var didTranscribeAnything = false
+	/// Set while the package is replacing a socket, so the `.connecting` that
+	/// follows a reconnect reads as recovery rather than as a fresh start.
+	private var isRecovering = false
+	/// Set the moment the user asks to stop, so a session that fails on the way
+	/// down after handing back words does not raise an alert about it.
+	private var isStopping = false
 
 	private(set) var state: TranscriptionEngineState = .unavailable(
 		"Not connected to a transcription server yet.")
@@ -169,9 +175,11 @@ final class StreamingTranscriber: SpeechTranscribing {
 
 	func startStreaming(options: TranscriptionOptions) async throws {
 		live.beginWaiting()
-		live.waitingForModelStatusText = "Connecting to \(serverIdProvider().isEmpty ? "transcription server" : serverIdProvider())..."
+		live.waitingForModelStatusText = "Connecting to \(destinationName)…"
 		lastUtterance = ""
 		didTranscribeAnything = false
+		isRecovering = false
+		isStopping = false
 		startOutcome = nil
 
 		do {
@@ -200,10 +208,9 @@ final class StreamingTranscriber: SpeechTranscribing {
 		} catch {
 			live.isWaitingForModel = false
 			live.isTranscribing = false
-			if live.waitingForModelStatusText.isEmpty {
-				live.waitingForModelStatusText = "Unable to start dictation."
-			}
-			live.shouldShowLiveTranscriptionWindow = true
+			live.waitingForModelStatusText = ""
+			live.shouldShowLiveTranscriptionWindow = false
+			report(error)
 			teardown()
 			AppLogger.shared.transcriber.error("Failed to start remote live stream: \(error)")
 			throw error
@@ -220,6 +227,7 @@ final class StreamingTranscriber: SpeechTranscribing {
 	}
 
 	func stopStreaming() {
+		isStopping = true
 		live.isWaitingForModel = false
 		live.waitingForModelStatusText = ""
 		live.isTranscribing = false
@@ -279,21 +287,43 @@ final class StreamingTranscriber: SpeechTranscribing {
 			onLiveAudioSamples?((0..<700).map { _ in level + Float.random(in: -0.02...0.02) })
 
 		case .failed(let error):
+			// Only terminal failures reach here — the package holds a recoverable one
+			// back while it replaces the socket, and reports it only once the budget
+			// is spent.
 			AppLogger.shared.transcriber.error("Remote dictation failed: \(error.localizedDescription)")
 			state = .unavailable(error.localizedDescription)
 			live.isWaitingForModel = true
-			live.waitingForModelStatusText = error.localizedDescription
+			live.waitingForModelStatusText = "Dictation stopped."
 			live.shouldShowLiveTranscriptionWindow = true
+			report(error)
 			finishStartIfPending(throwing: error)
 		}
 	}
 
 	private func handle(_ connectionState: DictationConnectionState) {
 		switch connectionState {
-		case .idle, .connecting, .finishing:
+		case .idle, .finishing:
 			break
 
+		case .connecting:
+			// A reconnect emits `.reconnecting` and then `.connecting` again. Without
+			// the flag the second one would read as a fresh connection and quietly
+			// drop the warning that words are being missed right now.
+			guard isRecovering else { break }
+			live.waitingForModelStatusText = "Reconnecting to \(destinationName)…"
+
+		case .reconnecting:
+			isRecovering = true
+			state = .preparing(progress: 0, status: "Reconnecting")
+			live.isWaitingForModel = true
+			live.waitingForModelStatusText = "Connection lost — reconnecting. Words spoken now are missed."
+			live.shouldShowLiveTranscriptionWindow = true
+
 		case .listening:
+			if isRecovering {
+				AppLogger.shared.transcriber.info("Remote session reconnected and is listening again")
+			}
+			isRecovering = false
 			state = .ready
 			live.isWaitingForModel = false
 			live.waitingForModelStatusText = ""
@@ -307,9 +337,8 @@ final class StreamingTranscriber: SpeechTranscribing {
 			case .finished, .cancelled:
 				break
 			case .failed(let error):
-				// The engine tears the socket down right after it commits an
-				// utterance, so a failure that arrives with words already in hand
-				// is the end of a good dictation, not a lost one.
+				// A failure that arrives with words already in hand at the moment the
+				// user is stopping is the end of a good dictation, not a lost one.
 				if didTranscribeAnything {
 					AppLogger.shared.transcriber.info(
 						"Remote session closed after transcribing: \(error.localizedDescription)")
@@ -320,6 +349,81 @@ final class StreamingTranscriber: SpeechTranscribing {
 				}
 			}
 		}
+	}
+
+	/// What to call the thing on the other end, in a sentence a user reads.
+	private var destinationName: String {
+		if isDirect() {
+			return baseURLProvider()?.host ?? "the transcription server"
+		}
+		let requested = serverIdProvider()
+		if !requested.isEmpty { return requested }
+		return cachedServer?.label ?? "the transcription server"
+	}
+
+	/// Turns a failure into something the user can act on, and raises it where it
+	/// will be seen. Silent while the user is already stopping a dictation that
+	/// produced words — interrupting them to report the end of a session they
+	/// ended, and got what they wanted from, would be noise.
+	private func report(_ error: Error) {
+		guard !(isStopping && didTranscribeAnything) else { return }
+		let failure = Self.failure(for: error, destination: destinationName)
+		live.failure = failure
+		AppLogger.shared.transcriber.error(
+			"Surfacing dictation failure: \(failure.title) — \(failure.message)")
+		NotificationCenter.default.post(name: .transcriptionFailureRaised, object: nil)
+	}
+
+	static func failure(for error: Error, destination: String) -> TranscriptionFailure {
+		let title = "Dictation stopped"
+		if let dictationError = error as? DictationError {
+			switch dictationError {
+			case .unauthorized, .credentialUnavailable:
+				return TranscriptionFailure(
+					title: title,
+					message:
+						"\(destination) rejected your credentials. Sign in again under Account settings, then start dictation again."
+				)
+			case .connectionFailed:
+				return TranscriptionFailure(
+					title: title,
+					message:
+						"Whispera could not reach \(destination). Check that the server is running and that this Mac can reach it on the network."
+				)
+			case .closedUnexpectedly:
+				return TranscriptionFailure(
+					title: title,
+					message:
+						"The connection to \(destination) dropped and reconnecting did not help. Check that the server is still running, then start dictation again."
+				)
+			case .protocolViolation:
+				return TranscriptionFailure(
+					title: title,
+					message:
+						"\(destination) answered with something Whispera did not understand. Check that the server URL points at an OpenAI-Realtime endpoint."
+				)
+			case .audioUnavailable:
+				return TranscriptionFailure(
+					title: title,
+					message:
+						"Whispera could not open the microphone. Check System Settings > Privacy & Security > Microphone."
+				)
+			case .server:
+				return TranscriptionFailure(
+					title: title,
+					message:
+						"\(destination) reported an error and reconnecting did not help. Its own log will say why; Whispera's log has the message it sent."
+				)
+			}
+		}
+		if let described = (error as? LocalizedError)?.errorDescription {
+			return TranscriptionFailure(title: title, message: described)
+		}
+		return TranscriptionFailure(
+			title: title,
+			message:
+				"Whispera could not run this dictation through \(destination). Check the server settings under Transcription."
+		)
 	}
 
 	private func finishStartIfPending(throwing error: Error?) {

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -19,8 +19,14 @@ import WhisperaDictation
 @MainActor
 final class StreamingTranscriber: SpeechTranscribing {
 	static let shared = StreamingTranscriber()
+	/// Same conformer, addressed straight at an engine. Separate instance because
+	/// each holds its own socket and resolved server.
+	static let direct = StreamingTranscriber(
+		baseURLProvider: { WhisperaSettings.transcriptionServerURL },
+		directProvider: { true })
 
-	nonisolated var engine: TranscriptionEngine { .whisperaStreaming }
+	private let engineCase: TranscriptionEngine
+	nonisolated var engine: TranscriptionEngine { engineCase }
 
 	/// One-shot transcription runs the same socket with a file or buffer source
 	/// instead of the microphone, so text mode works on this engine too.
@@ -34,6 +40,8 @@ final class StreamingTranscriber: SpeechTranscribing {
 	private let baseURLProvider: () -> URL?
 	private let serverIdProvider: () -> String
 	private let credentials: DictationCredentialProvider
+	private let isDirect: () -> Bool
+	private let directModel: () -> String
 
 	private var session: DictationSession?
 	private var eventTask: Task<Void, Never>?
@@ -55,10 +63,19 @@ final class StreamingTranscriber: SpeechTranscribing {
 	init(
 		baseURLProvider: @escaping () -> URL? = { WhisperaSettings.transcriptionServerURL },
 		serverIdProvider: @escaping () -> String = { WhisperaSettings.transcriptionServerId },
+		// Direct mode addresses an OpenAI-Realtime engine itself, with no Whispera
+		// backend in the path: no discovery to ask for a model, and no proxy to
+		// hold the engine's credentials. Useful on a trusted network, and the only
+		// shape available to a host that has no backend at all.
+		directProvider: @escaping () -> Bool = { false },
+		modelProvider: @escaping () -> String = { WhisperaSettings.transcriptionDirectModel },
 		tokenStore: AuthTokenStore = .shared
 	) {
 		self.baseURLProvider = baseURLProvider
 		self.serverIdProvider = serverIdProvider
+		self.isDirect = directProvider
+		self.directModel = modelProvider
+		self.engineCase = directProvider() ? .realtimeDirect : .whisperaStreaming
 		// Read at connect time and dropped afterwards, and re-read on the one
 		// unauthorized retry, so a short-lived session token survives it.
 		// A missing token is not fatal: a self-hosted proxy on a trusted network
@@ -73,6 +90,9 @@ final class StreamingTranscriber: SpeechTranscribing {
 	// MARK: - Lifecycle
 
 	func prepare() async throws {
+		// Direct mode has no registry to consult; the endpoint and model are the
+		// host's to state, and the first connect is what proves them.
+		guard !isDirect() else { return }
 		_ = try await resolveServer()
 	}
 
@@ -84,17 +104,25 @@ final class StreamingTranscriber: SpeechTranscribing {
 
 	// MARK: - Models
 
-	var activeModel: String? { cachedServer?.model }
+	var activeModel: String? { isDirect() ? directModel() : cachedServer?.model }
 
 	/// The backend lists one model per server, so the model list is the server
 	/// list. Selecting one records which server to stream through.
 	func models() async throws -> [TranscriptionModelInfo] {
-		try await directory().servers()
+		if isDirect() {
+			let model = directModel()
+			return [TranscriptionModelInfo(id: model, displayName: model)]
+		}
+		return try await directory().servers()
 			.filter { $0.supportsRealtime && $0.isOnline }
 			.map { TranscriptionModelInfo(id: $0.id, displayName: "\($0.label) — \($0.model)") }
 	}
 
 	func selectModel(_ id: String) async throws {
+		if isDirect() {
+			WhisperaSettings.transcriptionDirectModel = id
+			return
+		}
 		WhisperaSettings.transcriptionServerId = id
 		cachedServer = nil
 		_ = try await resolveServer()
@@ -389,6 +417,12 @@ final class StreamingTranscriber: SpeechTranscribing {
 	{
 		guard let baseURL = baseURLProvider() else {
 			throw StreamingTranscriberError.invalidServerURL
+		}
+		if isDirect() {
+			let model = directModel()
+			AppLogger.shared.transcriber.info(
+				"Streaming direct to \(baseURL.absoluteString) (\(model)); no backend in the path")
+			return .directEngine(baseURL, model: model, language: options.language)
 		}
 		let server = try await resolveServer()
 		return .backend(

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -409,12 +409,12 @@ final class StreamingTranscriber: SpeechTranscribing {
 				mode: sessionTwoPassMode,
 				options: sessionOptions,
 				generation: dictationGeneration)
-			// The paste is now waiting on the second pass. Saying so reuses the
-			// waiting channel the HUD already renders (and whose width rules
-			// already handle status text) instead of growing a new one.
-			live.isWaitingForModel = true
-			live.waitingForModelStatusText = "Polishing…"
-			live.shouldShowLiveTranscriptionWindow = true
+			// The paste is now waiting on the second pass. Announced on the
+			// finalize channel, which only the listening pill renders: the words
+			// window dismissed above, exactly as it does with the finalizer off,
+			// and must not come back for the polish. Routing this through
+			// isWaitingForModel put a second "Polishing…" capsule on screen.
+			live.beginFinalizing(statusText: "Polishing…")
 			AppLogger.shared.transcriber.info(
 				"Remote live streaming stopped; draft held for the two-pass finalizer (\(sessionTwoPassMode.rawValue))")
 			return transcript
@@ -447,9 +447,7 @@ final class StreamingTranscriber: SpeechTranscribing {
 		// The polishing status belongs to this dictation alone; if a newer one
 		// has started, it owns the HUD and nothing here may touch it.
 		if pending.generation == dictationGeneration {
-			live.isWaitingForModel = false
-			live.waitingForModelStatusText = ""
-			live.shouldShowLiveTranscriptionWindow = false
+			live.endFinalizing()
 		}
 
 		if let text = TwoPassPolicy.finalizedText(from: outcome) {

--- a/Client/StreamingTranscriber.swift
+++ b/Client/StreamingTranscriber.swift
@@ -253,6 +253,12 @@ final class StreamingTranscriber: SpeechTranscribing {
 
 			await session.start()
 			try await awaitCaptureEstablished()
+		} catch is CancellationError {
+			// The user stopped before capture was established. The stop path owns
+			// the state reset and the teardown; repeating either here would run
+			// against whatever dictation is current by the time this resumes, and
+			// there is no failure to report — ending a start is what was asked for.
+			throw CancellationError()
 		} catch {
 			live.isWaitingForModel = false
 			live.isTranscribing = false
@@ -280,61 +286,69 @@ final class StreamingTranscriber: SpeechTranscribing {
 		live.isWaitingForModel = false
 		live.waitingForModelStatusText = ""
 		live.isTranscribing = false
-		live.shouldShowLiveTranscriptionWindow = false
-		AudioDeviceManager.shared.restoreSystemDefault()
 
 		guard let session else {
 			teardown()
-			return live.confirmedText.trimmingCharacters(in: .whitespacesAndNewlines)
+			live.shouldShowLiveTranscriptionWindow = false
+			AudioDeviceManager.shared.restoreSystemDefault()
+			return LiveTranscriptionState.joined(
+				committed: live.confirmedText, draft: live.pendingText
+			).trimmingCharacters(in: .whitespacesAndNewlines)
 		}
 		self.session = nil
-		// Snapshot this dictation's plumbing before any await. The user can start
-		// a new dictation while the finish below is still waiting; from that
-		// moment the instance fields belong to the new session, and this stop's
-		// epilogue must only ever touch what it snapshotted — a late cleanup that
-		// cancels the new session's event task reads as "dictation randomly dies
-		// two seconds in", which is exactly the bug this shipped with.
 		let tracker = wordTracker
 		wordTracker = nil
 		let events = eventTask
 		eventTask = nil
+		// A start still waiting on `.listening` resolves now, so its failure path
+		// runs while this stop still owns the instance fields — not fifteen
+		// seconds later, against a newer dictation's session.
+		finishStartIfPending(throwing: CancellationError())
 
-		// A stop with nothing said must return in bounded time. finish() waits
-		// trailing silence plus the final-transcript timeout (~17 s) for an
-		// utterance that never existed; racing it against a deadline keeps the
-		// honest case (final lands ~0.6–1.3 s after the last word) and turns the
-		// silent case into a fast cancel.
-		let finished: String? = await withTaskGroup(of: String?.self) { group in
-			group.addTask { await session.finish() }
-			group.addTask {
-				try? await Task.sleep(nanoseconds: 3_500_000_000)
-				return nil
-			}
-			let first = await group.next() ?? nil
-			group.cancelAll()
-			return first
-		}
-		if finished == nil {
-			AppLogger.shared.transcriber.info(
-				"Stop deadline hit with no final transcript; cancelling the session")
-			await session.cancel()
-		}
+		// The transcript is already here: a streaming engine has fed every word
+		// into the live state as it was spoken, so the socket's close handshake
+		// adds nothing the paste needs. It used to gate the paste anyway, behind a
+		// 3.5 s deadline race — and in QA even the deadline never fired, because
+		// `addTask` children inherit this MainActor context and a wedged main
+		// thread starves the timer along with everything else. So the stop path
+		// now never suspends: take the words, hand them back, and let the close
+		// run behind it. The draft is included — for a native-delta engine those
+		// are real words the user spoke that the engine has not committed yet —
+		// and a trailing final that lands after this is dropped on purpose.
+		let transcript = LiveTranscriptionState.joined(
+			committed: live.confirmedText, draft: live.pendingText
+		).trimmingCharacters(in: .whitespacesAndNewlines)
 
-		let transcript = finished ?? live.confirmedText
-		let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-		// A new dictation may already own the shared live state; only the stop
-		// that is still current writes to it.
-		let superseded = self.session != nil
-		if !superseded {
-			if !trimmed.isEmpty {
-				live.ingest(committed: trimmed, draft: "")
-			}
-			live.setPending("")
+		// This method has no suspension point before returning, so no newer
+		// dictation can own the live state yet; promoting the draft here keeps
+		// what the tracker and the HUD saw consistent with what gets pasted.
+		if !transcript.isEmpty {
+			live.ingest(committed: transcript, draft: "")
 		}
+		live.setPending("")
+		live.shouldShowLiveTranscriptionWindow = false
 		tracker?.endSession()
 		events?.cancel()
-		AppLogger.shared.transcriber.info("Remote live streaming stopped")
-		return trimmed
+
+		// The epilogue may take as long as the network wants; it touches only
+		// this stop's snapshot, never the instance fields, which a newer dictation
+		// may already own. cancel(), not finish(): finish() waits out trailing
+		// silence plus the final-transcript timeout for a final this stop has
+		// already chosen to drop. The input device is restored only after the
+		// session's own microphone engine is down — switching the default device
+		// under a still-running AVAudioEngine is the main-thread wedge suspected
+		// in the QA hang — and only while no newer dictation has claimed it.
+		Task.detached { [weak self] in
+			await session.cancel()
+			await MainActor.run {
+				guard self?.session == nil else { return }
+				AudioDeviceManager.shared.restoreSystemDefault()
+			}
+		}
+
+		AppLogger.shared.transcriber.info(
+			"Remote live streaming stopped; returning the locally accumulated transcript")
+		return transcript
 	}
 
 	// MARK: - Events

--- a/Client/TranscriptionFailure.swift
+++ b/Client/TranscriptionFailure.swift
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// A dictation failure the user has to do something about.
+///
+/// Separate from the status line in the HUD, which is one line of state and has
+/// no room to explain anything. This is what an `.alert()` presents, so every
+/// message names the thing that failed and what to check. "InternalServerError"
+/// is not a message; "Whispera could not reach 192.168.50.140. Check that the
+/// server is running" is.
+struct TranscriptionFailure: Identifiable, Equatable {
+	let id = UUID()
+	let title: String
+	let message: String
+
+	static func == (lhs: TranscriptionFailure, rhs: TranscriptionFailure) -> Bool {
+		lhs.title == rhs.title && lhs.message == rhs.message
+	}
+}
+
+extension Notification.Name {
+	/// A dictation failed in a way the user has to act on. The app brings up
+	/// Settings, which is both where the alert is presented and where every one of
+	/// these failures is fixed.
+	static let transcriptionFailureRaised = Notification.Name("TranscriptionFailureRaised")
+}

--- a/Client/TranscriptionRouter.swift
+++ b/Client/TranscriptionRouter.swift
@@ -13,6 +13,17 @@ enum TranscriptionEngine: String, CaseIterable, Sendable {
 	case whisperaStreaming
 	case realtimeDirect
 
+	/// Whether the engine transcribes over a live socket to a server. These are the
+	/// engines that need a URL, and the ones live transcription is worth turning on
+	/// for — a server engine with it off records first and transcribes at the end,
+	/// which looks like the feature is broken.
+	var streamsFromAServer: Bool {
+		switch self {
+		case .whisperaStreaming, .realtimeDirect: return true
+		case .whisperKit, .whisperViaBYOK: return false
+		}
+	}
+
 	var displayName: String {
 		switch self {
 		case .whisperKit: return "WhisperKit (on-device)"

--- a/Client/TranscriptionRouter.swift
+++ b/Client/TranscriptionRouter.swift
@@ -11,12 +11,14 @@ enum TranscriptionEngine: String, CaseIterable, Sendable {
 	case whisperKit
 	case whisperViaBYOK
 	case whisperaStreaming
+	case realtimeDirect
 
 	var displayName: String {
 		switch self {
 		case .whisperKit: return "WhisperKit (on-device)"
 		case .whisperViaBYOK: return "OpenAI Whisper via your key"
 		case .whisperaStreaming: return "Whispera server (streaming)"
+		case .realtimeDirect: return "OpenAI-Realtime server (direct)"
 		}
 	}
 }
@@ -54,6 +56,17 @@ extension WhisperaSettings {
 
 	/// Which engine on that backend to stream through. Empty means "let the
 	/// backend's own `/transcription/servers` listing pick its default".
+	/// The model to ask a directly-addressed engine for. Only consulted in
+	/// `.realtimeDirect`: with no backend there is no `/transcription/servers`
+	/// to name one, so the host has to.
+	static var transcriptionDirectModel: String {
+		get {
+			let stored = UserDefaults.standard.string(forKey: "whisperaTranscriptionDirectModel") ?? ""
+			return stored.isEmpty ? "Systran/faster-distil-whisper-large-v3" : stored
+		}
+		set { UserDefaults.standard.set(newValue, forKey: "whisperaTranscriptionDirectModel") }
+	}
+
 	static var transcriptionServerId: String {
 		get { UserDefaults.standard.string(forKey: transcriptionServerIdKey) ?? "" }
 		set { UserDefaults.standard.set(newValue, forKey: transcriptionServerIdKey) }
@@ -89,6 +102,8 @@ struct TranscriptionRouter {
 			return RemoteBatchTranscriber.byok
 		case .whisperaStreaming:
 			return StreamingTranscriber.shared
+		case .realtimeDirect:
+			return StreamingTranscriber.direct
 		}
 	}
 }

--- a/Client/TranscriptionRouter.swift
+++ b/Client/TranscriptionRouter.swift
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// Where speech-to-text runs. Identity only — what each engine can do lives on
+/// the conformer as `TranscriptionCapabilities`, so adding a case never reopens
+/// a switch anywhere but here. WhisperKit stays the default (on-device, no
+/// network). See WHI-42, WHI-58.
+enum TranscriptionEngine: String, CaseIterable, Sendable {
+	case whisperKit
+	case whisperViaBYOK
+	case whisperaStreaming
+
+	var displayName: String {
+		switch self {
+		case .whisperKit: return "WhisperKit (on-device)"
+		case .whisperViaBYOK: return "OpenAI Whisper via your key"
+		case .whisperaStreaming: return "Whispera server (streaming)"
+		}
+	}
+}
+
+extension WhisperaSettings {
+	private static let engineKey = "whisperaTranscriptionEngine"
+	private static let transcriptionServerURLKey = "whisperaTranscriptionServerURL"
+	private static let transcriptionServerIdKey = "whisperaTranscriptionServerId"
+
+	/// Unknown raw values fall back to WhisperKit, so a persisted engine from a
+	/// build that had one we no longer ship degrades on-device instead of
+	/// trapping. Mirrors `llmMode`.
+	static var transcriptionEngine: TranscriptionEngine {
+		get {
+			TranscriptionEngine(rawValue: UserDefaults.standard.string(forKey: engineKey) ?? "")
+				?? .whisperKit
+		}
+		set { UserDefaults.standard.set(newValue.rawValue, forKey: engineKey) }
+	}
+
+	/// Base URL of the transcription backend. Separate from `serverURLString`
+	/// because the streaming proxy can live somewhere other than the account
+	/// backend; empty means "use the account backend".
+	static var transcriptionServerURLString: String {
+		get {
+			let stored = UserDefaults.standard.string(forKey: transcriptionServerURLKey) ?? ""
+			return stored.isEmpty ? serverURLString : stored
+		}
+		set { UserDefaults.standard.set(newValue, forKey: transcriptionServerURLKey) }
+	}
+
+	static var transcriptionServerURL: URL? {
+		URL(string: transcriptionServerURLString.trimmingCharacters(in: .whitespacesAndNewlines))
+	}
+
+	/// Which engine on that backend to stream through. Empty means "let the
+	/// backend's own `/transcription/servers` listing pick its default".
+	static var transcriptionServerId: String {
+		get { UserDefaults.standard.string(forKey: transcriptionServerIdKey) ?? "" }
+		set { UserDefaults.standard.set(newValue, forKey: transcriptionServerIdKey) }
+	}
+}
+
+/// Resolves the selected engine and hands back the conformer that runs it.
+/// Mirrors `RecipeRouter`.
+///
+/// The conformers are shared instances rather than freshly built ones: a
+/// streaming engine holds a live socket and a local engine holds a loaded
+/// model, so both have to outlive a single call.
+@MainActor
+struct TranscriptionRouter {
+	static let shared = TranscriptionRouter()
+
+	private let engineProvider: () -> TranscriptionEngine
+
+	init(engineProvider: @escaping () -> TranscriptionEngine = { WhisperaSettings.transcriptionEngine })
+	{
+		self.engineProvider = engineProvider
+	}
+
+	var selected: TranscriptionEngine { engineProvider() }
+
+	var active: SpeechTranscribing { Self.transcriber(for: engineProvider()) }
+
+	static func transcriber(for engine: TranscriptionEngine) -> SpeechTranscribing {
+		switch engine {
+		case .whisperKit:
+			return WhisperKitTranscriber.shared
+		case .whisperViaBYOK:
+			return RemoteBatchTranscriber.byok
+		case .whisperaStreaming:
+			return StreamingTranscriber.shared
+		}
+	}
+}

--- a/Client/TranscriptionRouter.swift
+++ b/Client/TranscriptionRouter.swift
@@ -42,10 +42,47 @@ enum TranscriptionEngine: String, CaseIterable, Sendable {
 	}
 }
 
+/// One-time split of the transcription-server URL into per-mode keys. The old
+/// single key was shared between the backend proxy (whisperaStreaming, e.g.
+/// http://127.0.0.1:3000) and a directly-addressed engine (realtimeDirect,
+/// e.g. http://192.168.50.140:8000/v1) — switching engines silently reused
+/// the other mode's URL and 404ed. The legacy value lands in whichever new
+/// key matches the engine that was selected when it was typed, so current
+/// setups keep working. Pure and defaults-injected so the whole table is
+/// testable against an isolated suite — see TranscriptionServerURLMigrationTests.
+enum TranscriptionServerURLMigration {
+	static let legacyKey = "whisperaTranscriptionServerURL"
+	static let migratedFlagKey = "whisperaTranscriptionServerURLKeysSplit"
+
+	static func migrateIfNeeded(in defaults: UserDefaults) {
+		guard !defaults.bool(forKey: migratedFlagKey) else { return }
+		defaults.set(true, forKey: migratedFlagKey)
+
+		let legacy = defaults.string(forKey: legacyKey) ?? ""
+		guard !legacy.isEmpty else { return }
+
+		let engine =
+			TranscriptionEngine(
+				rawValue: defaults.string(forKey: WhisperaSettings.transcriptionEngineKey) ?? "")
+			?? .auto
+		let destination =
+			engine == .realtimeDirect
+			? WhisperaSettings.transcriptionDirectURLKey
+			: WhisperaSettings.transcriptionBackendURLKey
+		// Never clobber a value the user already typed into a new key.
+		guard (defaults.string(forKey: destination) ?? "").isEmpty else { return }
+		defaults.set(legacy, forKey: destination)
+		AppLogger.shared.general.info(
+			"Split legacy transcription server URL into \(destination)")
+	}
+}
+
 extension WhisperaSettings {
-	private static let engineKey = "whisperaTranscriptionEngine"
-	private static let transcriptionServerURLKey = "whisperaTranscriptionServerURL"
-	private static let transcriptionServerIdKey = "whisperaTranscriptionServerId"
+	static let transcriptionEngineKey = "whisperaTranscriptionEngine"
+	static let transcriptionBackendURLKey = "whisperaTranscriptionBackendURL"
+	static let transcriptionDirectURLKey = "whisperaTranscriptionDirectURL"
+	static let transcriptionServerIdKey = "whisperaTranscriptionServerId"
+	static let transcriptionDirectModelKey = "whisperaTranscriptionDirectModel"
 
 	/// Unknown or absent raw values fall back to `auto` — a fresh install and a
 	/// build that had an engine this one no longer ships land on the same
@@ -53,25 +90,61 @@ extension WhisperaSettings {
 	/// whenever nothing is configured. Mirrors `llmMode`.
 	static var transcriptionEngine: TranscriptionEngine {
 		get {
-			TranscriptionEngine(rawValue: UserDefaults.standard.string(forKey: engineKey) ?? "")
+			TranscriptionEngine(
+				rawValue: UserDefaults.standard.string(forKey: transcriptionEngineKey) ?? "")
 				?? .auto
 		}
-		set { UserDefaults.standard.set(newValue.rawValue, forKey: engineKey) }
+		set { UserDefaults.standard.set(newValue.rawValue, forKey: transcriptionEngineKey) }
 	}
 
-	/// Base URL of the transcription backend. Separate from `serverURLString`
-	/// because the streaming proxy can live somewhere other than the account
-	/// backend; empty means "use the account backend".
-	static var transcriptionServerURLString: String {
+	/// Base URL of the Whispera transcription backend (the proxy `auto` and
+	/// `whisperaStreaming` talk to). Separate from `serverURLString` because the
+	/// streaming proxy can live somewhere other than the account backend; empty
+	/// means "use the account backend".
+	static var transcriptionBackendURLString: String {
 		get {
-			let stored = UserDefaults.standard.string(forKey: transcriptionServerURLKey) ?? ""
+			TranscriptionServerURLMigration.migrateIfNeeded(in: .standard)
+			let stored = UserDefaults.standard.string(forKey: transcriptionBackendURLKey) ?? ""
 			return stored.isEmpty ? serverURLString : stored
 		}
-		set { UserDefaults.standard.set(newValue, forKey: transcriptionServerURLKey) }
+		set { UserDefaults.standard.set(newValue, forKey: transcriptionBackendURLKey) }
 	}
 
-	static var transcriptionServerURL: URL? {
-		URL(string: transcriptionServerURLString.trimmingCharacters(in: .whitespacesAndNewlines))
+	static var transcriptionBackendURL: URL? { url(from: transcriptionBackendURLString) }
+
+	/// Base URL of a directly-addressed OpenAI-compatible engine (the
+	/// `realtimeDirect` mode), ending in /v1. Its own key rather than sharing the
+	/// backend's: the two are different machines with different URL shapes, and
+	/// one shared field meant switching engines silently kept the wrong one.
+	/// No account-server fallback — with no URL the direct engine is simply
+	/// unconfigured, which surfaces as `invalidServerURL` instead of a 404
+	/// against a server that is not an engine.
+	static var transcriptionDirectURLString: String {
+		get {
+			TranscriptionServerURLMigration.migrateIfNeeded(in: .standard)
+			return UserDefaults.standard.string(forKey: transcriptionDirectURLKey) ?? ""
+		}
+		set { UserDefaults.standard.set(newValue, forKey: transcriptionDirectURLKey) }
+	}
+
+	static var transcriptionDirectURL: URL? { url(from: transcriptionDirectURLString) }
+
+	/// The URL for whichever engine is currently selected. Read-only and routed
+	/// by engine: the streaming conformers' default `baseURLProvider` closures
+	/// (which live in a file another change owns right now) all read this one
+	/// property, and the routing is what guarantees each of them resolves the
+	/// URL that belongs to its mode.
+	static var transcriptionServerURLString: String {
+		transcriptionEngine == .realtimeDirect
+			? transcriptionDirectURLString
+			: transcriptionBackendURLString
+	}
+
+	static var transcriptionServerURL: URL? { url(from: transcriptionServerURLString) }
+
+	private static func url(from string: String) -> URL? {
+		let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+		return trimmed.isEmpty ? nil : URL(string: trimmed)
 	}
 
 	/// Which engine on that backend to stream through. Empty means "let the
@@ -81,10 +154,10 @@ extension WhisperaSettings {
 	/// to name one, so the host has to.
 	static var transcriptionDirectModel: String {
 		get {
-			let stored = UserDefaults.standard.string(forKey: "whisperaTranscriptionDirectModel") ?? ""
+			let stored = UserDefaults.standard.string(forKey: transcriptionDirectModelKey) ?? ""
 			return stored.isEmpty ? "Systran/faster-distil-whisper-large-v3" : stored
 		}
-		set { UserDefaults.standard.set(newValue, forKey: "whisperaTranscriptionDirectModel") }
+		set { UserDefaults.standard.set(newValue, forKey: transcriptionDirectModelKey) }
 	}
 
 	static var transcriptionServerId: String {

--- a/Client/TranscriptionRouter.swift
+++ b/Client/TranscriptionRouter.swift
@@ -5,9 +5,11 @@ import Foundation
 
 /// Where speech-to-text runs. Identity only — what each engine can do lives on
 /// the conformer as `TranscriptionCapabilities`, so adding a case never reopens
-/// a switch anywhere but here. WhisperKit stays the default (on-device, no
-/// network). See WHI-42, WHI-58.
+/// a switch anywhere but here. `auto` is the default for fresh installs: it
+/// decides between the others itself, so nobody has to configure anything to
+/// get the best path available. See WHI-42, WHI-58.
 enum TranscriptionEngine: String, CaseIterable, Sendable {
+	case auto
 	case whisperKit
 	case whisperViaBYOK
 	case whisperaStreaming
@@ -17,15 +19,21 @@ enum TranscriptionEngine: String, CaseIterable, Sendable {
 	/// engines that need a URL, and the ones live transcription is worth turning on
 	/// for — a server engine with it off records first and transcribes at the end,
 	/// which looks like the feature is broken.
+	///
+	/// `auto` answers `false` even though it may end up streaming: it resolves to
+	/// a *conformer* (`AutoTranscriber`) rather than to `StreamingTranscriber`
+	/// itself, so it is not "the streaming conformer" the way the other two are —
+	/// see `ServerEngineTests.everyServerEngineResolvesToTheStreamingConformer`.
 	var streamsFromAServer: Bool {
 		switch self {
 		case .whisperaStreaming, .realtimeDirect: return true
-		case .whisperKit, .whisperViaBYOK: return false
+		case .auto, .whisperKit, .whisperViaBYOK: return false
 		}
 	}
 
 	var displayName: String {
 		switch self {
+		case .auto: return "Automatic (recommended)"
 		case .whisperKit: return "WhisperKit (on-device)"
 		case .whisperViaBYOK: return "OpenAI Whisper via your key"
 		case .whisperaStreaming: return "Whispera server (streaming)"
@@ -39,13 +47,14 @@ extension WhisperaSettings {
 	private static let transcriptionServerURLKey = "whisperaTranscriptionServerURL"
 	private static let transcriptionServerIdKey = "whisperaTranscriptionServerId"
 
-	/// Unknown raw values fall back to WhisperKit, so a persisted engine from a
-	/// build that had one we no longer ship degrades on-device instead of
-	/// trapping. Mirrors `llmMode`.
+	/// Unknown or absent raw values fall back to `auto` — a fresh install and a
+	/// build that had an engine this one no longer ships land on the same
+	/// default, which is honest because `auto` degrades to on-device itself
+	/// whenever nothing is configured. Mirrors `llmMode`.
 	static var transcriptionEngine: TranscriptionEngine {
 		get {
 			TranscriptionEngine(rawValue: UserDefaults.standard.string(forKey: engineKey) ?? "")
-				?? .whisperKit
+				?? .auto
 		}
 		set { UserDefaults.standard.set(newValue.rawValue, forKey: engineKey) }
 	}
@@ -107,6 +116,8 @@ struct TranscriptionRouter {
 
 	static func transcriber(for engine: TranscriptionEngine) -> SpeechTranscribing {
 		switch engine {
+		case .auto:
+			return AutoTranscriber.shared
 		case .whisperKit:
 			return WhisperKitTranscriber.shared
 		case .whisperViaBYOK:

--- a/Client/TwoPassFinalizer.swift
+++ b/Client/TwoPassFinalizer.swift
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// Which engine re-reads the whole utterance once a live dictation stops.
+///
+/// The streaming engine commits words with no right context, which is what
+/// makes it fast and what caps its accuracy. A second pass over the session's
+/// retained audio trades the instant paste for a short "polishing" wait — only
+/// when the user turned it on, which is why `off` is the default.
+enum TwoPassFinalizerMode: String, CaseIterable, Sendable {
+	case off
+	case local
+	case server
+
+	/// Tolerates any stored garbage: a raw value from a build that shipped a
+	/// mode this one no longer does must degrade to off, not trap.
+	static func from(_ raw: String?) -> TwoPassFinalizerMode {
+		raw.flatMap(TwoPassFinalizerMode.init(rawValue:)) ?? .off
+	}
+
+	var isOn: Bool { self != .off }
+
+	/// Hard ceiling on the polishing wait. The user is staring at a HUD with
+	/// nothing pasted, so a pass that overruns is abandoned in favour of the
+	/// draft they would have had instantly. The server pass gets more headroom
+	/// because an upload rides the network on top of the transcription itself.
+	var deadline: TimeInterval {
+		switch self {
+		case .off: return 0
+		case .local: return 10
+		case .server: return 15
+		}
+	}
+
+	var displayName: String {
+		switch self {
+		case .off: return "Off"
+		case .local: return "On-device Whisper"
+		case .server: return "Server Whisper"
+		}
+	}
+}
+
+extension WhisperaSettings {
+	static let twoPassFinalizerKey = "whisperaTwoPassFinalizer"
+
+	/// Read at dictation start and held for the session, so flipping it in
+	/// Settings mid-recording changes the next dictation, not the running one.
+	static var twoPassFinalizer: TwoPassFinalizerMode {
+		get { .from(UserDefaults.standard.string(forKey: twoPassFinalizerKey)) }
+		set { UserDefaults.standard.set(newValue.rawValue, forKey: twoPassFinalizerKey) }
+	}
+}
+
+/// Little-endian mono PCM16 to the Float32 buffer the on-device engine and the
+/// WAV wrapper both want, resampled by linear interpolation.
+///
+/// Linear rather than AVAudioConverter because the input is raw `Data` off the
+/// session's retention buffer, not an AVAudioPCMBuffer, and a pure function
+/// over bytes is testable without CoreAudio. The missing low-pass means
+/// content between the target and source Nyquist (8–12 kHz for 24 kHz → 16 kHz)
+/// can alias, but speech energy sits almost entirely below 8 kHz and the
+/// second pass exists for words, not fidelity.
+enum PCM16Resampler {
+	static func float32Samples(
+		fromPCM16LittleEndian data: Data, sourceHz: Int, targetHz: Int
+	) -> [Float] {
+		guard sourceHz > 0, targetHz > 0 else { return [] }
+		// A trailing odd byte cannot be half a sample; dropping it beats letting
+		// it shift every later sample into byte-swapped noise.
+		let sampleCount = data.count / 2
+		guard sampleCount > 0 else { return [] }
+
+		var source = [Float](repeating: 0, count: sampleCount)
+		data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+			for index in 0..<sampleCount {
+				let low = UInt16(raw[index * 2])
+				let high = UInt16(raw[index * 2 + 1])
+				let value = Int16(bitPattern: (high << 8) | low)
+				// Divided by 32768 rather than Int16.max so -32768 lands exactly
+				// on -1.0 and no sample can leave [-1, 1).
+				source[index] = Float(value) / 32768.0
+			}
+		}
+		if sourceHz == targetHz { return source }
+
+		let ratio = Double(sourceHz) / Double(targetHz)
+		let outputCount = Int((Double(sampleCount) / ratio).rounded(.down))
+		guard outputCount > 0 else { return [] }
+
+		var output = [Float](repeating: 0, count: outputCount)
+		for n in 0..<outputCount {
+			let position = Double(n) * ratio
+			let index = Int(position)
+			let fraction = Float(position - Double(index))
+			let current = source[index]
+			// The last output sample can land on the final input sample exactly;
+			// clamping the neighbour keeps the interpolation in bounds.
+			let next = index + 1 < sampleCount ? source[index + 1] : current
+			output[n] = current + (next - current) * fraction
+		}
+		return output
+	}
+}
+
+/// How a second pass ended. One case carries text; every other case is a
+/// reason the streaming draft gets pasted instead.
+enum TwoPassOutcome: Equatable, Sendable {
+	case finalized(String)
+	case failed(String)
+	case deadlineExpired
+	case superseded
+	case noAudio
+}
+
+/// The fallback policy, pure so the whole decision table is testable: the
+/// finalizer's text wins only when it actually produced words; everything
+/// else — failure, deadline, supersession, silence — falls back to the draft.
+enum TwoPassPolicy {
+	/// The polished text to paste, or nil when the draft must be pasted.
+	static func finalizedText(from outcome: TwoPassOutcome) -> String? {
+		guard case .finalized(let text) = outcome else { return nil }
+		let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+		return trimmed.isEmpty ? nil : trimmed
+	}
+
+	/// One line for the log naming why the draft is being pasted; nil when the
+	/// finalizer won and there is nothing to explain.
+	static func fallbackReason(for outcome: TwoPassOutcome) -> String? {
+		switch outcome {
+		case .finalized(let text):
+			return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+				? "the second pass heard no speech" : nil
+		case .failed(let reason):
+			return reason
+		case .deadlineExpired:
+			return "the second pass overran its deadline"
+		case .superseded:
+			return "a newer dictation superseded the pass"
+		case .noAudio:
+			return "the session retained no audio"
+		}
+	}
+}
+
+/// Races a finalize pass against a wall clock, off the main actor.
+///
+/// Not a task group: a group waits for every child at scope exit, so a
+/// transcription that ignores its deadline would hold the "deadline" result
+/// hostage until it finished anyway. And not main-actor-inherited children:
+/// 845d8af showed a deadline timer that inherits a wedged main actor starves
+/// together with it and never fires. Two detached tasks race to resolve one
+/// continuation; the loser resumes into nothing, and the work task is left to
+/// wind down in the background after a cancel it is free to ignore.
+enum TwoPassDeadline {
+	static func race(
+		seconds: TimeInterval,
+		operation: @escaping @Sendable () async -> TwoPassOutcome
+	) async -> TwoPassOutcome {
+		guard seconds > 0 else { return await operation() }
+
+		let winner = FirstOutcome()
+		let work = Task.detached {
+			winner.resolve(await operation())
+		}
+		let deadline = Task.detached {
+			do {
+				try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+				winner.resolve(.deadlineExpired)
+			} catch {
+				// The only way this sleep throws is cancellation, and the only
+				// cancellation route is the race's own task — a newer dictation
+				// ending the wait.
+				winner.resolve(.superseded)
+			}
+		}
+		let outcome = await withTaskCancellationHandler {
+			await winner.value
+		} onCancel: {
+			winner.resolve(.superseded)
+		}
+		work.cancel()
+		deadline.cancel()
+		return outcome
+	}
+}
+
+/// Delivers the first outcome to exactly one waiter, whichever racer resolves
+/// first — same shape as `StreamingTranscriber`'s `ResumeOnce`, but carrying a
+/// value and tolerant of resolving before the waiter arrives.
+private final class FirstOutcome: @unchecked Sendable {
+	private let lock = NSLock()
+	private var outcome: TwoPassOutcome?
+	private var continuation: CheckedContinuation<TwoPassOutcome, Never>?
+
+	func resolve(_ outcome: TwoPassOutcome) {
+		lock.lock()
+		guard self.outcome == nil else {
+			lock.unlock()
+			return
+		}
+		self.outcome = outcome
+		let waiting = continuation
+		continuation = nil
+		lock.unlock()
+		waiting?.resume(returning: outcome)
+	}
+
+	var value: TwoPassOutcome {
+		get async {
+			await withCheckedContinuation { (waiting: CheckedContinuation<TwoPassOutcome, Never>) in
+				lock.lock()
+				if let outcome {
+					lock.unlock()
+					waiting.resume(returning: outcome)
+				} else {
+					continuation = waiting
+					lock.unlock()
+				}
+			}
+		}
+	}
+}

--- a/Client/WhisperKitTranscriber+Engine.swift
+++ b/Client/WhisperKitTranscriber+Engine.swift
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+
+/// The local conformer. Every member here forwards to a method that already
+/// existed, so WhisperKit's behaviour is the behaviour it had before WHI-58 —
+/// the protocol describes it rather than changing it.
+///
+/// The live decoding options stay derived from the user's persisted language and
+/// translation settings inside the transcriber, which is where they were
+/// derived before; `TranscriptionOptions.mode` is read only on the one-shot
+/// paths, where it was already an argument.
+extension WhisperKitTranscriber: SpeechTranscribing {
+	nonisolated var engine: TranscriptionEngine { .whisperKit }
+
+	nonisolated var capabilities: TranscriptionCapabilities {
+		[.fileTranscription, .bufferTranscription, .timestamps, .streaming, .managedModels, .translation]
+	}
+
+	var state: TranscriptionEngineState {
+		if isDownloadingModel {
+			return .preparing(
+				progress: downloadProgress, status: "Downloading \(downloadingModelName ?? "model")...")
+		}
+		if isInitializing {
+			return .preparing(progress: initializationProgress, status: initializationStatus)
+		}
+		if isModelLoading {
+			return .preparing(
+				progress: loadProgress, status: "Loading \(currentModel ?? selectedModel ?? "model")...")
+		}
+		if isCurrentModelLoaded() { return .ready }
+		if downloadedModels.isEmpty {
+			return .unavailable("No model downloaded. Download one in Settings.")
+		}
+		return .preparing(progress: 0, status: "Waiting for model...")
+	}
+
+	func prepare() async throws {
+		try await waitForReadyForTranscription()
+	}
+
+	// MARK: - Models
+
+	var activeModel: String? { currentModel }
+
+	func models() async throws -> [TranscriptionModelInfo] {
+		if availableModels.isEmpty {
+			try await refreshAvailableModels()
+		}
+		let downloaded = (try? await getDownloadedModels()) ?? downloadedModels
+		return availableModels.map { id in
+			TranscriptionModelInfo(
+				id: id,
+				displayName: WhisperKitTranscriber.getModelDisplayName(for: id),
+				isDownloaded: downloaded.contains(id))
+		}
+	}
+
+	func selectModel(_ id: String) async throws {
+		try await switchModel(to: id)
+	}
+
+	// MARK: - One-shot
+
+	func transcribe(fileAt url: URL, options: TranscriptionOptions) async throws -> String {
+		try await transcribe(audioURL: url, enableTranslation: options.mode == .translate)
+	}
+
+	func transcribe(samples: [Float], options: TranscriptionOptions) async throws -> String {
+		try await transcribeAudioArray(samples, enableTranslation: options.mode == .translate)
+	}
+
+	func transcribeWithTimestamps(fileAt url: URL, options: TranscriptionOptions) async throws
+		-> [TranscriptionSegment]
+	{
+		try await transcribeFileWithTimestamps(
+			at: url, enableTranslation: options.mode == .translate)
+	}
+
+	// MARK: - Streaming
+
+	func resetStreamingSession() {
+		clearLiveTranscriptionState()
+	}
+
+	func startStreaming(options: TranscriptionOptions) async throws {
+		try await liveStream()
+	}
+
+	func switchStreamingDevice() async {
+		await switchLiveStreamDevice()
+	}
+
+	func stopStreaming() {
+		stopLiveStream()
+	}
+}

--- a/Client/WhisperKitTranscriber+Engine.swift
+++ b/Client/WhisperKitTranscriber+Engine.swift
@@ -93,7 +93,12 @@ extension WhisperKitTranscriber: SpeechTranscribing {
 		await switchLiveStreamDevice()
 	}
 
-	func stopStreaming() {
+	@discardableResult
+	func stopStreaming() async -> String {
 		stopLiveStream()
+		// stopLiveStream() confirms the pending tail synchronously, so
+		// confirmedText already holds the whole transcript by the time it returns.
+		return LiveTranscriptionState.shared.confirmedText.trimmingCharacters(
+			in: .whitespacesAndNewlines)
 	}
 }

--- a/DictationWordTracker.swift
+++ b/DictationWordTracker.swift
@@ -46,16 +46,19 @@ enum CorrectionCommand {
 		}
 	}
 
+	/// Tracking only: a live dictation no longer types each confirmed segment as
+	/// it lands. Whispera pastes once, when the dictation ends (see
+	/// `AudioManager.applyAndPaste`/`stopLiveTranscription`), and the HUD is the
+	/// only place mid-dictation words show up. See WHI-58. `trackedWords` is
+	/// kept up to date regardless, since the correction commands below
+	/// (`processCorrectionCommand`/`executeCorrection`) still index into it.
 	private func handleConfirmedTextChange(_ fullText: String) {
 		guard isTrackingEnabled else { return }
 		let newContent = extractNewContent(from: fullText)
 		if !newContent.isEmpty {
 			trackWords(from: newContent)
-			Task {
-				await pasteText(newContent)
-			}
 		} else {
-			logger.debug("No new content to paste")
+			logger.debug("No new content to track")
 		}
 	}
 

--- a/LIVE-UI-RESULT.md
+++ b/LIVE-UI-RESULT.md
@@ -1,0 +1,236 @@
+# WHI-58 follow-up — one visual language for the pill and the live-words HUD
+
+Branch `ismatulla/whi-58-engine-protocol`. Not pushed, not merged, no PR.
+
+## Plan (written before editing views)
+
+1. Pull the pill's materials/type/spacing/motion out of `ListeningView.swift` +
+   `AudioMeterView.swift` into shared, reusable pieces.
+2. Rewrite `LiveTranscription/DictationView.swift` and
+   `LiveTranscription/LiveTranscriptionView.swift` to compose those pieces
+   instead of re-deriving their own chrome.
+3. Give the two windows a shared, testable notion of "where is the pill", and
+   make `LiveTranscriptionWindow` sit above it instead of following the caret.
+4. Confirm both engines render through `LiveTranscriptionState` with nothing
+   engine-specific left in the views.
+
+## What was extracted
+
+New file `What's up?/PillStyle.swift`:
+
+- `PillSpacing` — the design-language spacing scale (4/8/12/16/20/24) as named
+  constants, so paddings stop being magic numbers copied between files. In the
+  process, the three surfaces' padding (14/10, 14/10, 12/8) collapsed onto one
+  value (`md`/`sm` = 12/8) instead of three near-identical ones.
+- `PillTypography` — the `.rounded` caption for status lines, and the
+  body/title3 + primary/blue split that marks "the word being spoken right
+  now" in the word flow.
+- `PillIndicator` / `PillStatusRow` — one line of secondary status: a spinner
+  that settles into a static dot under Reduce Motion, a pulsing dot that
+  freezes under Reduce Motion, a static tinted icon, or nothing, plus caption
+  text. This replaced four separate hand-rolled spinner+text rows (two in
+  `ListeningView`, one in `DictationView`, one in the dead
+  `LiveTranscriptionView`) — one of which (`ListeningView`'s "preparing
+  model" row) had no Reduce Motion handling at all before this change.
+- `PillWordFlow` — the trailing run of live words, most recent one
+  emphasized, optional leading ellipsis. Used by `DictationView`, the
+  (currently unwired) `LiveTranscriptionView`, and the Settings preview.
+- `PillChrome` / `.pillChrome(cornerRadius:)` — the background: Liquid Glass
+  on macOS 26, otherwise the ultraThinMaterial + soft blue gradient border +
+  two-layer shadow every surface was reimplementing byte-for-byte. Applied to
+  `ListeningView`, `DictationView`, `LiveTranscriptionView`, and
+  `SettingsView`'s `LiveTranscriptionPreview` — that Settings preview was a
+  fifth copy of the exact same chrome + word-flow code, now deleted in favor
+  of the shared components so the preview can't drift from the real HUD.
+
+`AudioMeterView.swift` was already a clean, standalone, `Motion.meter`-driven
+component — left as-is; nothing to extract there.
+
+`ListeningView.swift` itself now calls `.pillChrome(cornerRadius:)` and
+`PillStatusRow` rather than owning the chrome — it's the source of the
+language, not a fourth copy of it.
+
+## Engine-agnostic check (decision 4)
+
+`LiveTranscription/DictationView.swift` and `LiveTranscriptionView.swift`
+already only touched `LiveTranscriptionState.shared`, never
+`WhisperKitTranscriber` — confirmed by grep, no change needed there. One real
+leftover was found and removed: `LiveTranscriptionState.currentText` (and its
+`WhisperKitTranscriber` passthrough) was a dead property nothing ever wrote to
+— `LiveTranscriptionView.swift` (unwired, but still compiled into the target)
+was the only reader, using it instead of the shared `stableDisplayText`. Cut
+over to `stableDisplayText` and deleted the dead property + passthrough +
+the placeholder-text filtering that only made sense for the old field.
+
+`ListeningView`'s direct reads of `WhisperKitTranscriber` (for the one-shot,
+non-streaming "preparing model" status while a local Whisper model loads) were
+left alone — that status is intrinsic to on-device loading, not something a
+remote engine has, and it's outside the two files decision 4 named.
+
+## Coordination design
+
+New file `What's up?/PillAnchor.swift`:
+
+- `PillAnchorProvider` (`@Observable`, `@MainActor`) — a one-writer,
+  many-reader broadcast of the pill's current on-screen frame (`nil` when the
+  pill is off screen). `ListeningWindow` is the only writer, publishing on
+  every place it already changes its own frame (initial show/hide, animated
+  resize, and the existing drag/external-resize observers). Nothing reaches
+  into `ListeningWindow`'s `NSWindow` from outside.
+- `PillAnchor.frame(for:screenFrame:pillFrame:)` — a pure function, no
+  `NSWindow`, no observation: given a surface size and the pill's frame (or
+  `nil`), returns the rect that surface should occupy. With a pill, the
+  surface is horizontally centered on the pill and its **bottom** edge sits
+  `PillMetrics.controlsGap` (8pt — the same gap the controls picker already
+  uses, not a second invented number) above the pill's top edge, so growth in
+  the surface's height reads as growing upward, never toward the pill. With no
+  pill (a transient racing the pill's own visibility notification, or shown
+  before the pill ever appears), it falls back to the pill's own bottom-center
+  resting spot (`PillMetrics.bottomAnchorFraction`), so it's never adrift.
+  Covered by `WhisperaUnitTests/PillAnchorTests.swift` (gap, no-overlap,
+  centering, grow-upward, follow-on-move, and the no-pill fallback) and
+  `PillAnchorProviderTests.swift` (publish/read/clear).
+
+`LiveTranscription/LiveTranscriptionWindow.swift` was rewritten:
+
+- Caret-following is gone. `AccessibilityHelper`'s caret APIs were only ever
+  called from this window (confirmed by grep across the repo), so nothing
+  else needed the code path decision 3 said to drop for the dictation
+  display; `followCaret`/`liveTranscriptionWindowOffset` Settings knobs are
+  removed from `SettingsView.swift` since neither controlled anything else.
+  `AccessibilityHelper.swift` itself is untouched — it's a general helper,
+  not something this task's decisions asked to remove.
+- The window now always resolves its position through
+  `PillAnchor.frame(...)` fed by `PillAnchorProvider.shared.pillFrame`. It
+  repositions on its existing 0.3s content-poll timer and, separately, the
+  moment the pill's frame changes (an `withObservationTracking` loop on
+  `PillAnchorProvider.shared.pillFrame`, the same pattern `ListeningWindow`
+  already uses for its own size presenters) — so a pill drag is followed on
+  the next layout pass without this window polling the pill itself.
+- First appearance rises into place (fade + short upward rise) rather than
+  popping in, matching the reveal language `ListeningWindow` already uses for
+  its controls panel — one shared motion vocabulary, not two.
+- Made non-movable and click-through (`isMovable = false`,
+  `ignoresMouseEvents = true`). Before, it was independently draggable; now
+  that it re-homes above the pill on every layout pass, an independent drag
+  would immediately be overridden and just fight the user. Dragging the pill
+  is how you move the whole assembly. `DictationView`'s content has no
+  interactive controls, so this has no functional cost.
+- The recipe-error toast keeps using this same window and the same
+  `PillAnchor` fallback path — it already anchored at bottom-center before
+  this change; now it's the identical code path the live words use, not a
+  parallel implementation of "bottom center."
+
+`RecordingWindowPolicy` (`AudioManager/AudioManager.swift`) changed from
+"exactly one of the two windows is eligible per mode" to: the listening pill
+is the persistent home for recording/transcribing status in **both** modes
+(`shouldShowListeningWindow` now depends only on `state != .idle`); the
+live-words window still only shows in live mode, and only once there is
+something transient to say. This is the behavioral pivot that makes
+requirement 3 ("when the pill is visible, the live window sits above it")
+meaningful — before this change the two were mutually exclusive by
+construction, so "above it" never applied. `DictationView`'s old fallback
+branch (rendering an embedded `ListeningView` mic/meter row when live mode had
+no words yet) was deleted since the real pill now already covers that.
+`WhisperaUnitTests/RecordingWindowPolicyTests.swift` was rewritten for the new
+contract (this suite is not in the DoD's "must stay green" list, since its
+old assertions encoded the behavior this task deliberately reverses).
+
+## What was run
+
+Built and tested on the configured remote build Mac (this Mac has no Xcode):
+
+```
+rsync … whi-58/ → 192.168.50.89:~/Developer/whispera-worktrees/whi-58-sync/
+xcodebuild -scheme Whispera -project Whispera.xcodeproj -configuration Debug \
+  -destination "platform=macOS,arch=arm64" -derivedDataPath build/chk \
+  CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO build
+```
+→ **BUILD SUCCEEDED**.
+
+Adding the two new source files to the target required manual
+`project.pbxproj` edits (`PBXBuildFile`/`PBXFileReference`/group/Sources-phase
+entries) — `What's up?/` and `LiveTranscription/` are plain `PBXGroup`s, not
+`PBXFileSystemSynchronizedRootGroup`s like `WhisperaUnitTests/`, so new files
+there don't get picked up automatically. Verified with `plutil -lint` before
+building.
+
+Tests (`xcodebuild test -only-testing:…`), the exact required suites plus the
+new coordination tests:
+
+```
+WhisperaUnitTests/LiveTranscriptionSegmentBufferTests
+WhisperaUnitTests/LiveTranscriptionFlickerFilterTests
+WhisperaUnitTests/LiveTranscriptionRemoteIngestTests   (LiveTranscriptionStateTests.swift)
+WhisperaUnitTests/TranscriptionRouterTests
+WhisperaUnitTests/TranscriptionFailureMessageTests     (the DoD's "TranscriptionFailureTests" — the struct itself is named TranscriptionFailureMessageTests)
+WhisperaUnitTests/SystemAudioMuterTests
+WhisperaUnitTests/DeviceSwitchRouteTests
+WhisperaUnitTests/FailedActivationHealingTests
+WhisperaUnitTests/RecordingSegmentLoadingTests
+WhisperaUnitTests/RecordingWindowPolicyTests
+WhisperaUnitTests/InitialDefaultsTests
+WhisperaUnitTests/PillAnchorTests               (new)
+WhisperaUnitTests/PillAnchorProviderTests       (new)
+```
+
+First two attempts hit the documented pre-existing flake ("Early unexpected
+exit, operation never finished bootstrapping") as a **total** bootstrap
+failure (0 of N tests ran), which was worse than the "reddens the summary"
+description. Root cause: a stray `xcodebuild test` process from an earlier,
+unrelated session was still running against the same `whi-58-sync` checkout
+on the shared build Mac (`ps aux` showed it PID 33551, started the previous
+evening, apparently hung mid `Resolve Package Graph`), fighting the new run
+for the single-instance `Whispera.app` identity. Killed it
+(`kill -9 33551 33546`) — did not touch the separately-running
+`/Applications/Whispera.app` (16330), since the orchestrator owns that — and
+reran. Result: **71 passed, 0 real failures**; the only 3 reported
+"failures" were the same known infra flake as three duplicate
+"Whispera (NNNNN) encountered an error" system entries, not assertion
+failures — every actual `#expect`/`XCTAssert` in the run passed, confirmed by
+reading the full test-case log and the `xcresulttool` summary. If a
+similarly stuck process reappears, it's a shared-Mac hygiene issue, not
+something introduced by this change.
+
+## What could not be verified without a microphone
+
+This Mac's lid is shut / no usable mic, and the owner does voice QA
+personally. Specifically unverified:
+
+- The live-words HUD actually rising above the real pill with real streaming
+  words from either engine (local WhisperKit or the remote realtimeDirect
+  engine), including the upward growth as more words arrive.
+- Dragging the pill mid-dictation and watching the HUD re-home on the next
+  layout pass.
+- The macOS 26 Liquid Glass rendering path for `pillChrome` (this build ran
+  against macOS 26.4.1 but no visual/screenshot check was done — Liquid Glass
+  is applied through `#available(macOS 26.0, *)`, same gate as the original
+  code).
+- Reduced-motion visuals in practice (System Settings → Accessibility →
+  Reduce Motion), beyond the fact that every animated path is code-gated on
+  `Motion.systemReduceMotion` / `accessibilityReduceMotion`.
+- The recipe-error toast's rise animation and the live-words HUD's own
+  first-appearance rise, visually.
+- `WHISPERA_AUTOSTART_DICTATION` was not exercised in this pass — the build
+  was verified with `xcodebuild build`/`test` only, per "build-check only;
+  the orchestrator handles install," and no build was installed to
+  `/Applications`.
+
+## Files touched
+
+- `What's up?/PillStyle.swift` (new)
+- `What's up?/PillAnchor.swift` (new)
+- `What's up?/ListeningView.swift`
+- `What's up?/ListeningWindow.swift`
+- `LiveTranscription/DictationView.swift`
+- `LiveTranscription/LiveTranscriptionView.swift`
+- `LiveTranscription/LiveTranscriptionWindow.swift`
+- `AudioManager/AudioManager.swift` (`RecordingWindowPolicy`)
+- `Client/LiveTranscriptionState.swift` (dropped dead `currentText`)
+- `WhisperKitTranscriber.swift` (dropped the `currentText` passthrough)
+- `SettingsView.swift` (dropped follow-caret/window-offset controls, shared
+  `LiveTranscriptionPreview` styling)
+- `Whispera.xcodeproj/project.pbxproj` (new files wired into the target)
+- `WhisperaUnitTests/RecordingWindowPolicyTests.swift` (updated for the new
+  policy)
+- `WhisperaUnitTests/PillAnchorTests.swift` (new)

--- a/LiveTranscription/DictationView.swift
+++ b/LiveTranscription/DictationView.swift
@@ -17,125 +17,44 @@ struct DictationView: View {
 		self.audioManager = audioManager
 	}
 
-	private var displayWords: [(text: String, isLast: Bool)] {
-		let words = live.stableDisplayText
-			.split(separator: " ")
-			.map(String.init)
-
-		guard !words.isEmpty else { return [] }
-
-		// Take only the last N words
-		let wordsToShow = words.suffix(maxWordsToShow)
-
-		return wordsToShow.enumerated().map { index, word in
-			(text: word, isLast: index == wordsToShow.count - 1)
-		}
+	private var displayWords: [String] {
+		Array(
+			live.stableDisplayText
+				.split(separator: " ")
+				.map(String.init)
+				.suffix(maxWordsToShow))
 	}
 
-	var body: some View {
-		VStack(spacing: 0) {
-			if let overlayError = coordinator.overlayError {
-				errorIndicator(overlayError)
-			} else if live.isWaitingForModel {
-				HStack(spacing: 8) {
-					// A spinner is indeterminate motion that never settles, which is
-					// exactly what reduced motion asks us not to draw. The dot says the
-					// same thing — something is in progress — and holds still.
-					if reduceMotion {
-						Image(systemName: "circle.dotted")
-							.imageScale(.small)
-							.foregroundColor(.secondary)
-					} else {
-						ProgressView()
-							.scaleEffect(0.7)
-					}
-					Text(live.waitingForModelStatusText)
-						.font(.system(.caption, design: .rounded))
-						.foregroundColor(.secondary)
-						.lineLimit(1)
-						.animation(.easeInOut(duration: 0.2), value: live.waitingForModelStatusText)
-				}
-				.padding(.horizontal, 14)
-				.padding(.vertical, 10)
-				.transition(.opacity.combined(with: .scale(scale: 0.95)))
-			} else if !live.stableDisplayText.isEmpty {
-				HStack(spacing: 4) {
-					if showEllipsis
-						&& live.stableDisplayText.split(separator: " ").count > maxWordsToShow
-					{
-						Text("...")
-							.font(.system(.body, design: .rounded))
-							.foregroundColor(Color.secondary.opacity(0.6))
-							.padding(.trailing, 2)
-					}
+	private var hasHiddenWords: Bool {
+		showEllipsis && live.stableDisplayText.split(separator: " ").count > maxWordsToShow
+	}
 
-					ForEach(Array(displayWords.enumerated()), id: \.offset) { _, wordInfo in
-						Text(wordInfo.text)
-							.font(.system(wordInfo.isLast ? .title3 : .body, design: .rounded))
-							.foregroundColor(wordInfo.isLast ? Color.blue : Color.primary.opacity(0.8))
-							.fontWeight(wordInfo.isLast ? .semibold : .regular)
-							.animation(.easeInOut(duration: 0.15), value: wordInfo.isLast)
-					}
-				}
-				.padding(.horizontal, 14)
-				.padding(.vertical, 10)
+	// This window is the pill's overlay for the transient things a live session
+	// says beyond "I am listening" — the pill underneath already covers that.
+	// See RecordingWindowPolicy and PillAnchor.
+	var body: some View {
+		Group {
+			if let overlayError = coordinator.overlayError {
+				PillStatusRow(
+					indicator: .icon("exclamationmark.triangle.fill", .orange),
+					text: overlayError,
+					textColor: .primary
+				)
 				.transition(.opacity.combined(with: .scale(scale: 0.95)))
-			} else if live.isTranscribing {
-				ListeningView(audioManager: audioManager)
+			} else if live.isWaitingForModel {
+				PillStatusRow(indicator: .progress, text: live.waitingForModelStatusText)
+					.animation(.easeInOut(duration: 0.2), value: live.waitingForModelStatusText)
+					.transition(.opacity.combined(with: .scale(scale: 0.95)))
+			} else if !live.stableDisplayText.isEmpty {
+				PillWordFlow(words: displayWords, showEllipsis: hasHiddenWords)
+					.transition(.opacity.combined(with: .scale(scale: 0.95)))
 			}
 		}
-		.animation(
-			reduceMotion ? nil : .easeInOut(duration: 0.2), value: live.isWaitingForModel
-		)
+		.padding(.horizontal, PillSpacing.md)
+		.padding(.vertical, PillSpacing.sm)
+		.animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: live.isWaitingForModel)
 		.fixedSize()
-		.background(
-			RoundedRectangle(cornerRadius: cornerRadius)
-				.fill(.ultraThinMaterial)
-				.overlay(
-					RoundedRectangle(cornerRadius: cornerRadius)
-						.fill(
-							LinearGradient(
-								colors: [
-									Color.blue.opacity(0.05),
-									Color.blue.opacity(0.02),
-								],
-								startPoint: .topLeading,
-								endPoint: .bottomTrailing
-							)
-						)
-				)
-		)
-		.overlay(
-			RoundedRectangle(cornerRadius: cornerRadius)
-				.strokeBorder(
-					LinearGradient(
-						colors: [
-							Color.blue.opacity(0.3),
-							Color.blue.opacity(0.1),
-						],
-						startPoint: .topLeading,
-						endPoint: .bottomTrailing
-					),
-					lineWidth: 1
-				)
-		)
-		.shadow(color: Color.blue.opacity(0.1), radius: 8, x: 0, y: 2)
-		.shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 1)
-	}
-
-	private func errorIndicator(_ message: String) -> some View {
-		HStack(spacing: 6) {
-			Image(systemName: "exclamationmark.triangle.fill")
-				.foregroundColor(.orange)
-				.imageScale(.small)
-			Text(message)
-				.font(.system(.caption, design: .rounded))
-				.foregroundColor(.primary)
-				.lineLimit(2)
-		}
-		.padding(.horizontal, 14)
-		.padding(.vertical, 10)
-		.transition(.opacity.combined(with: .scale(scale: 0.95)))
+		.pillChrome(cornerRadius: cornerRadius)
 	}
 }
 

--- a/LiveTranscription/DictationView.swift
+++ b/LiveTranscription/DictationView.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 
 struct DictationView: View {
-	@Bindable private var whisperKit = WhisperKitTranscriber.shared
+	// Bound to the shared live state rather than one engine, so whichever engine
+	// is transcribing reaches this view. See WHI-58.
+	@Bindable private var live = LiveTranscriptionState.shared
 	@State private var coordinator = DictationCoordinator.shared
 	private let audioManager: AudioManager
 
@@ -15,7 +17,7 @@ struct DictationView: View {
 	}
 
 	private var displayWords: [(text: String, isLast: Bool)] {
-		let words = whisperKit.stableDisplayText
+		let words = live.stableDisplayText
 			.split(separator: " ")
 			.map(String.init)
 
@@ -34,11 +36,11 @@ struct DictationView: View {
 		VStack(spacing: 0) {
 			if let overlayError = coordinator.overlayError {
 				errorIndicator(overlayError)
-			} else if whisperKit.isWaitingForModel {
+			} else if live.isWaitingForModel {
 				HStack(spacing: 8) {
 					ProgressView()
 						.scaleEffect(0.7)
-					Text(whisperKit.waitingForModelStatusText)
+					Text(live.waitingForModelStatusText)
 						.font(.system(.caption, design: .rounded))
 						.foregroundColor(.secondary)
 						.lineLimit(1)
@@ -46,10 +48,10 @@ struct DictationView: View {
 				.padding(.horizontal, 14)
 				.padding(.vertical, 10)
 				.transition(.opacity.combined(with: .scale(scale: 0.95)))
-			} else if !whisperKit.stableDisplayText.isEmpty {
+			} else if !live.stableDisplayText.isEmpty {
 				HStack(spacing: 4) {
 					if showEllipsis
-						&& whisperKit.stableDisplayText.split(separator: " ").count > maxWordsToShow
+						&& live.stableDisplayText.split(separator: " ").count > maxWordsToShow
 					{
 						Text("...")
 							.font(.system(.body, design: .rounded))
@@ -68,7 +70,7 @@ struct DictationView: View {
 				.padding(.horizontal, 14)
 				.padding(.vertical, 10)
 				.transition(.opacity.combined(with: .scale(scale: 0.95)))
-			} else if whisperKit.isTranscribing {
+			} else if live.isTranscribing {
 				ListeningView(audioManager: audioManager)
 			}
 		}

--- a/LiveTranscription/DictationView.swift
+++ b/LiveTranscription/DictationView.swift
@@ -13,6 +13,13 @@ struct DictationView: View {
 	@AppStorage("liveTranscriptionCornerRadius") private var cornerRadius = 10.0
 	@AppStorage("liveTranscriptionShowEllipsis") private var showEllipsis = true
 
+	// The last non-empty run of words, held so a display text that blanks for a
+	// beat mid-session cannot blink the sentence away — the mid-sentence
+	// disappearing the WHI-58 QA session reported. Cleared when the session
+	// ends, so a new dictation never opens on the previous one's words.
+	@State private var heldWords: [String] = []
+	@State private var heldEllipsis = false
+
 	init(audioManager: AudioManager) {
 		self.audioManager = audioManager
 	}
@@ -27,6 +34,14 @@ struct DictationView: View {
 
 	private var hasHiddenWords: Bool {
 		showEllipsis && live.stableDisplayText.split(separator: " ").count > maxWordsToShow
+	}
+
+	private var wordsToShow: [String] {
+		displayWords.isEmpty ? heldWords : displayWords
+	}
+
+	private var ellipsisToShow: Bool {
+		displayWords.isEmpty ? heldEllipsis : hasHiddenWords
 	}
 
 	// This window is the pill's overlay for the transient things a live session
@@ -45,16 +60,39 @@ struct DictationView: View {
 				PillStatusRow(indicator: .progress, text: live.waitingForModelStatusText)
 					.animation(.easeInOut(duration: 0.2), value: live.waitingForModelStatusText)
 					.transition(.opacity.combined(with: .scale(scale: 0.95)))
-			} else if !live.stableDisplayText.isEmpty {
-				PillWordFlow(words: displayWords, showEllipsis: hasHiddenWords)
+			} else if !wordsToShow.isEmpty {
+				PillWordFlow(words: wordsToShow, showEllipsis: ellipsisToShow)
+					// The ticker keeps its natural width and clips at the leading
+					// edge: the newest words hug the trailing edge — the half of
+					// the sentence the speaker is actually tracking — while older
+					// words slide out of view instead of stretching the frame.
+					.fixedSize()
+					.frame(maxWidth: .infinity, alignment: .trailing)
+					.clipped()
 					.transition(.opacity.combined(with: .scale(scale: 0.95)))
 			}
 		}
 		.padding(.horizontal, PillSpacing.md)
 		.padding(.vertical, PillSpacing.sm)
 		.animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: live.isWaitingForModel)
-		.fixedSize()
+		// The chrome spans the whole window: LiveTranscriptionWindow's frame
+		// follows the calm DictationHUDWidth rule, and filling it is what makes
+		// the visible pill grow in steady steps instead of re-fitting — and
+		// re-centering — around every new word.
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
 		.pillChrome(cornerRadius: cornerRadius)
+		.onChange(of: live.stableDisplayText) {
+			if !displayWords.isEmpty {
+				heldWords = displayWords
+				heldEllipsis = hasHiddenWords
+			}
+		}
+		.onChange(of: live.isTranscribing) { _, isTranscribing in
+			if !isTranscribing {
+				heldWords = []
+				heldEllipsis = false
+			}
+		}
 	}
 }
 

--- a/LiveTranscription/DictationView.swift
+++ b/LiveTranscription/DictationView.swift
@@ -5,6 +5,7 @@ struct DictationView: View {
 	// is transcribing reaches this view. See WHI-58.
 	@Bindable private var live = LiveTranscriptionState.shared
 	@State private var coordinator = DictationCoordinator.shared
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	private let audioManager: AudioManager
 
 	// Live transcription customization settings
@@ -25,7 +26,6 @@ struct DictationView: View {
 
 		// Take only the last N words
 		let wordsToShow = words.suffix(maxWordsToShow)
-		let startIndex = words.count - wordsToShow.count
 
 		return wordsToShow.enumerated().map { index, word in
 			(text: word, isLast: index == wordsToShow.count - 1)
@@ -38,12 +38,22 @@ struct DictationView: View {
 				errorIndicator(overlayError)
 			} else if live.isWaitingForModel {
 				HStack(spacing: 8) {
-					ProgressView()
-						.scaleEffect(0.7)
+					// A spinner is indeterminate motion that never settles, which is
+					// exactly what reduced motion asks us not to draw. The dot says the
+					// same thing — something is in progress — and holds still.
+					if reduceMotion {
+						Image(systemName: "circle.dotted")
+							.imageScale(.small)
+							.foregroundColor(.secondary)
+					} else {
+						ProgressView()
+							.scaleEffect(0.7)
+					}
 					Text(live.waitingForModelStatusText)
 						.font(.system(.caption, design: .rounded))
 						.foregroundColor(.secondary)
 						.lineLimit(1)
+						.animation(.easeInOut(duration: 0.2), value: live.waitingForModelStatusText)
 				}
 				.padding(.horizontal, 14)
 				.padding(.vertical, 10)
@@ -74,6 +84,9 @@ struct DictationView: View {
 				ListeningView(audioManager: audioManager)
 			}
 		}
+		.animation(
+			reduceMotion ? nil : .easeInOut(duration: 0.2), value: live.isWaitingForModel
+		)
 		.fixedSize()
 		.background(
 			RoundedRectangle(cornerRadius: cornerRadius)

--- a/LiveTranscription/DictationView.swift
+++ b/LiveTranscription/DictationView.swift
@@ -62,12 +62,15 @@ struct DictationView: View {
 					.transition(.opacity.combined(with: .scale(scale: 0.95)))
 			} else if !wordsToShow.isEmpty {
 				PillWordFlow(words: wordsToShow, showEllipsis: ellipsisToShow)
-					// The ticker keeps its natural width and clips at the leading
-					// edge: the newest words hug the trailing edge — the half of
-					// the sentence the speaker is actually tracking — while older
-					// words slide out of view instead of stretching the frame.
+					// The ticker keeps its natural width. With hidden history the
+					// ellipsis marks a sentence continuing off the leading edge, so
+					// the text hugs the trailing edge and older words slide out of
+					// view. With the whole transcript on screen there is no "more"
+					// side: any slack the frame's quantized width leaves splits
+					// evenly instead of pooling left of trailing-aligned text —
+					// the leftover gap the WHI-58 QA follow-up kept seeing.
 					.fixedSize()
-					.frame(maxWidth: .infinity, alignment: .trailing)
+					.frame(maxWidth: .infinity, alignment: ellipsisToShow ? .trailing : .center)
 					.clipped()
 					.transition(.opacity.combined(with: .scale(scale: 0.95)))
 			}

--- a/LiveTranscription/LiveTranscriptionView.swift
+++ b/LiveTranscription/LiveTranscriptionView.swift
@@ -4,19 +4,12 @@ struct LiveTranscriptionView: View {
 	// Bound to the shared live state rather than one engine, so whichever engine
 	// is transcribing reaches this view. See WHI-58.
 	@Bindable private var live = LiveTranscriptionState.shared
-	@State private var lastDisplayedText: String = ""
 
 	// Show only the last few words being transcribed
 	private var latestWords: String {
-		let currentText = live.currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+		let currentText = live.stableDisplayText.trimmingCharacters(in: .whitespacesAndNewlines)
 
-		// Filter out WhisperKit's default messages
-		if currentText.isEmpty || currentText.contains("Waiting for speech")
-			|| currentText.contains("Listening") || currentText.contains("waiting for speech")
-			|| currentText.contains("listening")
-		{
-			return ""
-		}
+		guard !currentText.isEmpty else { return "" }
 
 		// Get the last 6-8 words to show recent context
 		let words = currentText.components(separatedBy: .whitespacesAndNewlines)
@@ -29,41 +22,16 @@ struct LiveTranscriptionView: View {
 	}
 
 	var body: some View {
-		VStack(spacing: 0) {
+		Group {
 			if !latestWords.isEmpty {
-				// Show only the latest words being transcribed
-				Text(latestWords)
-					.font(.system(.body, design: .rounded))
-					.foregroundColor(.primary)
-					.multilineTextAlignment(.leading)
-					.lineLimit(2)  // Maximum 2 lines
-					.padding(.horizontal, 12)
-					.padding(.vertical, 8)
-					.animation(.none, value: latestWords)  // No animation to prevent rewrites
+				PillWordFlow(words: latestWords.split(separator: " ").map(String.init))
 			} else if live.isTranscribing {
-				// Minimal listening indicator
-				HStack(spacing: 6) {
-					Circle()
-						.fill(.blue)
-						.frame(width: 4, height: 4)
-						.scaleEffect(live.isTranscribing ? 1.2 : 1.0)
-						.animation(
-							.easeInOut(duration: 1.0).repeatForever(autoreverses: true),
-							value: live.isTranscribing)
-
-					Text("Listening...")
-						.font(.system(.caption, design: .rounded))
-						.foregroundColor(.secondary)
-				}
-				.padding(.horizontal, 12)
-				.padding(.vertical, 8)
+				PillStatusRow(indicator: .pulse(.blue), text: "Listening...")
 			}
 		}
-		.background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-		.overlay(
-			RoundedRectangle(cornerRadius: 8)
-				.stroke(.primary.opacity(0.1), lineWidth: 1)
-		)
-		.shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 2)
+		.padding(.horizontal, PillSpacing.md)
+		.padding(.vertical, PillSpacing.sm)
+		.animation(.none, value: latestWords)  // No animation to prevent rewrites
+		.pillChrome()
 	}
 }

--- a/LiveTranscription/LiveTranscriptionView.swift
+++ b/LiveTranscription/LiveTranscriptionView.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
 struct LiveTranscriptionView: View {
-	@Bindable private var whisperKit = WhisperKitTranscriber.shared
+	// Bound to the shared live state rather than one engine, so whichever engine
+	// is transcribing reaches this view. See WHI-58.
+	@Bindable private var live = LiveTranscriptionState.shared
 	@State private var lastDisplayedText: String = ""
 
 	// Show only the last few words being transcribed
 	private var latestWords: String {
-		let currentText = whisperKit.currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+		let currentText = live.currentText.trimmingCharacters(in: .whitespacesAndNewlines)
 
 		// Filter out WhisperKit's default messages
 		if currentText.isEmpty || currentText.contains("Waiting for speech")
@@ -38,16 +40,16 @@ struct LiveTranscriptionView: View {
 					.padding(.horizontal, 12)
 					.padding(.vertical, 8)
 					.animation(.none, value: latestWords)  // No animation to prevent rewrites
-			} else if whisperKit.isTranscribing {
+			} else if live.isTranscribing {
 				// Minimal listening indicator
 				HStack(spacing: 6) {
 					Circle()
 						.fill(.blue)
 						.frame(width: 4, height: 4)
-						.scaleEffect(whisperKit.isTranscribing ? 1.2 : 1.0)
+						.scaleEffect(live.isTranscribing ? 1.2 : 1.0)
 						.animation(
 							.easeInOut(duration: 1.0).repeatForever(autoreverses: true),
-							value: whisperKit.isTranscribing)
+							value: live.isTranscribing)
 
 					Text("Listening...")
 						.font(.system(.caption, design: .rounded))

--- a/LiveTranscription/LiveTranscriptionWindow.swift
+++ b/LiveTranscription/LiveTranscriptionWindow.swift
@@ -18,6 +18,12 @@ class LiveTranscriptionWindow: NSWindow {
 	private let audioManager: AudioManager
 	private var observationTimer: Timer?
 	private var lastTextContent: String = ""
+	// Latched once the session shows its first words, cleared when the window
+	// leaves. It is what lets a momentarily blank transcript keep the window up
+	// (DictationView holds the words themselves) without ever allowing a window
+	// that has shown nothing yet — the wide empty capsule the WHI-58 QA session
+	// caught mid-dictation.
+	private var hadWordsThisSession = false
 
 	@AppStorage("liveTranscriptionMaxWidthPercentage") private var maxWidthPercentage = 0.6
 	// The width estimate must price the words DictationView actually shows —
@@ -65,21 +71,42 @@ class LiveTranscriptionWindow: NSWindow {
 				// Keep the HUD up briefly after a recipe errors so the message is
 				// readable. The running state itself lives in the listening pill.
 				let recipeActive = self.coordinator.overlayError != nil
-				// A session whose display text is momentarily empty must not drop
-				// the window: blanking mid-sentence is the jumping the WHI-58 QA
-				// session reported. While the session runs, a window already on
-				// screen stays on screen; it leaves only when the dictation ends.
+				if self.isSessionActive, !self.live.isWaitingForModel,
+					!self.live.stableDisplayText.isEmpty
+				{
+					self.hadWordsThisSession = true
+				}
+				// The window shows only while it has something to say — a status
+				// line, words, or words it is holding through a momentarily blank
+				// transcript (the mid-sentence jumping the WHI-58 QA session
+				// reported). A session that has said nothing yet keeps the window
+				// hidden rather than presenting an empty capsule.
+				let hasContent = DictationHUDContent.hasSomethingToSay(
+					overlayError: self.coordinator.overlayError,
+					isWaitingForModel: self.live.isWaitingForModel,
+					waitingStatusText: self.live.waitingForModelStatusText,
+					displayText: self.live.stableDisplayText,
+					hasShownWordsThisSession: self.hadWordsThisSession)
 				let shouldShow =
 					RecordingWindowPolicy.shouldShowLiveTranscriptionWindow(
 						mode: self.audioManager.currentRecordingMode,
 						transcriberWantsWindow: self.isSessionActive
-							&& (self.live.shouldShowLiveTranscriptionWindow || self.isVisible)
+							&& self.live.shouldShowLiveTranscriptionWindow && hasContent
 					) || recipeActive
 
 				if shouldShow {
 					let newSize = self.calculateDynamicSize()
 
 					if !self.isVisible {
+						// The first presentation waits for the pill's published frame
+						// when the pill is on its way: presenting against the fallback
+						// spot lands the capsule on the pill itself and then visibly
+						// snaps up once the frame arrives — the detached-at-start the
+						// WHI-58 QA session reported. The pill publishes as part of
+						// its own show pass, so this waits at most one poll tick.
+						let pillExpected = RecordingWindowPolicy.shouldShowListeningWindow(
+							state: self.audioManager.currentState)
+						if pillExpected && PillAnchorProvider.shared.pillFrame == nil { return }
 						self.presentAbovePill(size: newSize)
 					} else {
 						let pendingText =
@@ -100,6 +127,7 @@ class LiveTranscriptionWindow: NSWindow {
 						self.alphaValue = 1
 						self.lastTextContent = ""
 					}
+					self.hadWordsThisSession = false
 				}
 			}
 		}
@@ -146,10 +174,10 @@ class LiveTranscriptionWindow: NSWindow {
 		let holdSteady = isSessionActive || isShowingRecipeError
 
 		if let overlayError = coordinator.overlayError {
-			// The recipe error is a caption-sized status line, priced like one.
+			// The recipe error is a caption-sized status line, measured like one.
 			let width = DictationHUDWidth.width(
 				current: currentWidth,
-				estimated: CGFloat(overlayError.count) * 7 + 60,
+				estimated: DictationHUDWidth.statusWidth(overlayError),
 				maximum: maxWidth,
 				isDictating: holdSteady
 			)
@@ -160,7 +188,7 @@ class LiveTranscriptionWindow: NSWindow {
 		if live.isWaitingForModel {
 			// A status line renders at caption size behind an indicator, not as
 			// the word ticker; the shared rule still keeps its frame stable.
-			estimated = CGFloat(live.waitingForModelStatusText.count) * 7 + 60
+			estimated = DictationHUDWidth.statusWidth(live.waitingForModelStatusText)
 		} else {
 			let allWords = live.stableDisplayText.split(separator: " ")
 			estimated = DictationHUDWidth.estimatedWidth(

--- a/LiveTranscription/LiveTranscriptionWindow.swift
+++ b/LiveTranscription/LiveTranscriptionWindow.swift
@@ -24,6 +24,8 @@ class LiveTranscriptionWindow: NSWindow {
 	// that has shown nothing yet — the wide empty capsule the WHI-58 QA session
 	// caught mid-dictation.
 	private var hadWordsThisSession = false
+	// The frame's grow-fast/shrink-slow state; see DictationHUDFrame.
+	private var frameRule = DictationHUDFrame()
 
 	@AppStorage("liveTranscriptionMaxWidthPercentage") private var maxWidthPercentage = 0.6
 	// The width estimate must price the words DictationView actually shows —
@@ -114,7 +116,13 @@ class LiveTranscriptionWindow: NSWindow {
 							? self.live.waitingForModelStatusText
 							: self.live.stableDisplayText
 
-						if pendingText != self.lastTextContent || self.isShowingRecipeError {
+						// Changed text resizes, but so does an unchanged one whose
+						// frame rule has decayed: the shrink half of the hysteresis
+						// fires on time, not on new words, so a speaker who pauses
+						// still gets the gap closed under them.
+						if pendingText != self.lastTextContent || self.isShowingRecipeError
+							|| abs(newSize.width - self.frame.width) >= 1
+						{
 							self.updateWindowSize(newSize)
 							self.lastTextContent = pendingText
 						}
@@ -162,24 +170,27 @@ class LiveTranscriptionWindow: NSWindow {
 		}
 	}
 
-	/// The frame's calm-motion contract lives in `DictationHUDWidth`: while a
-	/// dictation runs the width only ever steps up on a coarse grid, never
-	/// shrinks — even when the display text is momentarily empty — and stops
-	/// changing once it reaches the screen-derived ceiling. The content inside
-	/// handles overflow (DictationView's trailing ticker). Between sessions the
-	/// window is hidden, which is what resets the growth back to compact.
+	/// The frame's calm-motion contract lives in `DictationHUDFrame`: while a
+	/// dictation runs the width grows immediately on a coarse grid, decays one
+	/// quantum at a time only after the text has stopped needing it for a
+	/// sustained beat, and stops changing once it reaches the screen-derived
+	/// ceiling. The content inside handles overflow (DictationView's trailing
+	/// ticker). Hiding the window between sessions resets the growth to compact.
 	private func calculateDynamicSize() -> NSSize {
 		let maxWidth = min(currentScreen().visibleFrame.width * maxWidthPercentage, 800)
-		let currentWidth = isVisible ? frame.width : nil
+		// A hidden window has no width worth preserving; forgetting it here is
+		// what starts the next session compact.
+		if !isVisible { frameRule.reset() }
 		let holdSteady = isSessionActive || isShowingRecipeError
+		let now = CACurrentMediaTime()
 
 		if let overlayError = coordinator.overlayError {
 			// The recipe error is a caption-sized status line, measured like one.
-			let width = DictationHUDWidth.width(
-				current: currentWidth,
+			let width = frameRule.update(
 				estimated: DictationHUDWidth.statusWidth(overlayError),
 				maximum: maxWidth,
-				isDictating: holdSteady
+				isDictating: holdSteady,
+				now: now
 			)
 			return NSSize(width: width, height: 44)
 		}
@@ -191,17 +202,23 @@ class LiveTranscriptionWindow: NSWindow {
 			estimated = DictationHUDWidth.statusWidth(live.waitingForModelStatusText)
 		} else {
 			let allWords = live.stableDisplayText.split(separator: " ")
+			if allWords.isEmpty && hadWordsThisSession && isVisible {
+				// The transcript blanked mid-session and DictationView is showing
+				// its held words, which this window cannot measure. Hold the frame
+				// as it is rather than letting an empty measurement arm the decay.
+				return NSSize(width: frame.width, height: 36)
+			}
 			estimated = DictationHUDWidth.estimatedWidth(
 				words: allWords.suffix(maxWordsToShow).map(String.init),
 				hasEllipsis: allWords.count > maxWordsToShow
 			)
 		}
 
-		let width = DictationHUDWidth.width(
-			current: currentWidth,
+		let width = frameRule.update(
 			estimated: estimated,
 			maximum: maxWidth,
-			isDictating: holdSteady
+			isDictating: holdSteady,
+			now: now
 		)
 		return NSSize(width: width, height: 36)
 	}

--- a/LiveTranscription/LiveTranscriptionWindow.swift
+++ b/LiveTranscription/LiveTranscriptionWindow.swift
@@ -4,7 +4,9 @@ import SwiftUI
 
 @MainActor
 class LiveTranscriptionWindow: NSWindow {
-	private let whisperKit = WhisperKitTranscriber.shared
+	// The shared live state, not one engine: any engine that streams drives this
+	// window. See WHI-58.
+	private let live = LiveTranscriptionState.shared
 	private let coordinator = DictationCoordinator.shared
 	private let audioManager: AudioManager
 	private var observationTimer: Timer?
@@ -59,8 +61,8 @@ class LiveTranscriptionWindow: NSWindow {
 				let shouldShow =
 					RecordingWindowPolicy.shouldShowLiveTranscriptionWindow(
 						mode: self.audioManager.currentRecordingMode,
-						transcriberWantsWindow: self.whisperKit.shouldShowLiveTranscriptionWindow
-							&& (self.whisperKit.isTranscribing || self.whisperKit.isWaitingForModel)
+						transcriberWantsWindow: self.live.shouldShowLiveTranscriptionWindow
+							&& (self.live.isTranscribing || self.live.isWaitingForModel)
 					) || recipeActive
 
 				if shouldShow {
@@ -98,9 +100,9 @@ class LiveTranscriptionWindow: NSWindow {
 						}
 
 						let pendingText =
-							self.whisperKit.isWaitingForModel
-							? self.whisperKit.waitingForModelStatusText
-							: self.whisperKit.stableDisplayText
+							self.live.isWaitingForModel
+							? self.live.waitingForModelStatusText
+							: self.live.stableDisplayText
 
 						if pendingText != self.lastTextContent {
 							self.updateWindowSize(newSize)
@@ -170,9 +172,9 @@ class LiveTranscriptionWindow: NSWindow {
 		}
 
 		let pendingText =
-			whisperKit.isWaitingForModel
-			? whisperKit.waitingForModelStatusText
-			: whisperKit.stableDisplayText
+			live.isWaitingForModel
+			? live.waitingForModelStatusText
+			: live.stableDisplayText
 
 		if pendingText.isEmpty {
 			return NSSize(width: 120, height: 36)
@@ -327,7 +329,7 @@ class LiveTranscriptionWindow: NSWindow {
 			if let caretPosition = newCaretPosition {
 				self.lastCaretPosition = caretPosition
 
-				if self.followCaret && self.isVisible && self.whisperKit.isTranscribing
+				if self.followCaret && self.isVisible && self.live.isTranscribing
 					&& !self.isShowingRecipeError
 				{
 					let windowSize = self.calculateDynamicSize()

--- a/LiveTranscription/LiveTranscriptionWindow.swift
+++ b/LiveTranscription/LiveTranscriptionWindow.swift
@@ -2,6 +2,13 @@ import AppKit
 import QuartzCore
 import SwiftUI
 
+/// The pill's overlay for transient live-session content: the emerging words,
+/// a "waiting for model" status, or a post-dictation recipe error. It always
+/// sits above the listening pill — see `PillAnchor` — growing upward as its
+/// content grows, and never follows the caret: that used to be this window's
+/// only positioning mode, but with the pill itself now visible in every
+/// recording mode (see `RecordingWindowPolicy`), anchoring to the pill reads
+/// as one continuous surface instead of two disagreeing ones. See WHI-58.
 @MainActor
 class LiveTranscriptionWindow: NSWindow {
 	// The shared live state, not one engine: any engine that streams drives this
@@ -10,17 +17,14 @@ class LiveTranscriptionWindow: NSWindow {
 	private let coordinator = DictationCoordinator.shared
 	private let audioManager: AudioManager
 	private var observationTimer: Timer?
-	private var lastCaretPosition: NSPoint?
 	private var lastTextContent: String = ""
 
-	@AppStorage("liveTranscriptionWindowOffset") private var windowOffset = 25.0
 	@AppStorage("liveTranscriptionMaxWidthPercentage") private var maxWidthPercentage = 0.6
-	@AppStorage("liveTranscriptionFollowCaret") private var followCaret = true
 
 	init(audioManager: AudioManager) {
 		self.audioManager = audioManager
 		super.init(
-			contentRect: NSRect(x: 0, y: 0, width: 200, height: 32),  //TODO: make it customizeable
+			contentRect: NSRect(x: 0, y: 0, width: 200, height: 32),
 			styleMask: [.borderless],
 			backing: .buffered,
 			defer: false
@@ -30,9 +34,11 @@ class LiveTranscriptionWindow: NSWindow {
 		self.isOpaque = false
 		self.backgroundColor = .clear
 		self.hasShadow = true
-		self.isMovable = true
-		self.ignoresMouseEvents = false
-		self.isMovableByWindowBackground = true
+		// Dragging the pill is how the user repositions this whole surface;
+		// dragging the words themselves would just fight PillAnchor putting it
+		// straight back above the pill on the next layout pass.
+		self.isMovable = false
+		self.ignoresMouseEvents = true
 
 		self.center()
 
@@ -40,14 +46,11 @@ class LiveTranscriptionWindow: NSWindow {
 		self.contentView = hostingView
 
 		setupObservation()
-		setupCaretTracking()
+		observePillMovement()
 	}
 
 	deinit {
 		observationTimer?.invalidate()
-		Task { @MainActor in
-			AccessibilityHelper.onCaretChange = nil
-		}
 	}
 
 	private func setupObservation() {
@@ -69,42 +72,14 @@ class LiveTranscriptionWindow: NSWindow {
 					let newSize = self.calculateDynamicSize()
 
 					if !self.isVisible {
-						// The recipe error is not tied to what the user is typing, so it
-						// rises into the pill's resting place instead of dropping in at
-						// the caret.
-						if self.isShowingRecipeError {
-							self.presentErrorAtBottomCenter(size: newSize)
-						} else {
-							self.positionNearCaret(size: newSize)
-							self.makeKeyAndOrderFront(nil)
-						}
-					} else if self.isShowingRecipeError {
-						self.updateWindowSize(newSize)
+						self.presentAbovePill(size: newSize)
 					} else {
-						if self.followCaret {
-							_ = AccessibilityHelper.getCaretPosition()
-						}
-
-						if let currentCaretPosition = AccessibilityHelper.getCaretPosition() {
-							if let lastPosition = self.lastCaretPosition {
-								let distance = sqrt(
-									pow(currentCaretPosition.x - lastPosition.x, 2)
-										+ pow(currentCaretPosition.y - lastPosition.y, 2))
-
-								if distance > 50 {
-									self.positionRelativeToCaret(
-										caretPosition: currentCaretPosition, windowSize: newSize)
-								}
-							}
-							self.lastCaretPosition = currentCaretPosition
-						}
-
 						let pendingText =
 							self.live.isWaitingForModel
 							? self.live.waitingForModelStatusText
 							: self.live.stableDisplayText
 
-						if pendingText != self.lastTextContent {
+						if pendingText != self.lastTextContent || self.isShowingRecipeError {
 							self.updateWindowSize(newSize)
 							self.lastTextContent = pendingText
 						}
@@ -112,8 +87,8 @@ class LiveTranscriptionWindow: NSWindow {
 				} else {
 					if self.isVisible {
 						self.orderOut(nil)
-						// The error entry fades in from 0; restore it so a later
-						// caret-anchored word display is never left invisible.
+						// The reveal fades in from 0; restore it so the next appearance
+						// is never left invisible.
 						self.alphaValue = 1
 						self.lastTextContent = ""
 					}
@@ -128,41 +103,22 @@ class LiveTranscriptionWindow: NSWindow {
 		coordinator.overlayError != nil
 	}
 
-	/// Rises into the same bottom-centre resting place as the listening pill,
-	/// on the pill's own motion constants, instead of dropping in from above.
-	private func presentErrorAtBottomCenter(size: NSSize) {
-		let screenFrame = screenForWindow().visibleFrame
-		let x = screenFrame.origin.x + (screenFrame.width - size.width) / 2
-		let y = screenFrame.origin.y + (screenFrame.height * PillMetrics.bottomAnchorFraction)
-		let target = NSRect(x: x, y: y, width: size.width, height: size.height)
-
-		guard !Motion.systemReduceMotion else {
-			alphaValue = 1
-			setFrame(target, display: true)
-			makeKeyAndOrderFront(nil)
-			return
-		}
-
-		alphaValue = 0
-		setFrame(target.offsetBy(dx: 0, dy: -Self.errorRiseDistance), display: false)
-		makeKeyAndOrderFront(nil)
-
-		NSAnimationContext.runAnimationGroup { context in
-			context.duration = Motion.structuralDuration
-			context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-			context.allowsImplicitAnimation = true
-			self.animator().setFrame(target, display: true)
-		}
-		NSAnimationContext.runAnimationGroup { context in
-			context.duration = Motion.revealDuration
-			context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-			context.allowsImplicitAnimation = true
-			self.animator().alphaValue = 1
+	/// Repositions above the pill whenever the pill itself moves (a drag) or
+	/// changes size, so this window never has to reach into `ListeningWindow`
+	/// directly. See `PillAnchorProvider`.
+	private func observePillMovement() {
+		withObservationTracking {
+			_ = PillAnchorProvider.shared.pillFrame
+		} onChange: {
+			Task { @MainActor [weak self] in
+				guard let self else { return }
+				if self.isVisible {
+					self.updateWindowSize(self.calculateDynamicSize())
+				}
+				self.observePillMovement()
+			}
 		}
 	}
-
-	/// How far below its resting place the error starts its rise.
-	private static let errorRiseDistance: CGFloat = 24
 
 	private func calculateDynamicSize() -> NSSize {
 		// The recipe error gets its own comfortable width.
@@ -180,8 +136,7 @@ class LiveTranscriptionWindow: NSWindow {
 			return NSSize(width: 120, height: 36)
 		}
 
-		let screen = screenForWindow()
-		let screenWidth = screen.visibleFrame.width
+		let screenWidth = currentScreen().visibleFrame.width
 		let screenBasedMaxWidth = screenWidth * maxWidthPercentage
 
 		let words = pendingText.split(separator: " ")
@@ -199,143 +154,75 @@ class LiveTranscriptionWindow: NSWindow {
 		return NSSize(width: finalWidth, height: finalHeight)
 	}
 
-	private func screenForWindow() -> NSScreen {
-		if let caretPosition = lastCaretPosition {
-			let screen = screenContaining(point: caretPosition)
-			return screen
-		}
-
-		if self.isVisible {
-			let windowCenter = NSPoint(x: frame.midX, y: frame.midY)
-			let screen = screenContaining(point: windowCenter)
-			return screen
-		}
-
-		let screen = NSScreen.main ?? NSScreen.screens.first!
-		return screen
-	}
-
-	private func screenContaining(point: NSPoint) -> NSScreen {
-		for screen in NSScreen.screens {
-			if screen.frame.contains(point) {
+	/// The screen the pill is resting on, so this window's width clamp and its
+	/// anchor fallback agree with whatever display the pill is actually on.
+	private func currentScreen() -> NSScreen {
+		if let pillFrame = PillAnchorProvider.shared.pillFrame {
+			for screen in NSScreen.screens where screen.frame.contains(NSPoint(x: pillFrame.midX, y: pillFrame.midY)) {
 				return screen
 			}
 		}
 		return NSScreen.main ?? NSScreen.screens.first!
 	}
 
-	private func positionNearCaret(size: NSSize) {
-		if let caretPosition = AccessibilityHelper.getCaretPosition() {
-			lastCaretPosition = caretPosition
-			positionRelativeToCaret(caretPosition: caretPosition, windowSize: size)
-		} else {
-			positionAtBottomCenter(size: size)
-		}
-	}
+	/// First appearance: rises into place from just below its resting spot,
+	/// the same reveal language `ListeningWindow` uses for its controls panel.
+	private func presentAbovePill(size: NSSize) {
+		let target = PillAnchor.frame(
+			for: size, screenFrame: currentScreen().visibleFrame, pillFrame: PillAnchorProvider.shared.pillFrame)
 
-	private func positionRelativeToCaret(caretPosition: NSPoint, windowSize: NSSize) {
-		let screen = screenContaining(point: caretPosition)
-		let screenFrame = screen.visibleFrame
-
-		let halfScreenHeight = screenFrame.height / 2
-		let screenCenterY = screenFrame.origin.y + halfScreenHeight
-
-		var windowX: CGFloat
-		var windowY: CGFloat
-
-		windowX = caretPosition.x - (windowSize.width / 2)
-
-		let minX = screenFrame.origin.x + 20
-		let maxX = screenFrame.origin.x + screenFrame.width - windowSize.width - 20
-
-		windowX = max(minX, windowX)
-		windowX = min(maxX, windowX)
-
-		if caretPosition.y > screenCenterY {
-			windowY = caretPosition.y - windowSize.height - windowOffset
-
-			if windowY < screenFrame.origin.y + 10 {
-				windowY = caretPosition.y + (windowOffset * 0.6)
-			}
-		} else {
-			windowY = caretPosition.y + (windowOffset * 0.4)
-
-			if windowY + windowSize.height > screenFrame.origin.y + screenFrame.height - 10 {
-				windowY = caretPosition.y - windowSize.height - (windowOffset * 0.6)
-			}
+		guard !Motion.systemReduceMotion else {
+			alphaValue = 1
+			setFrame(target, display: true)
+			orderFront(nil)
+			return
 		}
 
-		windowY = max(screenFrame.origin.y + 20, windowY)
-		windowY = min(screenFrame.origin.y + screenFrame.height - windowSize.height - 20, windowY)
-
-		let newFrame = NSRect(
-			x: windowX, y: windowY, width: windowSize.width, height: windowSize.height)
+		alphaValue = 0
+		setFrame(target.offsetBy(dx: 0, dy: -Self.riseDistance), display: false)
+		orderFront(nil)
 
 		NSAnimationContext.runAnimationGroup { context in
-			context.duration = 0.2
+			context.duration = Motion.structuralDuration
+			context.timingFunction = CAMediaTimingFunction(name: .easeOut)
 			context.allowsImplicitAnimation = true
-			self.animator().setFrame(newFrame, display: true)
+			self.animator().setFrame(target, display: true)
 		}
-	}
-
-	private func positionAtBottomCenter(size: NSSize) {
-		let screen = screenForWindow()
-		let screenFrame = screen.visibleFrame
-		let windowX = screenFrame.origin.x + (screenFrame.width - size.width) / 2
-		let bottomOffset = screenFrame.height * 0.1
-		let windowY = screenFrame.origin.y + bottomOffset
-
-		let newFrame = NSRect(x: windowX, y: windowY, width: size.width, height: size.height)
-
 		NSAnimationContext.runAnimationGroup { context in
-			context.duration = 0.2
+			context.duration = Motion.revealDuration
+			context.timingFunction = CAMediaTimingFunction(name: .easeOut)
 			context.allowsImplicitAnimation = true
-			self.animator().setFrame(newFrame, display: true)
+			self.animator().alphaValue = 1
 		}
 	}
 
-	private func centerOnScreen(size: NSSize) {
-		positionAtBottomCenter(size: size)
-	}
+	/// How far below its resting place the reveal starts its rise.
+	private static let riseDistance: CGFloat = 24
 
 	private func updateWindowSize(_ newSize: NSSize) {
 		let currentFrame = self.frame
 
 		let widthDiff = abs(newSize.width - currentFrame.width)
 		let heightDiff = abs(newSize.height - currentFrame.height)
+		let pillFrame = PillAnchorProvider.shared.pillFrame
+		let target = PillAnchor.frame(for: newSize, screenFrame: currentScreen().visibleFrame, pillFrame: pillFrame)
 
-		if widthDiff < 10 && heightDiff < 5 {
+		// A pill move always repositions, even when the content size did not
+		// change; a content-only change below the noise floor is skipped.
+		guard widthDiff >= 10 || heightDiff >= 5 || abs(target.origin.x - currentFrame.origin.x) > 1
+			|| abs(target.origin.y - currentFrame.origin.y) > 1
+		else { return }
+
+		guard !Motion.systemReduceMotion else {
+			setFrame(target, display: true)
 			return
 		}
 
-		// The error stays bottom-centre for its whole life; only the live
-		// transcription display tracks the caret.
-		if isShowingRecipeError {
-			positionAtBottomCenter(size: newSize)
-			return
-		}
-
-		if let caretPosition = lastCaretPosition {
-			positionRelativeToCaret(caretPosition: caretPosition, windowSize: newSize)
-		} else {
-			positionAtBottomCenter(size: newSize)
-		}
-	}
-
-	private func setupCaretTracking() {
-		AccessibilityHelper.onCaretChange = { [weak self] newCaretPosition in
-			guard let self = self else { return }
-
-			if let caretPosition = newCaretPosition {
-				self.lastCaretPosition = caretPosition
-
-				if self.followCaret && self.isVisible && self.live.isTranscribing
-					&& !self.isShowingRecipeError
-				{
-					let windowSize = self.calculateDynamicSize()
-					self.positionRelativeToCaret(caretPosition: caretPosition, windowSize: windowSize)
-				}
-			}
+		NSAnimationContext.runAnimationGroup { context in
+			context.duration = Motion.structuralDuration
+			context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+			context.allowsImplicitAnimation = true
+			self.animator().setFrame(target, display: true)
 		}
 	}
 }

--- a/LiveTranscription/LiveTranscriptionWindow.swift
+++ b/LiveTranscription/LiveTranscriptionWindow.swift
@@ -20,6 +20,10 @@ class LiveTranscriptionWindow: NSWindow {
 	private var lastTextContent: String = ""
 
 	@AppStorage("liveTranscriptionMaxWidthPercentage") private var maxWidthPercentage = 0.6
+	// The width estimate must price the words DictationView actually shows —
+	// its trailing ticker caps at this many — not the whole transcript, or the
+	// frame would race to the ceiling while the visible text stays short.
+	@AppStorage("liveTranscriptionMaxWords") private var maxWordsToShow = 5
 
 	init(audioManager: AudioManager) {
 		self.audioManager = audioManager
@@ -61,11 +65,15 @@ class LiveTranscriptionWindow: NSWindow {
 				// Keep the HUD up briefly after a recipe errors so the message is
 				// readable. The running state itself lives in the listening pill.
 				let recipeActive = self.coordinator.overlayError != nil
+				// A session whose display text is momentarily empty must not drop
+				// the window: blanking mid-sentence is the jumping the WHI-58 QA
+				// session reported. While the session runs, a window already on
+				// screen stays on screen; it leaves only when the dictation ends.
 				let shouldShow =
 					RecordingWindowPolicy.shouldShowLiveTranscriptionWindow(
 						mode: self.audioManager.currentRecordingMode,
-						transcriberWantsWindow: self.live.shouldShowLiveTranscriptionWindow
-							&& (self.live.isTranscribing || self.live.isWaitingForModel)
+						transcriberWantsWindow: self.isSessionActive
+							&& (self.live.shouldShowLiveTranscriptionWindow || self.isVisible)
 					) || recipeActive
 
 				if shouldShow {
@@ -103,6 +111,12 @@ class LiveTranscriptionWindow: NSWindow {
 		coordinator.overlayError != nil
 	}
 
+	/// A dictation is running: the engine is transcribing, or holding the
+	/// session open behind a status line (waiting for model, reconnecting).
+	private var isSessionActive: Bool {
+		live.isTranscribing || live.isWaitingForModel
+	}
+
 	/// Repositions above the pill whenever the pill itself moves (a drag) or
 	/// changes size, so this window never has to reach into `ListeningWindow`
 	/// directly. See `PillAnchorProvider`.
@@ -120,38 +134,48 @@ class LiveTranscriptionWindow: NSWindow {
 		}
 	}
 
+	/// The frame's calm-motion contract lives in `DictationHUDWidth`: while a
+	/// dictation runs the width only ever steps up on a coarse grid, never
+	/// shrinks — even when the display text is momentarily empty — and stops
+	/// changing once it reaches the screen-derived ceiling. The content inside
+	/// handles overflow (DictationView's trailing ticker). Between sessions the
+	/// window is hidden, which is what resets the growth back to compact.
 	private func calculateDynamicSize() -> NSSize {
-		// The recipe error gets its own comfortable width.
+		let maxWidth = min(currentScreen().visibleFrame.width * maxWidthPercentage, 800)
+		let currentWidth = isVisible ? frame.width : nil
+		let holdSteady = isSessionActive || isShowingRecipeError
+
 		if let overlayError = coordinator.overlayError {
-			let width = min(480, max(200, CGFloat(overlayError.count) * 7 + 60))
+			// The recipe error is a caption-sized status line, priced like one.
+			let width = DictationHUDWidth.width(
+				current: currentWidth,
+				estimated: CGFloat(overlayError.count) * 7 + 60,
+				maximum: maxWidth,
+				isDictating: holdSteady
+			)
 			return NSSize(width: width, height: 44)
 		}
 
-		let pendingText =
-			live.isWaitingForModel
-			? live.waitingForModelStatusText
-			: live.stableDisplayText
-
-		if pendingText.isEmpty {
-			return NSSize(width: 120, height: 36)
+		let estimated: CGFloat
+		if live.isWaitingForModel {
+			// A status line renders at caption size behind an indicator, not as
+			// the word ticker; the shared rule still keeps its frame stable.
+			estimated = CGFloat(live.waitingForModelStatusText.count) * 7 + 60
+		} else {
+			let allWords = live.stableDisplayText.split(separator: " ")
+			estimated = DictationHUDWidth.estimatedWidth(
+				words: allWords.suffix(maxWordsToShow).map(String.init),
+				hasEllipsis: allWords.count > maxWordsToShow
+			)
 		}
 
-		let screenWidth = currentScreen().visibleFrame.width
-		let screenBasedMaxWidth = screenWidth * maxWidthPercentage
-
-		let words = pendingText.split(separator: " ")
-		let lastWordWidth = words.last.map { CGFloat($0.count) * 10 } ?? 0
-		let otherWordsWidth = words.dropLast().reduce(0) { $0 + CGFloat($1.count) * 7 }
-		let spacesWidth = CGFloat(max(0, words.count - 1)) * 4
-
-		let estimatedTextWidth = lastWordWidth + otherWordsWidth + spacesWidth
-		let paddedWidth = estimatedTextWidth + 32
-		let minWidth: CGFloat = 120
-		let maxWidth = min(screenBasedMaxWidth, 800)
-		let finalWidth = min(maxWidth, max(minWidth, paddedWidth))
-		let finalHeight: CGFloat = 36
-
-		return NSSize(width: finalWidth, height: finalHeight)
+		let width = DictationHUDWidth.width(
+			current: currentWidth,
+			estimated: estimated,
+			maximum: maxWidth,
+			isDictating: holdSteady
+		)
+		return NSSize(width: width, height: 36)
 	}
 
 	/// The screen the pill is resting on, so this window's width clamp and its

--- a/LiveTranscription/LiveTranscriptionWindow.swift
+++ b/LiveTranscription/LiveTranscriptionWindow.swift
@@ -147,10 +147,11 @@ class LiveTranscriptionWindow: NSWindow {
 		coordinator.overlayError != nil
 	}
 
-	/// A dictation is running: the engine is transcribing, or holding the
-	/// session open behind a status line (waiting for model, reconnecting).
+	/// A dictation is running — see `LiveTranscriptionState.isSessionActive`.
+	/// The post-stop finalize pass is not a session: this window dismisses at
+	/// stop and the listening pill alone announces the polish.
 	private var isSessionActive: Bool {
-		live.isTranscribing || live.isWaitingForModel
+		live.isSessionActive
 	}
 
 	/// Repositions above the pill whenever the pill itself moves (a drag) or

--- a/PASTE-MODEL-RESULT.md
+++ b/PASTE-MODEL-RESULT.md
@@ -1,0 +1,186 @@
+# WHI-58 follow-up: paste-once-at-stop, and a model picker for direct mode
+
+Two independent app-side changes on `ismatulla/whi-58-engine-protocol`. Neither touches
+the sibling `WhisperaDictation` package (`../../whispera-components-worktrees/dictation/apple`).
+
+## Change 1 — paste once, when dictation ends
+
+### Current behaviour, as found (before this change)
+
+Reading `AudioManager`, `StreamingTranscriber`, `WhisperKitTranscriber`,
+`LiveTranscriptionState` and `DictationWordTracker` turned up a mechanism the task
+description didn't name: **the live-typing behaviour was not in `AudioManager.applyAndPaste`
+at all.**
+
+- `applyAndPaste` only ever ran for **text mode** (`mode == .text` gated both the
+  `dictationProcessor` call and the paste). It was called from
+  `transcribeAudioBuffer`/`transcribeAudio`, which only run from the file/streaming
+  *text*-mode stop paths. Live mode never called it — so this function was already a
+  dead end for live dictation, not the thing doing the incremental pasting.
+- The actual incremental-paste mechanism was **`DictationWordTracker.handleConfirmedTextChange`**.
+  Both `WhisperKitTranscriber.liveStream()` and `StreamingTranscriber.startStreaming()`
+  construct a `DictationWordTracker`, whose `init` wires
+  `WhisperKitTranscriber.shared.onConfirmedTextChange` — which proxies to
+  `LiveTranscriptionState.shared.onConfirmedTextChange`, the *one* shared singleton
+  both engines write into. So every time either engine confirmed a new segment,
+  `handleConfirmedTextChange` computed the newly-confirmed words and pasted them
+  immediately via a simulated ⌘V — regardless of which engine produced them.
+- On stop, `WhisperKitTranscriber.stopLiveStream()` called `confirmPendingText()`
+  (flushes the pending tail into `confirmedText`) and `StreamingTranscriber.stopStreaming()`
+  awaited `session.finish()` and ingested the final transcript into `confirmedText` —
+  but neither pasted anything at that point; the final flush only ever updated the HUD.
+  Net effect: the *last* pending words (never yet "confirmed" while speaking) were
+  dropped from the paste stream entirely, and nothing was pasted as one whole
+  dictation, through the recipe pipeline or otherwise.
+- `DictationWordTracker` also carries dead correction-command code
+  (`processCorrectionCommand`/`executeCorrection`, "correct that to X", "replace last
+  N words") — grepped for call sites; none exist anywhere in the app. It's unwired
+  infrastructure that predates this change and is out of scope here.
+
+### What changed
+
+1. **`DictationWordTracker.handleConfirmedTextChange`** no longer pastes. It still
+   calls `trackWords` (kept for the dormant correction-command code, harmless either
+   way), but the `Task { await pasteText(newContent) }` call is gone. This is the
+   actual fix for "no partial ever pastes mid-dictation" — for both engines, since
+   the callback is wired through the single shared `LiveTranscriptionState`.
+
+2. **`SpeechTranscribing.stopStreaming()`** changed signature from `() -> Void` to
+   `@discardableResult func stopStreaming() async -> String`, returning the finished,
+   trimmed transcript instead of relying on a caller re-reading
+   `LiveTranscriptionState.shared.confirmedText` after an unspecified delay:
+   - `WhisperKitTranscriber+Engine.stopStreaming()` calls the existing
+     `stopLiveStream()` (synchronous — it confirms the pending tail before
+     returning) and then reads back `LiveTranscriptionState.shared.confirmedText`.
+   - `StreamingTranscriber.stopStreaming()` no longer fires-and-forgets a background
+     `Task` to `await session.finish()`; it awaits it directly (the method is async
+     now) and returns the trimmed result. This removed a nested `Task` — the method
+     itself is the async context now.
+   - The protocol's default (no-op) implementation returns `""`.
+
+3. **`AudioManager.stopLiveTranscription()`** now does the actual paste-once:
+   captures the engine, tears the session down exactly as before, then
+   `Task { let transcript = await engine.stopStreaming(); ...; await applyAndPaste(toPaste) }`.
+   `isTranscribing` is set `true` for the span of that task so the pill reflects
+   "processing" the same way text mode does while its transcription runs.
+
+4. **`AudioManager.applyAndPaste`** dropped the `mode == .text` gates on both the
+   `dictationProcessor` call and the paste. It's mode-agnostic now: whichever mode
+   produced a final transcript, the recipe pipeline (WHI-41) runs and the result
+   (if non-nil and non-empty) pastes once. The two pre-existing text-mode call
+   sites (`transcribeAudioBuffer`/`transcribeAudio`) are unaffected in practice —
+   `currentRecordingMode` is always `.text` there — this only *adds* a third call
+   site (the live-stop path) rather than changing text mode's behaviour.
+
+5. New pure function, unit-tested: `AudioManager.textToPaste(afterLiveDictationFinished:)`
+   — trims the transcript and returns `nil` for empty/whitespace-only, non-nil
+   otherwise. Tests: `WhisperaUnitTests/LiveDictationPasteTests.swift`.
+
+### Paste decision table (mode × outcome)
+
+| Mode | Outcome | Pastes? | Why |
+|---|---|---|---|
+| `.text` | transcription succeeds, processor/no-processor produces text | yes, once | unchanged — always did |
+| `.text` | processor returns nil (recipe executed an action) | no | unchanged — processor's own contract |
+| `.text` | transcription throws | no | error path never reaches `applyAndPaste` |
+| `.liveTranscription` | word confirmed mid-dictation | **no (was: yes, per segment)** | `DictationWordTracker` no longer pastes on `onConfirmedTextChange` |
+| `.liveTranscription` | user stops, `stopStreaming()` returns non-empty trimmed transcript | **yes, once** (new) | `stopLiveTranscription` → `applyAndPaste` |
+| `.liveTranscription` | user stops, transcript is empty/whitespace (nothing said, or a session that never confirmed anything) | no, no error | `textToPaste(afterLiveDictationFinished:)` returns `nil` |
+| `.liveTranscription` | user cancels during startup (`cancelCaptureStartup`, before capture is established) | no | this path never calls `stopLiveTranscription`/`stopStreaming` at all |
+| `.liveTranscription` | `startStreaming` throws before capture starts | no | `startLiveTranscription`'s catch block sets `isRecording = false` directly, never calls `stopLiveTranscription` |
+| `.liveTranscription` | a mid-session failure occurs, then the user explicitly stops | pastes whatever was salvaged (possibly empty → no paste) | consistent with the engine's own existing philosophy ("a failure that arrives with words already in hand ... is the end of a good dictation, not a lost one" — `StreamingTranscriber.report`); an empty result is indistinguishable from "nothing said" and correctly pastes nothing |
+
+The two structural "cancel/error" exclusions (cancelled startup, failed start) never
+reach `applyAndPaste` at all, so the single empty-check in `textToPaste` is sufficient
+to cover every "must not paste" case in the table without a separate outcome enum.
+
+No new setting was added or needed — no existing paste-on-live-stop toggle was found
+in `WhisperaSettings`/`SettingsView` (grepped for `pasteOnLive`, `pasteAtEnd`,
+`liveTranscriptionPaste`, etc. — nothing), so paste-once-at-stop simply becomes live
+mode's behaviour, as instructed.
+
+## Change 2 — backend model choice in Settings
+
+### `StreamingTranscriber.models()` (direct mode)
+
+Previously returned a single synthetic entry wrapping whatever string was already
+saved in `WhisperaSettings.transcriptionDirectModel` — not a real list.
+
+Now: `GET <baseURL>/models` (OpenAI-compatible; `baseURL` already ends in `/v1`,
+e.g. `http://192.168.50.140:8000/v1` → `/v1/models`), decodes
+`{data: [{id, task, ...}]}`, and filters to `task == "automatic-speech-recognition"`
+(a multi-purpose engine host can also serve LLMs/TTS/embeddings under the same
+endpoint). `selectModel(_:)` is unchanged — still writes
+`WhisperaSettings.transcriptionDirectModel`.
+
+Unreachable/malformed responses throw rather than returning `[]`:
+- transport failure or non-2xx → `StreamingTranscriberError.engineUnreachable(host)`
+- valid response but no ASR-tasked models → `StreamingTranscriberError.noModelsInstalled(host)`
+- undecodable body → `engineUnreachable(host)` (treated the same as unreachable —
+  something on the wire is not what was expected)
+
+`StreamingTranscriber` gained an injectable `urlSession: URLSession = .shared`
+constructor parameter (mirrors `RemoteTranscriber`'s existing pattern) so this fetch
+is testable against `MockURLProtocol` without a real engine. Backend mode
+(`whisperaStreaming`) is untouched — it still lists servers via
+`DictationServerDirectory.servers()`.
+
+Tests: `WhisperaUnitTests/StreamingTranscriberDirectModelsTests.swift` — filters
+non-ASR models out, hits the right path, and turns a 500 / bad JSON / an
+all-non-ASR model list into a thrown error rather than silence.
+
+### Settings UI (`SettingsView.swift`, direct-mode section)
+
+The free-text `directEngineModelField` is now the **fallback**, not the only option:
+
+- On first showing the direct-mode section (`.task(id: transcriptionEngineRaw)`) and
+  on tapping the new refresh button (⟳, `directEngineModelsRefreshButton`), Whispera
+  calls `StreamingTranscriber.direct.models()`.
+- **Success** → a `Picker` (`directEngineModelPicker`) bound to `$transcriptionDirectModel`,
+  populated with the fetched models, replaces the text field.
+- **Failure** → the picker never appears; the free-text field
+  (`directEngineModelField`) stays visible with whatever was last saved, plus an
+  inline orange warning row with the error's `localizedDescription`
+  (e.g. "Could not reach 192.168.50.140 to list its models..."). The saved model
+  string is never cleared by a failed fetch.
+- State transitions (`isFetchingDirectModels`, the options list, the error row) use
+  `.easeInOut(duration: 0.2)`, matching the design language's stated transition
+  duration.
+- New `@State`: `directModelOptions`, `isFetchingDirectModels`, `directModelFetchError`,
+  plus a `refreshDirectModels()` helper that drives them.
+
+## What was run
+
+- Build (remote, per the environment recipe): `xcodebuild ... build` — **BUILD SUCCEEDED**.
+- Targeted unit tests (remote): `LiveDictationPasteTests`,
+  `StreamingTranscriberDirectModelsTests`, `LiveTranscriptionSegmentBufferTests`,
+  `LiveTranscriptionFlickerFilterTests`, `LiveTranscriptionRemoteIngestTests`,
+  `TranscriptionRouterTests`, `TranscriptionFailureMessageTests`, `ServerEngineTests`,
+  `RecordingWindowPolicyTests`, `DeviceSwitchRouteTests`, `FailedActivationHealingTests`,
+  `RecordingSegmentLoadingTests`, `PillAnchorTests`, `SystemAudioMuterTests` — all
+  passed (note: the first `xcodebuild test` invocation hit an unrelated codesign
+  flake — `errSecInternalComponent` signing `XCTAutomationSupport.framework` with a
+  real Developer ID identity despite `CODE_SIGN_IDENTITY=-`; adding
+  `CODE_SIGNING_ALLOWED=NO` to the test invocation fixed it and every suite passed
+  clean on the retry).
+- No microphone on this build/QA Mac (lid shut) — did not attempt the headless
+  `WHISPERA_AUTOSTART_DICTATION` launch or install to `/Applications`, per the task's
+  "build-check only" instruction.
+
+## What needs the owner's voice QA
+
+- **Live dictation, both engines** (WhisperKit and `whisperaStreaming`/`realtimeDirect`):
+  confirm words only ever appear in the live HUD while speaking (never typed into the
+  focused app), and the full sentence pastes exactly once, through any matching
+  recipe, the moment the shortcut stops the dictation.
+- **Silence**: start and immediately stop a live dictation with nothing said —
+  confirm nothing pastes and no error/alert appears.
+- **Direct-mode model picker** against the real speaches 0.9.0-rc.3 engine at
+  `http://192.168.50.140:8000/v1`: confirm the picker lists the installed ASR models,
+  selecting one actually changes what the engine transcribes with, and pulling the
+  network/pointing at a wrong port produces the fallback text field with a readable
+  error rather than a blank picker.
+- **Mid-dictation failure then stop** (e.g. kill the engine mid-sentence, then press
+  the shortcut): confirm whatever was salvaged pastes once rather than being silently
+  dropped, matching the existing "failure with words in hand" philosophy — this path
+  could not be exercised without a live engine and microphone.

--- a/RESULT.md
+++ b/RESULT.md
@@ -1,0 +1,209 @@
+# WHI-58 — one transcription protocol, plus a streaming remote engine
+
+Branch `ismatulla/whi-58-engine-protocol`, based on `098bf9b`. Commit `2966c37`.
+Not pushed, not merged, no PR.
+
+## What I built
+
+**The protocol** — `Client/SpeechTranscribing.swift`. Audio in, text out.
+`TranscriptionEngine` stays an enum but is now identity only; what an engine can
+do is `TranscriptionCapabilities` on the conformer, so a new engine adds a case
+in exactly one `switch` (the router) instead of every caller.
+
+```swift
+@MainActor
+protocol SpeechTranscribing: AnyObject {
+    nonisolated var engine: TranscriptionEngine { get }
+    nonisolated var capabilities: TranscriptionCapabilities { get }
+    var state: TranscriptionEngineState { get }          // .unavailable(why) / .preparing(progress,status) / .ready
+    func prepare() async throws
+    func shutdown()
+
+    var activeModel: String? { get }
+    func models() async throws -> [TranscriptionModelInfo]
+    func selectModel(_ id: String) async throws
+    func downloadModel(_ id: String) async throws
+    func cancelModelDownload()
+
+    func transcribe(fileAt: URL, options: TranscriptionOptions) async throws -> String
+    func transcribe(samples: [Float], options: TranscriptionOptions) async throws -> String
+    func transcribeWithTimestamps(fileAt: URL, options: TranscriptionOptions) async throws -> [TranscriptionSegment]
+
+    var onLiveAudioSamples: (@MainActor ([Float]) -> Void)? { get set }
+    func resetStreamingSession()
+    func startStreaming(options: TranscriptionOptions) async throws
+    func switchStreamingDevice() async
+    func stopStreaming()
+}
+```
+
+Protocol-extension defaults throw `TranscriptionEngineError.unsupported(engine:capability:)`,
+so a conformer writes only what it does and an unsupported request fails loudly
+rather than silently degrading (WHI-42's rule).
+
+`TranscriptionOptions` is deliberately narrow — `mode` (`.transcribe`/`.translate`)
+and `language`. WhisperKit's sample length, prefill caches and temperature
+fallbacks stay inside the conformer that understands them, so a second engine
+never has to widen the type. `TranscriptionModelInfo` and
+`TranscriptionEngineState` are the other two neutral types.
+
+**Three conformers.**
+
+| Engine | Conformer | Capabilities |
+|---|---|---|
+| `.whisperKit` | `WhisperKitTranscriber` (`Client/WhisperKitTranscriber+Engine.swift`) | file, buffer, timestamps, streaming, managed models, translation |
+| `.whisperViaBYOK` | `RemoteBatchTranscriber` (new) | file, buffer |
+| `.whisperaStreaming` | `StreamingTranscriber` (new) | streaming, file, buffer |
+
+The WhisperKit conformance is a pure adapter — every member forwards to a method
+that already existed. `RemoteBatchTranscriber` wraps the untouched
+`RemoteTranscriber` (its tests still pass unmodified) and adds a WAV encoder for
+the raw-buffer path. `StreamingTranscriber` uses `WhisperaDictation` for the
+socket, the resampling and the credentials; it only resolves which server to
+talk to and turns that package's events into shared UI state.
+
+**The router** — `Client/TranscriptionRouter.swift`, a `@MainActor struct` with
+an injectable `engineProvider`, directly mirroring `RecipeRouter`. Conformers are
+shared instances, because a streaming engine holds a socket and a local one holds
+a loaded model.
+
+**The live UI is reused, not duplicated** — `Client/LiveTranscriptionState.swift`.
+`confirmedText`, `pendingText`, `stableDisplayText`,
+`shouldShowLiveTranscriptionWindow`, `isTranscribing`, `isWaitingForModel`,
+`waitingForModelStatusText`, `currentText` and `onConfirmedTextChange` moved out
+of `WhisperKitTranscriber` into one `@Observable` object, along with the
+two-segment confirmation buffer and the flicker filter, moved verbatim.
+`WhisperKitTranscriber` exposes all of them as forwarding computed properties, so
+its callers and tests are unchanged. `DictationView`, `LiveTranscriptionView` and
+`LiveTranscriptionWindow` now bind to the shared state. There is no second view,
+and `DictationWordTracker` keeps typing remote text into the focused app through
+the same `onConfirmedTextChange` hook.
+
+`AudioManager` talks only to `SpeechTranscribing`. It pins the engine for the
+duration of a dictation (`sessionTranscriber`) so a Settings change mid-recording
+cannot route stop, or a device switch, at an engine that never started.
+
+## Selecting a remote engine at runtime
+
+**UserDefaults, `UserDefaults.standard`, no env vars.**
+
+| Key | Values | Default |
+|---|---|---|
+| `whisperaTranscriptionEngine` | `whisperKit` · `whisperViaBYOK` · `whisperaStreaming` | `whisperKit` (also the fallback for any unrecognised value) |
+| `whisperaTranscriptionServerURL` | base URL of the transcription backend, e.g. `http://192.168.50.184:3000` | empty → falls back to `whisperaServerURL` |
+| `whisperaTranscriptionServerId` | server id from `GET /transcription/servers`, e.g. `speaches-lan` | empty → the backend's own default realtime server |
+| `whisperaByokTranscriptionModel` | model name for the BYOK upload endpoint | `whisper-1` |
+
+In the UI: **Settings → General → Transcription → Engine**. Picking
+"Whispera server (streaming)" reveals the URL and server-id fields.
+
+Auth is a bearer token from the Keychain via `AuthTokenStore` (service
+`com.whispera.clerk`, account `session`) — the same store the account path uses.
+Against the test backend (`NODE_ENV=test`) the token *is* the user id, so saving
+`demo-user` there is enough. The credential is minted per connect attempt and
+once more on the single unauthorized retry, so a short-lived token survives a
+reconnect.
+
+Capabilities, the realtime path and the audio format are read from
+`GET /transcription/servers` — nothing about `pcm16`/24000 Hz is hardcoded in the
+app; the package owns the conversion.
+
+## Engine picker: un-pinned, deliberately
+
+I restored the stored lookup and shipped the picker. The old getter ignored the
+stored value while the setter still wrote it, so the ticket's warning was real —
+but nothing in production ever called that setter, so no shipped install can hold
+a non-default value, and every engine now has a conformer behind it rather than a
+dead enum case. **Confirm you want this**: the moment this build ships, a
+`whisperaTranscriptionEngine` key holding `whisperViaBYOK` (only reachable by
+hand-editing defaults today) would route dictation off-device on first launch.
+
+## What I ran, and what came back
+
+- `GET http://192.168.50.184:3000/transcription/servers` with `Authorization: Bearer demo-user`
+  → 200, one server: `speaches-lan`, model `Systran/faster-distil-whisper-large-v3`,
+  capabilities `["batch","realtime"]`, realtime path `/transcription/stream?server=speaches-lan`,
+  audio `pcm16` / 24000 Hz / mono / `base64-json`.
+- Full build on the build Mac (`192.168.50.89`, Xcode 26.2), after rsyncing both
+  the worktree and the package:
+  `xcodebuild -scheme Whispera -destination "platform=macOS,arch=arm64" -derivedDataPath build/test-derived CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO build`
+  → **BUILD SUCCEEDED**. `WhisperaDictation.swiftmodule` and `.o` are in the
+  products directory, so the package really did resolve, compile and link. The
+  repo's `swift-format lint` build phase passed over the new files.
+- `xcodebuild test -only-testing:WhisperaUnitTests` on this branch: one complete
+  pass. Every suite passed except six tests, listed below.
+- `Package.resolved` is byte-identical before and after — a local package adds no pin.
+
+## The package dependency is NOT what the brief specified
+
+The brief said to pin `whispera-components` to branch `feat/swift-dictation-component`.
+That is not possible today, for two independent reasons I verified:
+
+1. **The branch has never been pushed.** `git ls-remote --heads origin` on the
+   checkout returns only `refs/heads/main` (`a0b114e`). The local tip `fb22655`
+   exists nowhere but that worktree.
+2. **The manifest is not at the repo root.** It lives at `apple/Package.swift`,
+   and SwiftPM cannot point a URL dependency at a subdirectory. So even `main`
+   could not be consumed by URL.
+
+What I did instead: an `XCLocalSwiftPackageReference` with
+`relativePath = ../../whispera-components-worktrees/dictation/apple`, plus an
+`XCSwiftPackageProductDependency` on `WhisperaDictation` linked into the app
+target. It builds, but it depends on that sibling checkout existing next to the
+worktree — I rsynced it to the build Mac at the mirrored path.
+
+**Decision for the owner:** push the branch and move the manifest to the repo
+root (or split the Apple package into its own repo), then swap this one pbxproj
+node for an `XCRemoteSwiftPackageReference`. Nothing else in the app changes.
+
+## Unfinished
+
+- **Six tests failed on this branch and I did not get them baselined.** All in
+  `WhisperaUnitTests`:
+  `FileTranscriptionTimestampE2ETests/{timestampedTranscriptionCarriesTimestampsInEveryLine, plainTranscriptionCarriesNoTimestamps, queuePathProducesTimestampsWithFreshDefaults}`
+  and `YouTubeDownloadTranscriptionTests/{queueManagerProcessesYouTubeWithTitle, downloadAndTranscribeWithPrefetchedInfo, downloadAndTranscribeYouTubeVideo}`.
+  They all need a downloaded WhisperKit model and/or network, and none of them
+  touch the code this change moved — but I am *not* claiming they were already
+  red, because I never got a clean baseline. Every attempt to run the base tree
+  hit the known "Early unexpected exit, never finished bootstrapping" flake, and
+  the build Mac ran out of disk mid-way. Treat these six as **unverified**.
+- **No live dictation through the backend.** I never drove the real app, so the
+  remote path is proven to compile and to resolve a server, not to put words on
+  screen. That is the verification that matters and it is outstanding.
+- **`switchStreamingDevice()` on the remote engine** activates the selection but
+  does not move an established stream; `AVAudioEngine` pins its input at start
+  and the package's `MicrophoneSource` takes no device argument. The change
+  applies to the next dictation, and it logs that.
+
+## Known issues in what I wrote
+
+Found by an adversarial review pass after the code was written; left unfixed
+because you asked me to stop:
+
+- **Two `DictationWordTracker` instances, one callback slot.** `LiveTranscriptionState`
+  has a single `onConfirmedTextChange`. `WhisperKitTranscriber`'s tracker
+  registers on it, and `StreamingTranscriber.startStreaming` builds its own
+  tracker whose `init` overwrites the same slot. Last writer wins. Inert while
+  `.whisperKit` is selected; it needs fixing before the streaming engine is used
+  in anger. Small fix — hand the tracker to the state instead of letting each
+  engine own one.
+- **Two debug log lines were dropped** in the segment-confirmation move
+  ("New segments to confirm: …" and "No new segments to confirm …"). No UI
+  effect, but the exported log is thinner than before.
+- **`onConfirmedTextChange` is now `@ObservationIgnored`** where it used to be an
+  observed `var`. Nothing reads it from a view body, so this is currently inert.
+
+Everything else in the move was checked line by line against `098bf9b` and found
+faithful: the index arithmetic, the `!newConfirmedText.isEmpty` guard, when
+`lastConfirmedSegmentCount` advances, the `suffix(2)` pending slice, the ordering
+of assignments around `confirmedText`'s `didSet`, and both of the places that
+reset the segment counter.
+
+## New tests
+
+`WhisperaUnitTests/LiveTranscriptionStateTests.swift` (19 tests) pins the segment
+buffer, the flicker filter and the remote ingest path.
+`WhisperaUnitTests/TranscriptionRouterTests.swift` pins that every engine
+resolves to a conformer, that conformers are reused, the capability matrix, and
+the WAV encoder. **These have not been run** — they were written after the last
+successful test pass.

--- a/RESULT.md
+++ b/RESULT.md
@@ -1,209 +1,69 @@
-# WHI-58 — one transcription protocol, plus a streaming remote engine
+# WHI-58 polish — reliability, usability, house style
 
-Branch `ismatulla/whi-58-engine-protocol`, based on `098bf9b`. Commit `2966c37`.
-Not pushed, not merged, no PR.
+Branch `ismatulla/whi-58-engine-protocol` (app) and `feat/swift-dictation-component`
+(package). Not pushed, not merged, no PR.
 
-## What I built
+The earlier WHI-58 build record — the protocol, the three conformers, the shared
+live state — is the version of this file at commit `563c913`. This one records
+the polish pass on top of it.
 
-**The protocol** — `Client/SpeechTranscribing.swift`. Audio in, text out.
-`TranscriptionEngine` stays an enum but is now identity only; what an engine can
-do is `TranscriptionCapabilities` on the conformer, so a new engine adds a case
-in exactly one `switch` (the router) instead of every caller.
+## Plan (written before any behaviour changed)
 
-```swift
-@MainActor
-protocol SpeechTranscribing: AnyObject {
-    nonisolated var engine: TranscriptionEngine { get }
-    nonisolated var capabilities: TranscriptionCapabilities { get }
-    var state: TranscriptionEngineState { get }          // .unavailable(why) / .preparing(progress,status) / .ready
-    func prepare() async throws
-    func shutdown()
+### 1. Reliability
 
-    var activeModel: String? { get }
-    func models() async throws -> [TranscriptionModelInfo]
-    func selectModel(_ id: String) async throws
-    func downloadModel(_ id: String) async throws
-    func cancelModelDownload()
+**Root cause first, workaround second.** The `InternalServerError` that kills a
+speaches session ~1.5 s after the first transcript is not a transcription fault.
+Its traceback ends in `speaches/routers/chat.py` → `openai.APIConnectionError`:
+the OpenAI Realtime API is conversational, so after server-side VAD closes an
+utterance speaches auto-generates an assistant *response* and routes it at a
+chat-completions backend that is not configured on that host. The socket dies
+with it. speaches ignores `intent=transcription` but does accept
+`turn_detection: {type: "server_vad", create_response: false}` in
+`session.update`.
 
-    func transcribe(fileAt: URL, options: TranscriptionOptions) async throws -> String
-    func transcribe(samples: [Float], options: TranscriptionOptions) async throws -> String
-    func transcribeWithTimestamps(fileAt: URL, options: TranscriptionOptions) async throws -> [TranscriptionSegment]
+So:
 
-    var onLiveAudioSamples: (@MainActor ([Float]) -> Void)? { get set }
-    func resetStreamingSession()
-    func startStreaming(options: TranscriptionOptions) async throws
-    func switchStreamingDevice() async
-    func stopStreaming()
-}
-```
+1. `RealtimeProtocol.sessionUpdate` sends `turn_detection` with
+   `create_response: false`. That removes the cause. Because sending
+   `turn_detection` at all replaces the engine's VAD block, the learned
+   `silence_duration_ms` from `session.created` is echoed back, or the trailing
+   silence budget the session computes from it goes stale.
+2. A **bounded reconnect** stays, for closes that are genuinely unexpected.
+   `DictationError` grows an `isRecoverable` classification — server error,
+   unexpected close, dropped connection are recoverable; a rejected credential
+   after the permitted retry, an unavailable credential, a protocol violation,
+   unavailable audio and a cancelled session are terminal. `DictationSession`
+   reconnects once, with backoff, and only while the audio source can be
+   resubscribed (the microphone can; a file or a drained push source cannot, and
+   retrying those would send silence and call it success).
+3. A first-connect transport failure goes through the same budget, so the
+   intermittent `connectionFailed("The Internet connection appears to be
+   offline.")` retries before it is surfaced.
+4. `DictationConnectionState` grows `.reconnecting(attempt:)` so the gap is
+   visible in the UI rather than hidden. Audio spoken during the gap is lost;
+   that is stated on screen.
 
-Protocol-extension defaults throw `TranscriptionEngineError.unsupported(engine:capability:)`,
-so a conformer writes only what it does and an unsupported request fails loudly
-rather than silently degrading (WHI-42's rule).
+All of it is pinned by checks that never touch the network, in
+`Sources/DictationChecks`.
 
-`TranscriptionOptions` is deliberately narrow — `mode` (`.transcribe`/`.translate`)
-and `language`. WhisperKit's sample length, prefill caches and temperature
-fallbacks stay inside the conformer that understands them, so a second engine
-never has to widen the type. `TranscriptionModelInfo` and
-`TranscriptionEngineState` are the other two neutral types.
+### 2. Usability
 
-**Three conformers.**
+1. Direct mode gets the engine-URL and model fields in Settings, composed from
+   the existing `SettingsSection`/`SettingRow`, so `defaults write` is no longer
+   required.
+2. Choosing a server engine turns live transcription on, and says so, rather than
+   silently leaving the user on the record-then-transcribe path that looks broken.
+3. `LiveTranscriptionState.waitingForModelStatusText` carries connecting,
+   listening, reconnecting and failure, each in plain language.
+4. Failures raise a `.alert()` with the `presenting:` data pattern, carrying a
+   message that says what to do. The HUD keeps only the short status line.
 
-| Engine | Conformer | Capabilities |
-|---|---|---|
-| `.whisperKit` | `WhisperKitTranscriber` (`Client/WhisperKitTranscriber+Engine.swift`) | file, buffer, timestamps, streaming, managed models, translation |
-| `.whisperViaBYOK` | `RemoteBatchTranscriber` (new) | file, buffer |
-| `.whisperaStreaming` | `StreamingTranscriber` (new) | streaming, file, buffer |
+### 3. Style
 
-The WhisperKit conformance is a pure adapter — every member forwards to a method
-that already existed. `RemoteBatchTranscriber` wraps the untouched
-`RemoteTranscriber` (its tests still pass unmodified) and adds a WAV encoder for
-the raw-buffer path. `StreamingTranscriber` uses `WhisperaDictation` for the
-socket, the resampling and the credentials; it only resolves which server to
-talk to and turns that package's events into shared UI state.
+`design-language.md` spacing (4/8/12/16/20/24), `.easeInOut(duration: 0.2)` on
+state, `.easeOut(duration: 0.1)` on presses, no new section style, no emoji, no
+`print`, reduced-motion respected.
 
-**The router** — `Client/TranscriptionRouter.swift`, a `@MainActor struct` with
-an injectable `engineProvider`, directly mirroring `RecipeRouter`. Conformers are
-shared instances, because a streaming engine holds a socket and a local one holds
-a loaded model.
+## Outcome
 
-**The live UI is reused, not duplicated** — `Client/LiveTranscriptionState.swift`.
-`confirmedText`, `pendingText`, `stableDisplayText`,
-`shouldShowLiveTranscriptionWindow`, `isTranscribing`, `isWaitingForModel`,
-`waitingForModelStatusText`, `currentText` and `onConfirmedTextChange` moved out
-of `WhisperKitTranscriber` into one `@Observable` object, along with the
-two-segment confirmation buffer and the flicker filter, moved verbatim.
-`WhisperKitTranscriber` exposes all of them as forwarding computed properties, so
-its callers and tests are unchanged. `DictationView`, `LiveTranscriptionView` and
-`LiveTranscriptionWindow` now bind to the shared state. There is no second view,
-and `DictationWordTracker` keeps typing remote text into the focused app through
-the same `onConfirmedTextChange` hook.
-
-`AudioManager` talks only to `SpeechTranscribing`. It pins the engine for the
-duration of a dictation (`sessionTranscriber`) so a Settings change mid-recording
-cannot route stop, or a device switch, at an engine that never started.
-
-## Selecting a remote engine at runtime
-
-**UserDefaults, `UserDefaults.standard`, no env vars.**
-
-| Key | Values | Default |
-|---|---|---|
-| `whisperaTranscriptionEngine` | `whisperKit` · `whisperViaBYOK` · `whisperaStreaming` | `whisperKit` (also the fallback for any unrecognised value) |
-| `whisperaTranscriptionServerURL` | base URL of the transcription backend, e.g. `http://192.168.50.184:3000` | empty → falls back to `whisperaServerURL` |
-| `whisperaTranscriptionServerId` | server id from `GET /transcription/servers`, e.g. `speaches-lan` | empty → the backend's own default realtime server |
-| `whisperaByokTranscriptionModel` | model name for the BYOK upload endpoint | `whisper-1` |
-
-In the UI: **Settings → General → Transcription → Engine**. Picking
-"Whispera server (streaming)" reveals the URL and server-id fields.
-
-Auth is a bearer token from the Keychain via `AuthTokenStore` (service
-`com.whispera.clerk`, account `session`) — the same store the account path uses.
-Against the test backend (`NODE_ENV=test`) the token *is* the user id, so saving
-`demo-user` there is enough. The credential is minted per connect attempt and
-once more on the single unauthorized retry, so a short-lived token survives a
-reconnect.
-
-Capabilities, the realtime path and the audio format are read from
-`GET /transcription/servers` — nothing about `pcm16`/24000 Hz is hardcoded in the
-app; the package owns the conversion.
-
-## Engine picker: un-pinned, deliberately
-
-I restored the stored lookup and shipped the picker. The old getter ignored the
-stored value while the setter still wrote it, so the ticket's warning was real —
-but nothing in production ever called that setter, so no shipped install can hold
-a non-default value, and every engine now has a conformer behind it rather than a
-dead enum case. **Confirm you want this**: the moment this build ships, a
-`whisperaTranscriptionEngine` key holding `whisperViaBYOK` (only reachable by
-hand-editing defaults today) would route dictation off-device on first launch.
-
-## What I ran, and what came back
-
-- `GET http://192.168.50.184:3000/transcription/servers` with `Authorization: Bearer demo-user`
-  → 200, one server: `speaches-lan`, model `Systran/faster-distil-whisper-large-v3`,
-  capabilities `["batch","realtime"]`, realtime path `/transcription/stream?server=speaches-lan`,
-  audio `pcm16` / 24000 Hz / mono / `base64-json`.
-- Full build on the build Mac (`192.168.50.89`, Xcode 26.2), after rsyncing both
-  the worktree and the package:
-  `xcodebuild -scheme Whispera -destination "platform=macOS,arch=arm64" -derivedDataPath build/test-derived CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO build`
-  → **BUILD SUCCEEDED**. `WhisperaDictation.swiftmodule` and `.o` are in the
-  products directory, so the package really did resolve, compile and link. The
-  repo's `swift-format lint` build phase passed over the new files.
-- `xcodebuild test -only-testing:WhisperaUnitTests` on this branch: one complete
-  pass. Every suite passed except six tests, listed below.
-- `Package.resolved` is byte-identical before and after — a local package adds no pin.
-
-## The package dependency is NOT what the brief specified
-
-The brief said to pin `whispera-components` to branch `feat/swift-dictation-component`.
-That is not possible today, for two independent reasons I verified:
-
-1. **The branch has never been pushed.** `git ls-remote --heads origin` on the
-   checkout returns only `refs/heads/main` (`a0b114e`). The local tip `fb22655`
-   exists nowhere but that worktree.
-2. **The manifest is not at the repo root.** It lives at `apple/Package.swift`,
-   and SwiftPM cannot point a URL dependency at a subdirectory. So even `main`
-   could not be consumed by URL.
-
-What I did instead: an `XCLocalSwiftPackageReference` with
-`relativePath = ../../whispera-components-worktrees/dictation/apple`, plus an
-`XCSwiftPackageProductDependency` on `WhisperaDictation` linked into the app
-target. It builds, but it depends on that sibling checkout existing next to the
-worktree — I rsynced it to the build Mac at the mirrored path.
-
-**Decision for the owner:** push the branch and move the manifest to the repo
-root (or split the Apple package into its own repo), then swap this one pbxproj
-node for an `XCRemoteSwiftPackageReference`. Nothing else in the app changes.
-
-## Unfinished
-
-- **Six tests failed on this branch and I did not get them baselined.** All in
-  `WhisperaUnitTests`:
-  `FileTranscriptionTimestampE2ETests/{timestampedTranscriptionCarriesTimestampsInEveryLine, plainTranscriptionCarriesNoTimestamps, queuePathProducesTimestampsWithFreshDefaults}`
-  and `YouTubeDownloadTranscriptionTests/{queueManagerProcessesYouTubeWithTitle, downloadAndTranscribeWithPrefetchedInfo, downloadAndTranscribeYouTubeVideo}`.
-  They all need a downloaded WhisperKit model and/or network, and none of them
-  touch the code this change moved — but I am *not* claiming they were already
-  red, because I never got a clean baseline. Every attempt to run the base tree
-  hit the known "Early unexpected exit, never finished bootstrapping" flake, and
-  the build Mac ran out of disk mid-way. Treat these six as **unverified**.
-- **No live dictation through the backend.** I never drove the real app, so the
-  remote path is proven to compile and to resolve a server, not to put words on
-  screen. That is the verification that matters and it is outstanding.
-- **`switchStreamingDevice()` on the remote engine** activates the selection but
-  does not move an established stream; `AVAudioEngine` pins its input at start
-  and the package's `MicrophoneSource` takes no device argument. The change
-  applies to the next dictation, and it logs that.
-
-## Known issues in what I wrote
-
-Found by an adversarial review pass after the code was written; left unfixed
-because you asked me to stop:
-
-- **Two `DictationWordTracker` instances, one callback slot.** `LiveTranscriptionState`
-  has a single `onConfirmedTextChange`. `WhisperKitTranscriber`'s tracker
-  registers on it, and `StreamingTranscriber.startStreaming` builds its own
-  tracker whose `init` overwrites the same slot. Last writer wins. Inert while
-  `.whisperKit` is selected; it needs fixing before the streaming engine is used
-  in anger. Small fix — hand the tracker to the state instead of letting each
-  engine own one.
-- **Two debug log lines were dropped** in the segment-confirmation move
-  ("New segments to confirm: …" and "No new segments to confirm …"). No UI
-  effect, but the exported log is thinner than before.
-- **`onConfirmedTextChange` is now `@ObservationIgnored`** where it used to be an
-  observed `var`. Nothing reads it from a view body, so this is currently inert.
-
-Everything else in the move was checked line by line against `098bf9b` and found
-faithful: the index arithmetic, the `!newConfirmedText.isEmpty` guard, when
-`lastConfirmedSegmentCount` advances, the `suffix(2)` pending slice, the ordering
-of assignments around `confirmedText`'s `didSet`, and both of the places that
-reset the segment counter.
-
-## New tests
-
-`WhisperaUnitTests/LiveTranscriptionStateTests.swift` (19 tests) pins the segment
-buffer, the flicker filter and the remote ingest path.
-`WhisperaUnitTests/TranscriptionRouterTests.swift` pins that every engine
-resolves to a conformer, that conformers are reused, the capability matrix, and
-the WAV encoder. **These have not been run** — they were written after the last
-successful test pass.
+_Filled in below once the work was done and driven._

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -140,7 +140,7 @@ struct SettingsView: View {
 	@AppStorage("globalCommandShortcut") private var globalCommandShortcut = "⌘⌥C"
 	@AppStorage("useStreamingTranscription") private var useStreamingTranscription = true
 	@AppStorage("whisperaTranscriptionEngine") private var transcriptionEngineRaw = TranscriptionEngine
-		.whisperKit.rawValue
+		.auto.rawValue
 	@AppStorage("whisperaTranscriptionServerURL") private var transcriptionServerURL = ""
 	@AppStorage("whisperaTranscriptionServerId") private var transcriptionServerId = ""
 	@AppStorage("whisperaTranscriptionDirectModel") private var transcriptionDirectModel = ""
@@ -156,10 +156,12 @@ struct SettingsView: View {
 		MaterialStyle(rawValue: materialStyleRaw)
 	}
 
-	/// Falls back on-device for the same reason `WhisperaSettings` does: a stored
-	/// engine from a build that shipped one we no longer do must degrade, not trap.
+	/// Falls back to `auto` for the same reason `WhisperaSettings` does: a stored
+	/// engine from a build that shipped one we no longer do must degrade, not
+	/// trap — and `auto` itself degrades further, to on-device, whenever nothing
+	/// is configured.
 	private var selectedTranscriptionEngine: TranscriptionEngine {
-		TranscriptionEngine(rawValue: transcriptionEngineRaw) ?? .whisperKit
+		TranscriptionEngine(rawValue: transcriptionEngineRaw) ?? .auto
 	}
 
 	/// The live state, for the dictation-failure alert. Read directly rather than
@@ -219,6 +221,10 @@ struct SettingsView: View {
 	@State private var directModelOptions: [TranscriptionModelInfo] = []
 	@State private var isFetchingDirectModels = false
 	@State private var directModelFetchError: String?
+	// Automatic engine: what it currently resolves to, refreshed whenever the
+	// picker lands on it. Same shape as the direct-mode model fetch above.
+	@State private var autoResolutionCaption = "Deciding…"
+	@State private var isResolvingAutoEngine = false
 	@AppStorage(SettingsRouting.selectedTabDefaultsKey) private var selectedSettingsTab =
 		SettingsDestination.general.rawValue
 
@@ -507,6 +513,35 @@ struct SettingsView: View {
 							}
 						}
 
+						if transcriptionEngineRaw == TranscriptionEngine.auto.rawValue {
+							VStack(alignment: .leading, spacing: 8) {
+								Text(
+									"Streams through a transcription server when one is configured and reachable, preferring the one with the best live-word quality. Falls back to WhisperKit on-device otherwise. Nothing else to set up."
+								)
+								.font(.caption)
+								.foregroundColor(.secondary)
+								HStack(spacing: 6) {
+									if isResolvingAutoEngine {
+										ProgressView()
+											.scaleEffect(0.5)
+									}
+									Text(autoResolutionCaption)
+										.font(.caption)
+										.foregroundColor(.secondary)
+										.accessibilityIdentifier("autoEngineResolutionCaption")
+								}
+								.animation(.easeInOut(duration: 0.2), value: isResolvingAutoEngine)
+							}
+							.task(id: transcriptionEngineRaw) {
+								guard transcriptionEngineRaw == TranscriptionEngine.auto.rawValue else {
+									return
+								}
+								isResolvingAutoEngine = true
+								autoResolutionCaption = await AutoTranscriber.shared.resolutionCaption()
+								isResolvingAutoEngine = false
+							}
+						}
+
 						if transcriptionEngineRaw == TranscriptionEngine.whisperaStreaming.rawValue {
 							VStack(alignment: .leading, spacing: 8) {
 								Text(
@@ -611,7 +646,12 @@ struct SettingsView: View {
 							}
 						}
 
-						if selectedTranscriptionEngine.streamsFromAServer {
+						// `auto` is included alongside the server engines: it may resolve to
+						// one, and the wording below is already engine-agnostic — the
+						// caveat is exactly as true when `auto` lands on WhisperKit.
+						if selectedTranscriptionEngine.streamsFromAServer
+							|| selectedTranscriptionEngine == .auto
+						{
 							InfoBox(style: .info) {
 								Text(
 									enableStreaming

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -139,11 +139,6 @@ struct SettingsView: View {
 	@AppStorage("autoExecuteCommands") private var autoExecuteCommands = false
 	@AppStorage("globalCommandShortcut") private var globalCommandShortcut = "⌘⌥C"
 	@AppStorage("useStreamingTranscription") private var useStreamingTranscription = true
-	@AppStorage("whisperaTranscriptionEngine") private var transcriptionEngineRaw = TranscriptionEngine
-		.auto.rawValue
-	@AppStorage("whisperaTranscriptionServerURL") private var transcriptionServerURL = ""
-	@AppStorage("whisperaTranscriptionServerId") private var transcriptionServerId = ""
-	@AppStorage("whisperaTranscriptionDirectModel") private var transcriptionDirectModel = ""
 	@AppStorage("shortcutHapticFeedback") private var shortcutHapticFeedback = false
 	@AppStorage("enableRecordingGlow") private var enableRecordingGlow = true
 	// Key unchanged from the older pause-based feature so existing opt-outs survive.
@@ -154,14 +149,6 @@ struct SettingsView: View {
 
 	private var materialStyle: MaterialStyle {
 		MaterialStyle(rawValue: materialStyleRaw)
-	}
-
-	/// Falls back to `auto` for the same reason `WhisperaSettings` does: a stored
-	/// engine from a build that shipped one we no longer do must degrade, not
-	/// trap — and `auto` itself degrades further, to on-device, whenever nothing
-	/// is configured.
-	private var selectedTranscriptionEngine: TranscriptionEngine {
-		TranscriptionEngine(rawValue: transcriptionEngineRaw) ?? .auto
 	}
 
 	/// The live state, for the dictation-failure alert. Read directly rather than
@@ -214,17 +201,6 @@ struct SettingsView: View {
 	@State private var liveTranscriptionInfoWindow: NSWindow?
 	@State private var logsSize: String = "Calculating..."
 	@State private var showingClearLogsConfirmation = false
-	// Direct-mode ("realtimeDirect") model list: fetched from the engine's own
-	// /models endpoint rather than typed by hand. Empty + no error means "not
-	// fetched yet", which is also the state a failed fetch falls back to, so the
-	// free-text field underneath stays reachable either way.
-	@State private var directModelOptions: [TranscriptionModelInfo] = []
-	@State private var isFetchingDirectModels = false
-	@State private var directModelFetchError: String?
-	// Automatic engine: what it currently resolves to, refreshed whenever the
-	// picker lands on it. Same shape as the direct-mode model fetch above.
-	@State private var autoResolutionCaption = "Deciding…"
-	@State private var isResolvingAutoEngine = false
 	@AppStorage(SettingsRouting.selectedTabDefaultsKey) private var selectedSettingsTab =
 		SettingsDestination.general.rawValue
 
@@ -487,181 +463,13 @@ struct SettingsView: View {
 					Divider()
 
 					SettingsSection("Transcription") {
-						SettingRow(
-							"Engine",
-							description: "Where speech-to-text runs. On-device needs no network."
-						) {
-							Picker("Transcription engine", selection: $transcriptionEngineRaw) {
-								ForEach(TranscriptionEngine.allCases, id: \.rawValue) { engine in
-									Text(engine.displayName).tag(engine.rawValue)
-								}
-							}
-							.labelsHidden()
-							.frame(width: 240)
-							.accessibilityIdentifier("transcriptionEnginePicker")
-							// A server engine with live transcription off records first and
-							// transcribes at the end, which reads as the engine not working.
-							// Choosing one turns it on; the box below says so, and the
-							// toggle stays the user's.
-							.onChange(of: transcriptionEngineRaw) { _, raw in
-								guard TranscriptionEngine(rawValue: raw)?.streamsFromAServer == true,
-									!enableStreaming
-								else { return }
-								enableStreaming = true
-								AppLogger.shared.general.info(
-									"Live transcription turned on because a server engine was selected: \(raw)")
-							}
-						}
-
-						if transcriptionEngineRaw == TranscriptionEngine.auto.rawValue {
-							VStack(alignment: .leading, spacing: 8) {
-								Text(
-									"Streams through a transcription server when one is configured and reachable, preferring the one with the best live-word quality. Falls back to WhisperKit on-device otherwise. Nothing else to set up."
-								)
-								.font(.caption)
-								.foregroundColor(.secondary)
-								HStack(spacing: 6) {
-									if isResolvingAutoEngine {
-										ProgressView()
-											.scaleEffect(0.5)
-									}
-									Text(autoResolutionCaption)
-										.font(.caption)
-										.foregroundColor(.secondary)
-										.accessibilityIdentifier("autoEngineResolutionCaption")
-								}
-								.animation(.easeInOut(duration: 0.2), value: isResolvingAutoEngine)
-							}
-							.task(id: transcriptionEngineRaw) {
-								guard transcriptionEngineRaw == TranscriptionEngine.auto.rawValue else {
-									return
-								}
-								isResolvingAutoEngine = true
-								autoResolutionCaption = await AutoTranscriber.shared.resolutionCaption()
-								isResolvingAutoEngine = false
-							}
-						}
-
-						if transcriptionEngineRaw == TranscriptionEngine.whisperaStreaming.rawValue {
-							VStack(alignment: .leading, spacing: 8) {
-								Text(
-									"Streams audio to a Whispera transcription server over a WebSocket. Leave the server blank to use the backend's own default."
-								)
-								.font(.caption)
-								.foregroundColor(.secondary)
-								TextField(
-									WhisperaSettings.serverURLString + " (leave blank to reuse the account server)",
-									text: $transcriptionServerURL
-								)
-								.textFieldStyle(.roundedBorder)
-								.autocorrectionDisabled()
-								.accessibilityIdentifier("transcriptionServerURLField")
-								TextField("Server id (e.g. speaches-lan)", text: $transcriptionServerId)
-									.textFieldStyle(.roundedBorder)
-									.autocorrectionDisabled()
-									.accessibilityIdentifier("transcriptionServerIdField")
-							}
-						}
-
-						// Direct mode has no backend to ask which engines exist or what
-						// they run, so both are the user's to state. Without these fields
-						// the engine is only reachable by editing defaults by hand.
-						if transcriptionEngineRaw == TranscriptionEngine.realtimeDirect.rawValue {
-							VStack(alignment: .leading, spacing: 8) {
-								Text(
-									"Streams audio straight to an OpenAI-Realtime engine, with no Whispera backend in between. The engine holds its own credentials, so use this only on a network you trust."
-								)
-								.font(.caption)
-								.foregroundColor(.secondary)
-								TextField("http://192.168.0.10:8000/v1", text: $transcriptionServerURL)
-									.textFieldStyle(.roundedBorder)
-									.autocorrectionDisabled()
-									.accessibilityIdentifier("directEngineURLField")
-
-								HStack(spacing: 8) {
-									if isFetchingDirectModels {
-										ProgressView()
-											.scaleEffect(0.6)
-										Text("Checking the engine for installed models…")
-											.font(.caption)
-											.foregroundColor(.secondary)
-									} else if !directModelOptions.isEmpty {
-										Picker("Model", selection: $transcriptionDirectModel) {
-											ForEach(directModelOptions) { model in
-												Text(model.displayName).tag(model.id)
-											}
-										}
-										.labelsHidden()
-										.frame(width: 260)
-										.accessibilityIdentifier("directEngineModelPicker")
-									} else {
-										// Fallback: the fetch never ran or it failed. Typing a
-										// model by hand keeps the engine reachable even when
-										// Whispera cannot list what it has installed.
-										TextField(
-											"Model (e.g. Systran/faster-distil-whisper-large-v3)",
-											text: $transcriptionDirectModel
-										)
-										.textFieldStyle(.roundedBorder)
-										.autocorrectionDisabled()
-										.accessibilityIdentifier("directEngineModelField")
-									}
-
-									Button {
-										refreshDirectModels()
-									} label: {
-										Image(systemName: "arrow.clockwise")
-									}
-									.buttonStyle(.bordered)
-									.controlSize(.small)
-									.disabled(isFetchingDirectModels)
-									.accessibilityIdentifier("directEngineModelsRefreshButton")
-									.help("Ask the engine what speech-to-text models it has installed")
-								}
-								.animation(.easeInOut(duration: 0.2), value: isFetchingDirectModels)
-								.animation(.easeInOut(duration: 0.2), value: directModelOptions)
-
-								if let directModelFetchError {
-									HStack(spacing: 6) {
-										Image(systemName: "exclamationmark.triangle.fill")
-											.foregroundColor(.orange)
-											.font(.caption)
-										Text(directModelFetchError)
-											.font(.caption)
-											.foregroundColor(.orange)
-									}
-									.transition(.opacity)
-								}
-
-								Text(
-									"The URL is the engine's OpenAI-compatible base, ending in /v1. Refresh to list the models it already has installed, or type one directly if it cannot be reached right now."
-								)
-								.font(.caption)
-								.foregroundColor(.secondary)
-							}
-							.animation(.easeInOut(duration: 0.2), value: directModelFetchError)
-							.task(id: transcriptionEngineRaw) {
-								guard directModelOptions.isEmpty, directModelFetchError == nil else { return }
-								refreshDirectModels()
-							}
-						}
-
-						// `auto` is included alongside the server engines: it may resolve to
-						// one, and the wording below is already engine-agnostic — the
-						// caveat is exactly as true when `auto` lands on WhisperKit.
-						if selectedTranscriptionEngine.streamsFromAServer
-							|| selectedTranscriptionEngine == .auto
-						{
-							InfoBox(style: .info) {
-								Text(
-									enableStreaming
-										? "Live transcription is on, so words appear while you speak. Turning it off under Live Transcription Mode makes Whispera record first and transcribe at the end."
-										: "Live Transcription Mode is off, so nothing appears until you stop speaking and the whole recording is transcribed. Turn it on below to see words as you say them."
-								)
-								.font(.caption)
-								.foregroundColor(.secondary)
-							}
-						}
+						// The engine picker and every server field moved to the Servers
+						// tab; this line is the trail for anyone who last saw them here.
+						Text(
+							"The speech engine and its servers are set up in the Servers tab."
+						)
+						.font(.caption)
+						.foregroundColor(.secondary)
 
 						SettingRow(
 							"Streaming Transcription",
@@ -832,12 +640,12 @@ struct SettingsView: View {
 			}
 			.tag(SettingsDestination.general.rawValue)
 
-			// MARK: - AI Mode Tab
-			LLMModeSettingsView()
+			// MARK: - Servers Tab
+			ServersSettingsView()
 				.tabItem {
-					Label("AI Mode", systemImage: "brain")
+					Label("Servers", systemImage: "server.rack")
 				}
-				.tag(SettingsDestination.aiMode.rawValue)
+				.tag(SettingsDestination.servers.rawValue)
 
 			// MARK: - Recipes Tab
 			RecipesView()
@@ -1289,6 +1097,11 @@ struct SettingsView: View {
 		}
 		.frame(maxWidth: 600)
 		.onAppear {
+			// The AI Mode tab became the Servers tab; a stored selection of the
+			// old tab would otherwise leave the TabView with nothing selected.
+			if selectedSettingsTab == "aiMode" {
+				selectedSettingsTab = SettingsDestination.servers.rawValue
+			}
 			loadAvailableModels()
 			checkLaunchAtStartupStatus()
 			updateLogsSize()
@@ -1727,29 +1540,6 @@ struct SettingsView: View {
 
 		// Store reference
 		liveTranscriptionInfoWindow = window
-	}
-
-	/// Asks the directly-addressed engine what speech-to-text models it has
-	/// installed. A failure keeps whatever model string is already saved and
-	/// falls back to the free-text field rather than clearing the selection —
-	/// an engine that is briefly unreachable should not cost the user their
-	/// configured model.
-	private func refreshDirectModels() {
-		isFetchingDirectModels = true
-		directModelFetchError = nil
-		Task { @MainActor in
-			do {
-				let models = try await StreamingTranscriber.direct.models()
-				directModelOptions = models
-				isFetchingDirectModels = false
-			} catch {
-				AppLogger.shared.general.error(
-					"Failed to list direct-engine models: \(error.localizedDescription)")
-				directModelOptions = []
-				directModelFetchError = error.localizedDescription
-				isFetchingDirectModels = false
-			}
-		}
 	}
 
 	private func getModelStatusText() -> String {

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -139,6 +139,10 @@ struct SettingsView: View {
 	@AppStorage("autoExecuteCommands") private var autoExecuteCommands = false
 	@AppStorage("globalCommandShortcut") private var globalCommandShortcut = "⌘⌥C"
 	@AppStorage("useStreamingTranscription") private var useStreamingTranscription = true
+	@AppStorage("whisperaTranscriptionEngine") private var transcriptionEngineRaw = TranscriptionEngine
+		.whisperKit.rawValue
+	@AppStorage("whisperaTranscriptionServerURL") private var transcriptionServerURL = ""
+	@AppStorage("whisperaTranscriptionServerId") private var transcriptionServerId = ""
 	@AppStorage("shortcutHapticFeedback") private var shortcutHapticFeedback = false
 	@AppStorage("enableRecordingGlow") private var enableRecordingGlow = true
 	// Key unchanged from the older pause-based feature so existing opt-outs survive.
@@ -457,6 +461,41 @@ struct SettingsView: View {
 					Divider()
 
 					SettingsSection("Transcription") {
+						SettingRow(
+							"Engine",
+							description: "Where speech-to-text runs. On-device needs no network."
+						) {
+							Picker("Transcription engine", selection: $transcriptionEngineRaw) {
+								ForEach(TranscriptionEngine.allCases, id: \.rawValue) { engine in
+									Text(engine.displayName).tag(engine.rawValue)
+								}
+							}
+							.labelsHidden()
+							.frame(width: 240)
+							.accessibilityIdentifier("transcriptionEnginePicker")
+						}
+
+						if transcriptionEngineRaw == TranscriptionEngine.whisperaStreaming.rawValue {
+							VStack(alignment: .leading, spacing: 8) {
+								Text(
+									"Streams audio to a Whispera transcription server over a WebSocket. Leave the server blank to use the backend's own default."
+								)
+								.font(.caption)
+								.foregroundColor(.secondary)
+								TextField(
+									WhisperaSettings.serverURLString + " (leave blank to reuse the account server)",
+									text: $transcriptionServerURL
+								)
+								.textFieldStyle(.roundedBorder)
+								.autocorrectionDisabled()
+								.accessibilityIdentifier("transcriptionServerURLField")
+								TextField("Server id (e.g. speaches-lan)", text: $transcriptionServerId)
+									.textFieldStyle(.roundedBorder)
+									.autocorrectionDisabled()
+									.accessibilityIdentifier("transcriptionServerIdField")
+							}
+						}
+
 						SettingRow(
 							"Streaming Transcription",
 							description:

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -167,13 +167,14 @@ struct SettingsView: View {
 	private let liveTranscription = LiveTranscriptionState.shared
 
 	// MARK: - Live Transcription Settings
+	// No caret-follow or cursor-offset settings: the live-words window now
+	// always rests above the listening pill (see PillAnchor), so there is
+	// nothing left for either knob to control.
 	@AppStorage("liveTranscriptionMaxWords") private var liveTranscriptionMaxWords = 5
 	@AppStorage("liveTranscriptionCornerRadius") private var liveTranscriptionCornerRadius = 10.0
-	@AppStorage("liveTranscriptionWindowOffset") private var liveTranscriptionWindowOffset = 25.0
 	@AppStorage("liveTranscriptionShowEllipsis") private var liveTranscriptionShowEllipsis = true
 	@AppStorage("liveTranscriptionMaxWidthPercentage") private
 		var liveTranscriptionMaxWidthPercentage = 0.6
-	@AppStorage("liveTranscriptionFollowCaret") private var liveTranscriptionFollowCaret = true
 
 	// MARK: - File Transcription Settings
 	@AppStorage("fileSelectionShortcut") private var fileSelectionShortcut = "⌃F"
@@ -972,29 +973,6 @@ struct SettingsView: View {
 
 							VStack(alignment: .leading, spacing: 8) {
 								HStack {
-									Text("Window Position Offset")
-										.font(.subheadline)
-									Spacer()
-									Text("\(Int(liveTranscriptionWindowOffset)) px")
-										.font(.system(.body, design: .monospaced))
-										.foregroundColor(.secondary)
-								}
-
-								Slider(value: $liveTranscriptionWindowOffset, in: 10...50, step: 5)
-									.onChange(of: liveTranscriptionWindowOffset) {
-										NSHapticFeedbackManager.defaultPerformer.perform(
-											.generic, performanceTime: .now)
-									}
-
-								Text("Distance from the cursor position")
-									.font(.caption)
-									.foregroundColor(.secondary)
-							}
-
-							Divider()
-
-							VStack(alignment: .leading, spacing: 8) {
-								HStack {
 									Text("Maximum Window Width")
 										.font(.subheadline)
 									Spacer()
@@ -1025,13 +1003,6 @@ struct SettingsView: View {
 								"Show Ellipsis", description: "Display '...' when text is truncated"
 							) {
 								Toggle("", isOn: $liveTranscriptionShowEllipsis)
-							}
-
-							SettingRow(
-								"Follow Caret Position",
-								description: "Window follows cursor position while typing"
-							) {
-								Toggle("", isOn: $liveTranscriptionFollowCaret)
 							}
 						}
 
@@ -1772,70 +1743,21 @@ struct LiveTranscriptionPreview: View {
 
 	private let sampleText = "The quick brown fox jumps over the lazy dog and runs through the forest"
 
-	private var displayWords: [(text: String, isLast: Bool)] {
-		let words = sampleText.split(separator: " ").map(String.init)
-		guard !words.isEmpty else { return [] }
+	// Renders through the same PillWordFlow + pillChrome the real live-words
+	// window uses, so this preview can never drift from what Settings promises.
+	private var displayWords: [String] {
+		Array(sampleText.split(separator: " ").map(String.init).suffix(maxWords))
+	}
 
-		let wordsToShow = words.suffix(maxWords)
-		return wordsToShow.enumerated().map { index, word in
-			(text: word, isLast: index == wordsToShow.count - 1)
-		}
+	private var hasHiddenWords: Bool {
+		showEllipsis && sampleText.split(separator: " ").count > maxWords
 	}
 
 	var body: some View {
-		VStack(spacing: 0) {
-			HStack(spacing: 4) {
-				// Show ellipsis if configured and there are more words
-				if showEllipsis && sampleText.split(separator: " ").count > maxWords {
-					Text("...")
-						.font(.system(.body, design: .rounded))
-						.foregroundColor(Color.secondary.opacity(0.6))
-						.padding(.trailing, 2)
-				}
-
-				ForEach(Array(displayWords.enumerated()), id: \.offset) { _, wordInfo in
-					Text(wordInfo.text)
-						.font(.system(wordInfo.isLast ? .title3 : .body, design: .rounded))
-						.foregroundColor(wordInfo.isLast ? Color.blue : Color.primary.opacity(0.8))
-						.fontWeight(wordInfo.isLast ? .semibold : .regular)
-				}
-			}
-			.padding(.horizontal, 14)
-			.padding(.vertical, 10)
-		}
-		.background(
-			RoundedRectangle(cornerRadius: cornerRadius)
-				.fill(.ultraThinMaterial)
-				.overlay(
-					RoundedRectangle(cornerRadius: cornerRadius)
-						.fill(
-							LinearGradient(
-								colors: [
-									Color.blue.opacity(0.05),
-									Color.blue.opacity(0.02),
-								],
-								startPoint: .topLeading,
-								endPoint: .bottomTrailing
-							)
-						)
-				)
-		)
-		.overlay(
-			RoundedRectangle(cornerRadius: cornerRadius)
-				.strokeBorder(
-					LinearGradient(
-						colors: [
-							Color.blue.opacity(0.3),
-							Color.blue.opacity(0.1),
-						],
-						startPoint: .topLeading,
-						endPoint: .bottomTrailing
-					),
-					lineWidth: 1
-				)
-		)
-		.shadow(color: Color.blue.opacity(0.1), radius: 8, x: 0, y: 2)
-		.shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 1)
+		PillWordFlow(words: displayWords, showEllipsis: hasHiddenWords)
+			.padding(.horizontal, PillSpacing.md)
+			.padding(.vertical, PillSpacing.sm)
+			.pillChrome(cornerRadius: cornerRadius)
 	}
 }
 

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -212,6 +212,13 @@ struct SettingsView: View {
 	@State private var liveTranscriptionInfoWindow: NSWindow?
 	@State private var logsSize: String = "Calculating..."
 	@State private var showingClearLogsConfirmation = false
+	// Direct-mode ("realtimeDirect") model list: fetched from the engine's own
+	// /models endpoint rather than typed by hand. Empty + no error means "not
+	// fetched yet", which is also the state a failed fetch falls back to, so the
+	// free-text field underneath stays reachable either way.
+	@State private var directModelOptions: [TranscriptionModelInfo] = []
+	@State private var isFetchingDirectModels = false
+	@State private var directModelFetchError: String?
 	@AppStorage(SettingsRouting.selectedTabDefaultsKey) private var selectedSettingsTab =
 		SettingsDestination.general.rawValue
 
@@ -535,18 +542,72 @@ struct SettingsView: View {
 									.textFieldStyle(.roundedBorder)
 									.autocorrectionDisabled()
 									.accessibilityIdentifier("directEngineURLField")
-								TextField(
-									"Model (e.g. Systran/faster-distil-whisper-large-v3)",
-									text: $transcriptionDirectModel
-								)
-								.textFieldStyle(.roundedBorder)
-								.autocorrectionDisabled()
-								.accessibilityIdentifier("directEngineModelField")
+
+								HStack(spacing: 8) {
+									if isFetchingDirectModels {
+										ProgressView()
+											.scaleEffect(0.6)
+										Text("Checking the engine for installed models…")
+											.font(.caption)
+											.foregroundColor(.secondary)
+									} else if !directModelOptions.isEmpty {
+										Picker("Model", selection: $transcriptionDirectModel) {
+											ForEach(directModelOptions) { model in
+												Text(model.displayName).tag(model.id)
+											}
+										}
+										.labelsHidden()
+										.frame(width: 260)
+										.accessibilityIdentifier("directEngineModelPicker")
+									} else {
+										// Fallback: the fetch never ran or it failed. Typing a
+										// model by hand keeps the engine reachable even when
+										// Whispera cannot list what it has installed.
+										TextField(
+											"Model (e.g. Systran/faster-distil-whisper-large-v3)",
+											text: $transcriptionDirectModel
+										)
+										.textFieldStyle(.roundedBorder)
+										.autocorrectionDisabled()
+										.accessibilityIdentifier("directEngineModelField")
+									}
+
+									Button {
+										refreshDirectModels()
+									} label: {
+										Image(systemName: "arrow.clockwise")
+									}
+									.buttonStyle(.bordered)
+									.controlSize(.small)
+									.disabled(isFetchingDirectModels)
+									.accessibilityIdentifier("directEngineModelsRefreshButton")
+									.help("Ask the engine what speech-to-text models it has installed")
+								}
+								.animation(.easeInOut(duration: 0.2), value: isFetchingDirectModels)
+								.animation(.easeInOut(duration: 0.2), value: directModelOptions)
+
+								if let directModelFetchError {
+									HStack(spacing: 6) {
+										Image(systemName: "exclamationmark.triangle.fill")
+											.foregroundColor(.orange)
+											.font(.caption)
+										Text(directModelFetchError)
+											.font(.caption)
+											.foregroundColor(.orange)
+									}
+									.transition(.opacity)
+								}
+
 								Text(
-									"The URL is the engine's OpenAI-compatible base, ending in /v1. The model has to be one the engine already has installed."
+									"The URL is the engine's OpenAI-compatible base, ending in /v1. Refresh to list the models it already has installed, or type one directly if it cannot be reached right now."
 								)
 								.font(.caption)
 								.foregroundColor(.secondary)
+							}
+							.animation(.easeInOut(duration: 0.2), value: directModelFetchError)
+							.task(id: transcriptionEngineRaw) {
+								guard directModelOptions.isEmpty, directModelFetchError == nil else { return }
+								refreshDirectModels()
 							}
 						}
 
@@ -1626,6 +1687,29 @@ struct SettingsView: View {
 
 		// Store reference
 		liveTranscriptionInfoWindow = window
+	}
+
+	/// Asks the directly-addressed engine what speech-to-text models it has
+	/// installed. A failure keeps whatever model string is already saved and
+	/// falls back to the free-text field rather than clearing the selection —
+	/// an engine that is briefly unreachable should not cost the user their
+	/// configured model.
+	private func refreshDirectModels() {
+		isFetchingDirectModels = true
+		directModelFetchError = nil
+		Task { @MainActor in
+			do {
+				let models = try await StreamingTranscriber.direct.models()
+				directModelOptions = models
+				isFetchingDirectModels = false
+			} catch {
+				AppLogger.shared.general.error(
+					"Failed to list direct-engine models: \(error.localizedDescription)")
+				directModelOptions = []
+				directModelFetchError = error.localizedDescription
+				isFetchingDirectModels = false
+			}
+		}
 	}
 
 	private func getModelStatusText() -> String {

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -143,6 +143,7 @@ struct SettingsView: View {
 		.whisperKit.rawValue
 	@AppStorage("whisperaTranscriptionServerURL") private var transcriptionServerURL = ""
 	@AppStorage("whisperaTranscriptionServerId") private var transcriptionServerId = ""
+	@AppStorage("whisperaTranscriptionDirectModel") private var transcriptionDirectModel = ""
 	@AppStorage("shortcutHapticFeedback") private var shortcutHapticFeedback = false
 	@AppStorage("enableRecordingGlow") private var enableRecordingGlow = true
 	// Key unchanged from the older pause-based feature so existing opt-outs survive.
@@ -154,6 +155,16 @@ struct SettingsView: View {
 	private var materialStyle: MaterialStyle {
 		MaterialStyle(rawValue: materialStyleRaw)
 	}
+
+	/// Falls back on-device for the same reason `WhisperaSettings` does: a stored
+	/// engine from a build that shipped one we no longer do must degrade, not trap.
+	private var selectedTranscriptionEngine: TranscriptionEngine {
+		TranscriptionEngine(rawValue: transcriptionEngineRaw) ?? .whisperKit
+	}
+
+	/// The live state, for the dictation-failure alert. Read directly rather than
+	/// mirrored into `@State`: `@Observable` tracks the read from the body.
+	private let liveTranscription = LiveTranscriptionState.shared
 
 	// MARK: - Live Transcription Settings
 	@AppStorage("liveTranscriptionMaxWords") private var liveTranscriptionMaxWords = 5
@@ -192,6 +203,7 @@ struct SettingsView: View {
 	@State private var showingToolsSettings = false
 	@State private var showingSafetySettings = false
 	@State private var showingUpdaterError = false
+	@State private var showingTranscriptionFailure = false
 	@State private var showingStorageDetails = false
 	@State private var showingClearAllConfirmation = false
 	@State private var confirmationStep = 0
@@ -473,6 +485,18 @@ struct SettingsView: View {
 							.labelsHidden()
 							.frame(width: 240)
 							.accessibilityIdentifier("transcriptionEnginePicker")
+							// A server engine with live transcription off records first and
+							// transcribes at the end, which reads as the engine not working.
+							// Choosing one turns it on; the box below says so, and the
+							// toggle stays the user's.
+							.onChange(of: transcriptionEngineRaw) { _, raw in
+								guard TranscriptionEngine(rawValue: raw)?.streamsFromAServer == true,
+									!enableStreaming
+								else { return }
+								enableStreaming = true
+								AppLogger.shared.general.info(
+									"Live transcription turned on because a server engine was selected: \(raw)")
+							}
 						}
 
 						if transcriptionEngineRaw == TranscriptionEngine.whisperaStreaming.rawValue {
@@ -493,6 +517,47 @@ struct SettingsView: View {
 									.textFieldStyle(.roundedBorder)
 									.autocorrectionDisabled()
 									.accessibilityIdentifier("transcriptionServerIdField")
+							}
+						}
+
+						// Direct mode has no backend to ask which engines exist or what
+						// they run, so both are the user's to state. Without these fields
+						// the engine is only reachable by editing defaults by hand.
+						if transcriptionEngineRaw == TranscriptionEngine.realtimeDirect.rawValue {
+							VStack(alignment: .leading, spacing: 8) {
+								Text(
+									"Streams audio straight to an OpenAI-Realtime engine, with no Whispera backend in between. The engine holds its own credentials, so use this only on a network you trust."
+								)
+								.font(.caption)
+								.foregroundColor(.secondary)
+								TextField("http://192.168.0.10:8000/v1", text: $transcriptionServerURL)
+									.textFieldStyle(.roundedBorder)
+									.autocorrectionDisabled()
+									.accessibilityIdentifier("directEngineURLField")
+								TextField(
+									"Model (e.g. Systran/faster-distil-whisper-large-v3)",
+									text: $transcriptionDirectModel
+								)
+								.textFieldStyle(.roundedBorder)
+								.autocorrectionDisabled()
+								.accessibilityIdentifier("directEngineModelField")
+								Text(
+									"The URL is the engine's OpenAI-compatible base, ending in /v1. The model has to be one the engine already has installed."
+								)
+								.font(.caption)
+								.foregroundColor(.secondary)
+							}
+						}
+
+						if selectedTranscriptionEngine.streamsFromAServer {
+							InfoBox(style: .info) {
+								Text(
+									enableStreaming
+										? "Live transcription is on, so words appear while you speak. Turning it off under Live Transcription Mode makes Whispera record first and transcribe at the end."
+										: "Live Transcription Mode is off, so nothing appears until you stop speaking and the whole recording is transcribed. Turn it on below to see words as you say them."
+								)
+								.font(.caption)
+								.foregroundColor(.secondary)
 							}
 						}
 
@@ -1199,6 +1264,18 @@ struct SettingsView: View {
 		}
 		.onChange(of: softwareUpdater.lastUpdaterError) {
 			showingUpdaterError = softwareUpdater.lastUpdaterError != nil
+		}
+		.alert(
+			liveTranscription.failure?.title ?? "Dictation stopped",
+			isPresented: $showingTranscriptionFailure,
+			presenting: liveTranscription.failure
+		) { _ in
+			Button("OK") { liveTranscription.failure = nil }
+		} message: { failure in
+			Text(failure.message)
+		}
+		.onChange(of: liveTranscription.failure) {
+			showingTranscriptionFailure = liveTranscription.failure != nil
 		}
 		.alert("Storage Details", isPresented: $showingStorageDetails) {
 			Button("OK") {}

--- a/What's up?/ListeningView.swift
+++ b/What's up?/ListeningView.swift
@@ -124,21 +124,9 @@ struct ListeningView: View {
 		case .initializing, .recording:
 			micLiveRow
 		case .preparingModel(let status):
-			HStack(spacing: 8) {
-				ZStack {
-					ProgressView()
-						.scaleEffect(0.7)
-				}
-				.frame(width: 20, height: 20)
-				Text(status)
-					.font(.system(.caption, design: .rounded))
-					.foregroundColor(.secondary)
-					.lineLimit(1)
-			}
+			PillStatusRow(indicator: .progress, text: status)
 		case .transcribing:
-			Text("Transcribing...")
-				.font(.system(.caption, design: .rounded))
-				.foregroundColor(.secondary)
+			PillStatusRow(text: "Transcribing...")
 		case .runningRecipe(let name):
 			runningRecipeView(name)
 		}
@@ -147,7 +135,7 @@ struct ListeningView: View {
 	/// One branch for both mic-live phases, so the device icon keeps its identity
 	/// across the initializing/recording flip a device switch causes.
 	private var micLiveRow: some View {
-		HStack(spacing: 8) {
+		HStack(spacing: PillSpacing.sm) {
 			if layout.phase == .recording {
 				controlsButton
 			} else {
@@ -208,16 +196,11 @@ struct ListeningView: View {
 	/// The post-dictation action, running inside the pill. It takes its final
 	/// layout immediately; the window's animated frame growth is what reveals it.
 	private func runningRecipeView(_ name: String) -> some View {
-		HStack(spacing: 8) {
-			ProgressView()
-				.scaleEffect(0.7)
-			Text("Running \(name)…")
-				.font(.system(.caption, design: .rounded))
-				.foregroundColor(.secondary)
-				.lineLimit(1)
+		HStack(spacing: PillSpacing.sm) {
+			PillStatusRow(indicator: .progress, text: "Running \(name)…")
 			if layout.showCancel {
 				Button("Cancel") { coordinator.cancel() }
-					.font(.system(.caption, design: .rounded))
+					.font(PillTypography.status)
 					.buttonStyle(.plain)
 					.foregroundColor(.blue)
 			}
@@ -277,8 +260,8 @@ struct ListeningView: View {
 	private var pillContent: some View {
 		contentView
 			.transition(.opacity)
-			.padding(.horizontal, 14)
-			.padding(.vertical, 10)
+			.padding(.horizontal, PillSpacing.md)
+			.padding(.vertical, PillSpacing.sm)
 			.fixedSize(horizontal: true, vertical: false)
 			// The module swap is a pure fade at the reveal constant. The content
 			// takes its final layout immediately and the window's frame animation
@@ -292,32 +275,12 @@ struct ListeningView: View {
 			if #available(macOS 26.0, *) {
 				pillContent
 					.frame(height: 30 * layout.typeScale)
-					.glassEffect()
 			} else {
 				pillContent
 					.frame(height: 50 * layout.typeScale)
-					.background(
-						RoundedRectangle(cornerRadius: cornerRadius)
-							.fill(.ultraThinMaterial)
-					)
-					.overlay(
-						RoundedRectangle(cornerRadius: cornerRadius)
-							.strokeBorder(
-								LinearGradient(
-									colors: [
-										Color.blue.opacity(0.3),
-										Color.blue.opacity(0.1),
-									],
-									startPoint: .topLeading,
-									endPoint: .bottomTrailing
-								),
-								lineWidth: 1
-							)
-					)
-					.shadow(color: Color.blue.opacity(0.1), radius: 8, x: 0, y: 2)
-					.shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 1)
 			}
 		}
+		.pillChrome(cornerRadius: cornerRadius)
 		// The pill reports its natural laid-out size and the window assigns it once
 		// per real change, mirroring the popover's measurement bridge.
 		.onGeometryChange(for: CGSize.self) { proxy in

--- a/What's up?/ListeningView.swift
+++ b/What's up?/ListeningView.swift
@@ -8,6 +8,10 @@ enum PillPhase: Equatable {
 	case initializing
 	case preparingModel(String)
 	case transcribing
+	/// The post-stop finalize pass ("Polishing…"). A phase of this pill because
+	/// the pill is the anchor the user watches after stopping; the words window
+	/// has already dismissed and must not come back to repeat the status.
+	case finalizing(String)
 	case runningRecipe(String)
 	case recording
 }
@@ -44,6 +48,7 @@ struct PillLayout: Equatable {
 
 struct ListeningView: View {
 	@State private var whisperKit = WhisperKitTranscriber.shared
+	@State private var live = LiveTranscriptionState.shared
 	@State private var coordinator = DictationCoordinator.shared
 	@State private var showControls = false
 	@State private var showCancel = false
@@ -95,6 +100,11 @@ struct ListeningView: View {
 			if coordinator.isRunning {
 				return .runningRecipe(coordinator.runningRecipeName ?? "command")
 			}
+			// Same shape for the two-pass polish: the words window dismissed at
+			// stop, and this pill is the one surface that says the paste is coming.
+			if live.isFinalizing {
+				return .finalizing(live.finalizingStatusText)
+			}
 			if whisperKit.isWaitingForModel
 				|| whisperKit.isInitializing
 				|| whisperKit.isModelLoading
@@ -123,7 +133,7 @@ struct ListeningView: View {
 			EmptyView()
 		case .initializing, .recording:
 			micLiveRow
-		case .preparingModel(let status):
+		case .preparingModel(let status), .finalizing(let status):
 			PillStatusRow(indicator: .progress, text: status)
 		case .transcribing:
 			PillStatusRow(text: "Transcribing...")

--- a/What's up?/ListeningWindow.swift
+++ b/What's up?/ListeningWindow.swift
@@ -128,8 +128,7 @@ class ListeningWindow: NSWindow {
 
 	private func updateVisibility() {
 		let shouldShow = RecordingWindowPolicy.shouldShowListeningWindow(
-			state: audioManager.currentState,
-			mode: audioManager.currentRecordingMode
+			state: audioManager.currentState
 		)
 
 		if shouldShow && !isVisible {
@@ -139,9 +138,11 @@ class ListeningWindow: NSWindow {
 			applyPillSize(animated: false)
 			positionAtBottomCenter()
 			orderFront(nil)
+			PillAnchorProvider.shared.publish(frame)
 		} else if !shouldShow && isVisible {
 			hidePickerWindow(animated: false)
 			orderOut(nil)
+			PillAnchorProvider.shared.publish(nil)
 		}
 	}
 
@@ -156,16 +157,14 @@ class ListeningWindow: NSWindow {
 			}
 		}
 
-		// RecordingStateChanged covers the three stored AudioManager flags but not
-		// `currentRecordingMode`, which the policy also reads. Observing the
-		// computed policy inputs directly closes that gap without polling.
+		// RecordingStateChanged covers the three stored AudioManager flags.
+		// Observing the policy's input directly closes any gap without polling.
 		observeRecordingState()
 	}
 
 	private func observeRecordingState() {
 		withObservationTracking {
 			_ = audioManager.currentState
-			_ = audioManager.currentRecordingMode
 		} onChange: {
 			Task { @MainActor [weak self] in
 				guard let self else { return }
@@ -226,6 +225,7 @@ class ListeningWindow: NSWindow {
 		guard animated, isVisible, !Motion.systemReduceMotion else {
 			setFrame(newFrame, display: true)
 			layoutPickerWindow(pillFrame: newFrame, animated: false)
+			PillAnchorProvider.shared.publish(newFrame)
 			return
 		}
 
@@ -235,6 +235,11 @@ class ListeningWindow: NSWindow {
 		let pickerTarget: NSRect? = pickerWindow.flatMap { picker in
 			picker.isVisible ? pickerFrame(size: controlsPresenter.size, pillFrame: newFrame) : nil
 		}
+
+		// Published up front rather than in the completion handler: anything
+		// anchored above the pill (the live-words HUD) animates to its own new
+		// position on the same beat instead of lagging a whole animation behind.
+		PillAnchorProvider.shared.publish(newFrame)
 
 		drivenFrameAnimations += 1
 		NSAnimationContext.runAnimationGroup { context in
@@ -288,8 +293,9 @@ class ListeningWindow: NSWindow {
 		}
 	}
 
-	/// Keeps the controls panel glued to the pill while the user drags it, and
-	/// while any frame change this class did not initiate lands.
+	/// Keeps the controls panel — and, via `PillAnchorProvider`, the live-words
+	/// HUD — glued to the pill while the user drags it, and while any frame
+	/// change this class did not initiate lands.
 	private func setupFollowObservers() {
 		moveObserver = NotificationCenter.default.addObserver(
 			forName: NSWindow.didMoveNotification,
@@ -299,6 +305,7 @@ class ListeningWindow: NSWindow {
 			Task { @MainActor in
 				guard let self, !self.isDrivingFrameAnimation else { return }
 				self.layoutPickerWindow(animated: false)
+				PillAnchorProvider.shared.publish(self.frame)
 			}
 		}
 
@@ -310,6 +317,7 @@ class ListeningWindow: NSWindow {
 			Task { @MainActor in
 				guard let self, !self.isDrivingFrameAnimation else { return }
 				self.layoutPickerWindow(animated: false)
+				PillAnchorProvider.shared.publish(self.frame)
 			}
 		}
 	}

--- a/What's up?/PillAnchor.swift
+++ b/What's up?/PillAnchor.swift
@@ -1,0 +1,49 @@
+import AppKit
+
+/// Publishes the listening pill's on-screen frame so other floating surfaces —
+/// today, only the live-words HUD — can sit relative to it without reaching
+/// into `ListeningWindow`'s `NSWindow` directly. `ListeningWindow` is the sole
+/// writer; everything else only reads. See WHI-58.
+@MainActor
+@Observable
+final class PillAnchorProvider {
+	static let shared = PillAnchorProvider()
+
+	/// nil while the pill is off screen. Anything anchoring to it should fall
+	/// back to the pill's own resting spot — see `PillAnchor.frame`.
+	private(set) var pillFrame: NSRect?
+
+	func publish(_ frame: NSRect?) {
+		pillFrame = frame
+	}
+}
+
+/// Pure geometry for where a surface of a given size should sit relative to the
+/// pill. No `NSWindow`, no observation — a plain function so the coordination
+/// rule is covered by an ordinary unit test instead of a screenshot. See
+/// PillAnchorTests.
+enum PillAnchor {
+	/// Gap between the pill's top edge and the bottom of whatever sits above it,
+	/// matching the pill's own controls-panel gap (`PillMetrics.controlsGap`) so
+	/// every surface that grows out of the pill uses the same one number.
+	static let gap: CGFloat = PillMetrics.controlsGap
+
+	/// A rect for `size` whose bottom edge sits `gap` above the pill — so growth
+	/// in `size.height` reads as the surface growing upward, away from the
+	/// pill, never toward or through it — and which is horizontally centered on
+	/// the pill. With no pill on screen, falls back to the pill's own
+	/// bottom-center resting spot, so a transient shown before the pill appears
+	/// (or a stale read racing the pill's own visibility notification) lands
+	/// exactly where the pill would be.
+	static func frame(for size: CGSize, screenFrame: NSRect, pillFrame: NSRect?) -> NSRect {
+		guard let pillFrame else {
+			let x = screenFrame.origin.x + (screenFrame.width - size.width) / 2
+			let y = screenFrame.origin.y + screenFrame.height * PillMetrics.bottomAnchorFraction
+			return NSRect(x: x, y: y, width: size.width, height: size.height)
+		}
+
+		let x = (pillFrame.midX - size.width / 2).rounded()
+		let y = pillFrame.maxY + gap
+		return NSRect(x: x, y: y, width: size.width, height: size.height)
+	}
+}

--- a/What's up?/PillStyle.swift
+++ b/What's up?/PillStyle.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+/// The pill's visual language, factored out of `ListeningView` +
+/// `AudioMeterView` so every other pill-family surface (the live-words HUD in
+/// `LiveTranscription/`, its Settings preview) composes the same materials,
+/// type, spacing and motion instead of re-deriving them. See WHI-58.
+
+/// The spacing scale from design-language.md. Every pill-family surface picks
+/// its paddings from here rather than inventing its own numbers.
+enum PillSpacing {
+	static let xs: CGFloat = 4
+	static let sm: CGFloat = 8
+	static let md: CGFloat = 12
+	static let lg: CGFloat = 16
+	static let xl: CGFloat = 20
+	static let xxl: CGFloat = 24
+}
+
+/// Default corner radius for pre-Liquid-Glass pill surfaces. Individual windows
+/// still expose this as a user-tunable `@AppStorage` value; this is only the
+/// shared fallback so a fresh install already looks right.
+enum PillCornerRadius {
+	static let standard: CGFloat = 10
+}
+
+/// Typography shared by every pill-family surface: the `.rounded` design that
+/// gives the pill its voice, plus the one place that decides what "the word
+/// being spoken right now" looks like versus everything around it.
+enum PillTypography {
+	/// Secondary status lines: "Transcribing...", "Waiting for model...", the
+	/// controls tooltip line.
+	static let status: Font = .system(.caption, design: .rounded)
+	/// The trailing ellipsis shown before a truncated run of words.
+	static let ellipsis: Font = .system(.body, design: .rounded)
+	/// A word in the live-words flow. The most recently confirmed word is
+	/// emphasized so the eye finds it without hunting.
+	static func word(emphasized: Bool) -> Font {
+		.system(emphasized ? .title3 : .body, design: .rounded)
+	}
+}
+
+/// What sits to the left of a status line: an indeterminate spinner that
+/// settles into a static glyph under Reduce Motion, a pulsing "listening" dot
+/// that freezes under Reduce Motion, a static tinted icon, or nothing.
+enum PillIndicator {
+	case none
+	case progress
+	case pulse(Color)
+	case icon(String, Color)
+}
+
+/// One line of secondary status: an optional indicator plus caption text. Used
+/// for "preparing model", "waiting for model", "transcribing", "listening" and
+/// inline errors — every place a pill-family surface shows a single line of
+/// status rather than the live words themselves.
+struct PillStatusRow: View {
+	var indicator: PillIndicator = .none
+	var text: String
+	var textColor: Color = .secondary
+
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
+	@State private var isPulsing = false
+
+	var body: some View {
+		HStack(spacing: PillSpacing.sm) {
+			indicatorView
+			Text(text)
+				.font(PillTypography.status)
+				.foregroundColor(textColor)
+				.lineLimit(2)
+		}
+		.onAppear {
+			if case .pulse = indicator { isPulsing = true }
+		}
+	}
+
+	@ViewBuilder
+	private var indicatorView: some View {
+		switch indicator {
+		case .none:
+			EmptyView()
+		case .progress:
+			// A spinner is indeterminate motion that never settles, which is
+			// exactly what Reduce Motion asks us not to draw. The dot says the
+			// same thing — something is in progress — and holds still.
+			if reduceMotion {
+				Image(systemName: "circle.dotted")
+					.imageScale(.small)
+					.foregroundColor(.secondary)
+			} else {
+				ProgressView()
+					.scaleEffect(0.7)
+					.frame(width: 20, height: 20)
+			}
+		case .pulse(let color):
+			Circle()
+				.fill(color)
+				.frame(width: 4, height: 4)
+				.scaleEffect(reduceMotion ? 1.0 : (isPulsing ? 1.2 : 1.0))
+				.animation(
+					reduceMotion ? nil : .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+					value: isPulsing)
+		case .icon(let name, let color):
+			Image(systemName: name)
+				.foregroundColor(color)
+				.imageScale(.small)
+		}
+	}
+}
+
+/// The trailing run of live words: recent words at body weight, the most
+/// recent one emphasized, optionally preceded by an ellipsis when there is
+/// more history than is being shown. Shared by the live-words HUD and its
+/// Settings preview so they can never drift apart.
+struct PillWordFlow: View {
+	var words: [String]
+	var showEllipsis: Bool = false
+
+	var body: some View {
+		HStack(spacing: PillSpacing.xs) {
+			if showEllipsis {
+				Text("...")
+					.font(PillTypography.ellipsis)
+					.foregroundColor(Color.secondary.opacity(0.6))
+					.padding(.trailing, 2)
+			}
+
+			ForEach(Array(words.enumerated()), id: \.offset) { index, word in
+				let isLast = index == words.count - 1
+				Text(word)
+					.font(PillTypography.word(emphasized: isLast))
+					.foregroundColor(isLast ? Color.blue : Color.primary.opacity(0.8))
+					.fontWeight(isLast ? .semibold : .regular)
+					.animation(.easeInOut(duration: 0.15), value: isLast)
+			}
+		}
+	}
+}
+
+/// The pill's background: on macOS 26 the system Liquid Glass, and before that
+/// the hand-built material + soft blue border + shadow pair every pill-family
+/// surface used to reimplement on its own. One definition, so the listening
+/// pill and the live-words HUD cannot visually drift apart again.
+struct PillChrome: ViewModifier {
+	var cornerRadius: CGFloat = PillCornerRadius.standard
+
+	func body(content: Content) -> some View {
+		if #available(macOS 26.0, *) {
+			content.glassEffect()
+		} else {
+			content
+				.background(
+					RoundedRectangle(cornerRadius: cornerRadius)
+						.fill(.ultraThinMaterial)
+						.overlay(
+							RoundedRectangle(cornerRadius: cornerRadius)
+								.fill(
+									LinearGradient(
+										colors: [
+											Color.blue.opacity(0.05),
+											Color.blue.opacity(0.02),
+										],
+										startPoint: .topLeading,
+										endPoint: .bottomTrailing
+									)
+								)
+						)
+				)
+				.overlay(
+					RoundedRectangle(cornerRadius: cornerRadius)
+						.strokeBorder(
+							LinearGradient(
+								colors: [
+									Color.blue.opacity(0.3),
+									Color.blue.opacity(0.1),
+								],
+								startPoint: .topLeading,
+								endPoint: .bottomTrailing
+							),
+							lineWidth: 1
+						)
+				)
+				.shadow(color: Color.blue.opacity(0.1), radius: 8, x: 0, y: 2)
+				.shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 1)
+		}
+	}
+}
+
+extension View {
+	/// Applies the shared pill chrome (materials, border, shadow / Liquid Glass)
+	/// at the given corner radius.
+	func pillChrome(cornerRadius: CGFloat = PillCornerRadius.standard) -> some View {
+		modifier(PillChrome(cornerRadius: cornerRadius))
+	}
+}

--- a/WhisperKitTranscriber.swift
+++ b/WhisperKitTranscriber.swift
@@ -12,64 +12,77 @@ import WhisperKit
 	var isInitialized = false
 	private var cancellables = Set<AnyCancellable>()
 	var isInitializing = false
-	var isWaitingForModel: Bool = false
-	var waitingForModelStatusText: String = ""
 	var isStreamingAudio: Bool = false
 	var initializationProgress: Double = 0.0
 	var initializationStatus = "Starting..."
 	var availableModels: [String] = []
 	var currentModel: String?
 	var downloadedModels: Set<String> = []
-	var onConfirmedTextChange: ((String) -> Void)?
 	@ObservationIgnored var onLiveAudioSamples: (@MainActor ([Float]) -> Void)?
-	var shouldShowLiveTranscriptionWindow: Bool = false
-	var isTranscribing: Bool = false
 	var decodingOptions: DecodingOptions?
-	var currentText: String = ""
 	var dictationWordTracker: DictationWordTracker?
 	// Live text management
 	private var isLiveTranscriptionMode = false
-	private var lastConfirmedSegmentCount: Int = 0
-	var confirmedText: String = "" {
-		didSet {
-			onConfirmedTextChange?(confirmedText)
-		}
+
+	/// The one live-transcription surface, shared with every other engine. The
+	/// properties below forward to it so existing callers, views and tests are
+	/// unchanged while a remote engine can drive the same HUD. See WHI-58.
+	@ObservationIgnored
+	private let live = LiveTranscriptionState.shared
+
+	var onConfirmedTextChange: ((String) -> Void)? {
+		get { live.onConfirmedTextChange }
+		set { live.onConfirmedTextChange = newValue }
 	}
-	private var pendingText: String = ""  // Internal working property
-	var stableDisplayText: String = ""  // UI-facing stable property
-	private var lastDisplayedPendingText: String = ""
-	var shouldShowDebugWindow: Bool = false
-	var latestWord: String {
-		let words = stableDisplayText.split(separator: " ")
-		return words.last?.description ?? ""
+	var isWaitingForModel: Bool {
+		get { live.isWaitingForModel }
+		set { live.isWaitingForModel = newValue }
 	}
+	var waitingForModelStatusText: String {
+		get { live.waitingForModelStatusText }
+		set { live.waitingForModelStatusText = newValue }
+	}
+	var shouldShowLiveTranscriptionWindow: Bool {
+		get { live.shouldShowLiveTranscriptionWindow }
+		set { live.shouldShowLiveTranscriptionWindow = newValue }
+	}
+	var isTranscribing: Bool {
+		get { live.isTranscribing }
+		set { live.isTranscribing = newValue }
+	}
+	var currentText: String {
+		get { live.currentText }
+		set { live.currentText = newValue }
+	}
+	var confirmedText: String {
+		get { live.confirmedText }
+		set { live.confirmedText = newValue }
+	}
+	private var pendingText: String {
+		get { live.pendingText }
+		set { live.pendingText = newValue }
+	}
+	var stableDisplayText: String {
+		get { live.stableDisplayText }
+		set { live.stableDisplayText = newValue }
+	}
+	var shouldShowDebugWindow: Bool {
+		get { live.shouldShowDebugWindow }
+		set { live.shouldShowDebugWindow = newValue }
+	}
+	var latestWord: String { live.latestWord }
 
 	func clearLiveTranscriptionState() {
 		liveStreamStartupTask?.cancel()
 		liveStreamStartupTask = nil
-		isWaitingForModel = false
-		waitingForModelStatusText = ""
-		pendingText = ""
-		stableDisplayText = ""
-		lastDisplayedPendingText = ""
-		shouldShowLiveTranscriptionWindow = false
-		isTranscribing = false
-		confirmedText = ""
-		shouldShowDebugWindow = false
+		live.reset()
 		transcriptionTask?.cancel()
 		transcriptionTask = nil
 		lastBufferSize = 0
-		lastConfirmedSegmentCount = 0
 	}
 
 	func beginLiveTranscriptionWaitingUI() {
-		pendingText = ""
-		stableDisplayText = ""
-		lastDisplayedPendingText = ""
-		confirmedText = ""
-		shouldShowLiveTranscriptionWindow = true
-		isWaitingForModel = true
-		waitingForModelStatusText = "Waiting for model..."
+		live.beginWaiting()
 	}
 
 	private func updateWaitingStatusText() {
@@ -185,35 +198,6 @@ import WhisperKit
 		}
 	}
 
-	private func shouldUpdatePendingText(newText: String) -> Bool {
-		// If the text is empty or previous text was non-empty, always update (to handle clearing)
-		if newText.isEmpty || lastDisplayedPendingText.isEmpty {
-			return true
-		}
-
-		// Convert to word arrays for comparison
-		let newWords = newText.split(separator: " ").map(String.init)
-		let oldWords = lastDisplayedPendingText.split(separator: " ").map(String.init)
-
-		// If word count changed significantly, update
-		let wordCountDiff = abs(newWords.count - oldWords.count)
-		if wordCountDiff > 1 { return true }
-
-		// If the last few words are different, update
-		let wordsToCompare = min(3, min(newWords.count, oldWords.count))
-		if wordsToCompare > 0 {
-			let newLastWords = Array(newWords.suffix(wordsToCompare))
-			let oldLastWords = Array(oldWords.suffix(wordsToCompare))
-
-			if newLastWords != oldLastWords {
-				return true
-			}
-		}
-
-		// Similar enough, don't update
-		return false
-	}
-
 	private func safelyPasteText(_ text: String) {
 		guard !text.isEmpty else { return }
 
@@ -236,16 +220,7 @@ import WhisperKit
 	}
 
 	private func confirmPendingText() {
-		guard !pendingText.isEmpty else { return }
-
-		// Sync all display properties before confirming to prevent double transcription
-		stableDisplayText = pendingText
-		lastDisplayedPendingText = pendingText
-
-		// Since WhisperKit provides complete transcription history in pendingText,
-		// we replace confirmedText entirely rather than appending
-		confirmedText = pendingText
-		pendingText = ""
+		live.confirmPending()
 	}
 
 	private var selectedLanguage: String {
@@ -568,7 +543,7 @@ import WhisperKit
 				shouldShowLiveTranscriptionWindow = true
 				isTranscribing = true
 				isLiveTranscriptionMode = true
-				lastConfirmedSegmentCount = 0
+				live.resetSegmentConfirmation()
 
 				await AudioDeviceManager.shared.activateSelectedDevice()
 				let selectedDeviceID = AudioDeviceManager.shared.resolveActiveDeviceID()
@@ -674,84 +649,15 @@ import WhisperKit
 				return
 			}
 
-			let fullTranscriptionText =
-				segments
-				.map { $0.text.trimmingCharacters(in: .whitespaces) }
-				.joined(separator: " ")
+			let segmentTexts = segments.map { $0.text.trimmingCharacters(in: .whitespaces) }
 
 			AppLogger.shared.transcriber.debug(
-				"Transcription received: \(segments.count) segments, full text: '\(fullTranscriptionText)'"
+				"Transcription received: \(segments.count) segments, full text: '\(segmentTexts.joined(separator: " "))'"
 			)
 			AppLogger.shared.transcriber.debug(
 				"Current state: confirmedText.count=\(confirmedText.count), pendingText='\(pendingText)'")
 
-			let requiredSegmentsForConfirmation = 2
-
-			if segments.count > requiredSegmentsForConfirmation {
-				let numberOfSegmentsToConfirm = segments.count - requiredSegmentsForConfirmation
-
-				// Only confirm new segments that haven't been confirmed before
-				if numberOfSegmentsToConfirm > lastConfirmedSegmentCount {
-					let newSegmentsToConfirm = numberOfSegmentsToConfirm - lastConfirmedSegmentCount
-					let startIndex = lastConfirmedSegmentCount
-					let endIndex = lastConfirmedSegmentCount + newSegmentsToConfirm
-
-					let newConfirmedSegments = Array(segments[startIndex..<endIndex])
-
-					let newConfirmedText =
-						newConfirmedSegments
-						.map { $0.text.trimmingCharacters(in: .whitespaces) }
-						.joined(separator: " ")
-
-					AppLogger.shared.transcriber.debug("New segments to confirm: \(newSegmentsToConfirm), text: '\(newConfirmedText)'")
-
-					if !newConfirmedText.isEmpty {
-						let updatedConfirmedText: String
-						if !confirmedText.isEmpty {
-							updatedConfirmedText = confirmedText + " " + newConfirmedText
-						} else {
-							updatedConfirmedText = newConfirmedText
-						}
-						confirmedText = updatedConfirmedText
-						lastConfirmedSegmentCount = numberOfSegmentsToConfirm
-					}
-				} else {
-					AppLogger.shared.transcriber.debug(
-						"No new segments to confirm (already confirmed \(lastConfirmedSegmentCount) segments)"
-					)
-				}
-				let remainingSegments = Array(segments.suffix(requiredSegmentsForConfirmation))
-
-				let newPendingText =
-					remainingSegments
-					.map { $0.text.trimmingCharacters(in: .whitespaces) }
-					.joined(separator: " ")
-
-				// Always update internal pendingText for logic
-				pendingText = newPendingText
-
-				// Only update UI-facing property if text has changed meaningfully
-				if shouldUpdatePendingText(newText: newPendingText) {
-					stableDisplayText = newPendingText
-					lastDisplayedPendingText = newPendingText
-				}
-			} else {
-				let newPendingText =
-					segments
-					.map { $0.text.trimmingCharacters(in: .whitespaces) }
-					.joined(separator: " ")
-
-				// Always update internal pendingText for logic
-				pendingText = newPendingText
-
-				// Only update UI-facing property if text has changed meaningfully
-				if shouldUpdatePendingText(newText: newPendingText) {
-					stableDisplayText = newPendingText
-					lastDisplayedPendingText = newPendingText
-				}
-			}
-
-			shouldShowLiveTranscriptionWindow = !stableDisplayText.isEmpty || !confirmedText.isEmpty
+			live.ingest(segmentTexts: segmentTexts)
 		}
 	}
 

--- a/WhisperKitTranscriber.swift
+++ b/WhisperKitTranscriber.swift
@@ -50,10 +50,6 @@ import WhisperKit
 		get { live.isTranscribing }
 		set { live.isTranscribing = newValue }
 	}
-	var currentText: String {
-		get { live.currentText }
-		set { live.currentText = newValue }
-	}
 	var confirmedText: String {
 		get { live.confirmedText }
 		set { live.confirmedText = newValue }

--- a/Whispera.xcodeproj/project.pbxproj
+++ b/Whispera.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		D63900E52E3F13F7005B5623 /* TranscriptionQueueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63900E42E3F13F7005B5623 /* TranscriptionQueueManager.swift */; };
 		D63900E72E3F1550005B5623 /* TranscriptionQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63900E62E3F1550005B5623 /* TranscriptionQueueView.swift */; };
 		D63A30E32E2EBF1300BA20B7 /* LiveTranscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63A30DF2E2EBF1300BA20B7 /* LiveTranscriptionView.swift */; };
+		D6PILLSTY02F000000000002 /* PillStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6PILLSTY02F000000000001 /* PillStyle.swift */; };
+		D6PILLANCR02F00000000002 /* PillAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6PILLANCR02F00000000001 /* PillAnchor.swift */; };
 		D63A30E52E2EBF1300BA20B7 /* LiveTranscriptionWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63A30E02E2EBF1300BA20B7 /* LiveTranscriptionWindow.swift */; };
 		D63A30E72E2EBF1E00BA20B7 /* AccessibilityHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63A30E62E2EBF1E00BA20B7 /* AccessibilityHelper.swift */; };
 		D63A31112E2EE20C00BA20B7 /* DictationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63A31102E2EE20C00BA20B7 /* DictationView.swift */; };
@@ -162,6 +164,8 @@
 		D6BENCH022F0000000000003 /* BenchmarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkView.swift; sourceTree = "<group>"; };
 		D6C81FC82E0001AB00D32F2A /* ContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextProvider.swift; sourceTree = "<group>"; };
 		D6D486242EA482B200C1D5FA /* AudioMeterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMeterView.swift; sourceTree = "<group>"; };
+		D6PILLSTY02F000000000001 /* PillStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillStyle.swift; sourceTree = "<group>"; };
+		D6PILLANCR02F00000000001 /* PillAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillAnchor.swift; sourceTree = "<group>"; };
 		D6DEVPK022F0000000000001 /* DevicePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePickerView.swift; sourceTree = "<group>"; };
 		D6F9D7812ED6C31C00959822 /* AudioEngineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineController.swift; sourceTree = "<group>"; };
 		D6F9D7822ED6C31C00959822 /* AudioLevelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioLevelMonitor.swift; sourceTree = "<group>"; };
@@ -269,6 +273,8 @@
 				D6DEVPK022F0000000000001 /* DevicePickerView.swift */,
 				D60F53F52EA4688E0063C008 /* ListeningWindow.swift */,
 				D60F53F22EA451200063C008 /* ListeningView.swift */,
+				D6PILLSTY02F000000000001 /* PillStyle.swift */,
+				D6PILLANCR02F00000000001 /* PillAnchor.swift */,
 			);
 			path = "What's up?";
 			sourceTree = "<group>";
@@ -549,6 +555,8 @@
 				D66E6D6B2E185B8E00F55A5B /* ShortcutOptionsView.swift in Sources */,
 				D66E6D6F2E185BD100F55A5B /* TestStepView.swift in Sources */,
 				D63A30E32E2EBF1300BA20B7 /* LiveTranscriptionView.swift in Sources */,
+				D6PILLSTY02F000000000002 /* PillStyle.swift in Sources */,
+				D6PILLANCR02F00000000002 /* PillAnchor.swift in Sources */,
 				D63900E52E3F13F7005B5623 /* TranscriptionQueueManager.swift in Sources */,
 				D63A30E52E2EBF1300BA20B7 /* LiveTranscriptionWindow.swift in Sources */,
 				D648B7CB2DF9FF8B006079ED /* Constants.swift in Sources */,

--- a/Whispera.xcodeproj/project.pbxproj
+++ b/Whispera.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		D6LMTEST12F0000000000001 /* LargeModelTranscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6LMTEST22F0000000000001 /* LargeModelTranscriptionTests.swift */; };
 		D6SOFTUPD2ED700000000005 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6SOFTUPD2ED700000000004 /* SoftwareUpdater.swift */; };
 		D6SPARKLE2ED700000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = D6SPARKLE2ED700000000002 /* Sparkle */; };
+		D6WDICTBLD00000000000003 /* WhisperaDictation in Frameworks */ = {isa = PBXBuildFile; productRef = D6WDICTPRD00000000000002 /* WhisperaDictation */; };
 		FDB1B0A903214623AADB4048 /* KeyboardInputSourceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91EF5D0CAB5432B90AFFF23 /* KeyboardInputSourceManager.swift */; };
 		D6DEVMGR12F0000000000001 /* AudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEVMGR22F0000000000001 /* AudioDeviceManager.swift */; };
 		D6DEVMGR12F0000000000002 /* AudioDeviceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DEVMGR22F0000000000002 /* AudioDeviceManagerTests.swift */; };
@@ -188,6 +189,7 @@
 				D6B81FB42DEFF5CC00D32F2A /* WhisperKit in Frameworks */,
 				D63900CF2E3D77B4005B5623 /* YouTubeKit in Frameworks */,
 				D6SPARKLE2ED700000000003 /* Sparkle in Frameworks */,
+				D6WDICTBLD00000000000003 /* WhisperaDictation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -476,6 +478,7 @@
 				D63900CD2E3D77B4005B5623 /* XCRemoteSwiftPackageReference "YouTubeKit" */,
 				D6D486302EA49C1F00C1D5FA /* XCRemoteSwiftPackageReference "WhisperKit" */,
 				D6SPARKLE2ED700000000001 /* XCRemoteSwiftPackageReference "Sparkle" */,
+				D6WDICTPKG00000000000001 /* XCLocalSwiftPackageReference "whispera-components apple" */,
 			);
 			productRefGroup = 8A8A8A8A8A8A8A8A8A8A8A8A /* Products */;
 			projectDirPath = "";
@@ -949,6 +952,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		D6WDICTPKG00000000000001 /* XCLocalSwiftPackageReference "whispera-components apple" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../whispera-components-worktrees/dictation/apple;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		D63900CD2E3D77B4005B5623 /* XCRemoteSwiftPackageReference "YouTubeKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1022,6 +1032,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D6SPARKLE2ED700000000001 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		D6WDICTPRD00000000000002 /* WhisperaDictation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D6WDICTPKG00000000000001 /* XCLocalSwiftPackageReference "whispera-components apple" */;
+			productName = WhisperaDictation;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -79,7 +79,9 @@ extension Notification.Name {
 }
 
 enum SettingsDestination: String {
-	case general, aiMode, recipes, storage, liveTranscription, fileTranscription, benchmark
+	// `servers` replaced `aiMode` when the LLM configuration moved under the
+	// Servers tab; SettingsView rewrites a stored "aiMode" selection on appear.
+	case general, servers, recipes, storage, liveTranscription, fileTranscription, benchmark
 }
 
 enum SettingsRouting {
@@ -153,6 +155,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 		}
 
 		AppDelegate.registerInitialDefaults(in: .standard)
+		// Before any engine reads a server URL: the shared key splits into
+		// per-mode keys exactly once, keyed off the engine it was typed for.
+		TranscriptionServerURLMigration.migrateIfNeeded(in: .standard)
 
 		Task { @MainActor in
 			audioManager = AudioManager()

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -185,6 +185,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 			liveTranscriptionWindow = LiveTranscriptionWindow(audioManager: audioManager)
 			listeningWindow = ListeningWindow(audioManager: audioManager)
 			recordingGlowController = RecordingGlowController(audioManager: audioManager)
+
+			// Verification affordance: dictation can otherwise only start from a real
+			// keypress, which a headless harness cannot post without an Accessibility
+			// grant. Env-gated, so every normal launch is unaffected.
+			// WHISPERA_AUTOSTART_DICTATION=<seconds to record>
+			if let raw = ProcessInfo.processInfo.environment["WHISPERA_AUTOSTART_DICTATION"],
+				let duration = Double(raw), duration > 0
+			{
+				AppLogger.shared.general.info("Autostart: dictating for \(duration)s")
+				Task { @MainActor [weak self] in
+					try? await Task.sleep(nanoseconds: 4_000_000_000)
+					self?.audioManager.toggleRecording()
+					try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+					self?.audioManager.toggleRecording()
+					AppLogger.shared.general.info("Autostart: stopped")
+				}
+			}
 			if !hasCompletedOnboarding {
 				showOnboarding()
 			}

--- a/WhisperaApp.swift
+++ b/WhisperaApp.swift
@@ -186,22 +186,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 			listeningWindow = ListeningWindow(audioManager: audioManager)
 			recordingGlowController = RecordingGlowController(audioManager: audioManager)
 
-			// Verification affordance: dictation can otherwise only start from a real
-			// keypress, which a headless harness cannot post without an Accessibility
-			// grant. Env-gated, so every normal launch is unaffected.
-			// WHISPERA_AUTOSTART_DICTATION=<seconds to record>
-			if let raw = ProcessInfo.processInfo.environment["WHISPERA_AUTOSTART_DICTATION"],
-				let duration = Double(raw), duration > 0
-			{
-				AppLogger.shared.general.info("Autostart: dictating for \(duration)s")
-				Task { @MainActor [weak self] in
-					try? await Task.sleep(nanoseconds: 4_000_000_000)
-					self?.audioManager.toggleRecording()
-					try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
-					self?.audioManager.toggleRecording()
-					AppLogger.shared.general.info("Autostart: stopped")
-				}
-			}
+			startAutostartDictationIfRequested()
 			if !hasCompletedOnboarding {
 				showOnboarding()
 			}
@@ -231,6 +216,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 				}
 			}
 
+			// A dictation that failed for a reason the user has to fix. Settings is
+			// where the alert is presented and where every one of those reasons is
+			// changed, so bringing it up is the whole recovery step.
+			NotificationCenter.default.addObserver(
+				forName: .transcriptionFailureRaised,
+				object: nil,
+				queue: .main
+			) { [weak self] _ in
+				Task { @MainActor in
+					UserDefaults.standard.set(
+						SettingsDestination.general.rawValue,
+						forKey: SettingsRouting.selectedTabDefaultsKey)
+					self?.perform(.settings)
+				}
+			}
+
 			// Listen for activation requests from other instances
 			DistributedNotificationCenter.default().addObserver(
 				forName: NSNotification.Name("ActivateApp"),
@@ -241,6 +242,42 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 			}
 		}
 	}
+
+	// MARK: - Test affordance
+
+	/// Starts and stops one dictation on a timer, when — and only when — the
+	/// environment asks for it.
+	///
+	/// Dictation is otherwise reachable only from a real keypress, which a headless
+	/// verification run cannot post without an Accessibility grant. Nothing in the
+	/// app sets this variable and nothing in a normal launch supplies it, so the
+	/// method returns immediately on every user's machine; the log line names it as
+	/// a test affordance so a support log that does contain one is not mistaken for
+	/// the app dictating on its own.
+	///
+	/// `WHISPERA_AUTOSTART_DICTATION=<seconds to record>`.
+	private func startAutostartDictationIfRequested() {
+		guard let raw = ProcessInfo.processInfo.environment["WHISPERA_AUTOSTART_DICTATION"],
+			let requested = Double(raw), requested > 0
+		else { return }
+
+		// Clamped so a stray value cannot hold the microphone open indefinitely.
+		let duration = min(requested, Self.autostartMaximumSeconds)
+		AppLogger.shared.general.info(
+			"Test affordance WHISPERA_AUTOSTART_DICTATION is set: dictating for \(duration)s")
+		Task { @MainActor [weak self] in
+			try? await Task.sleep(nanoseconds: UInt64(Self.autostartWarmupSeconds * 1_000_000_000))
+			self?.audioManager.toggleRecording()
+			try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+			self?.audioManager.toggleRecording()
+			AppLogger.shared.general.info("Test affordance WHISPERA_AUTOSTART_DICTATION: stopped")
+		}
+	}
+
+	/// Long enough for the status item, the windows and the engine to settle before
+	/// the microphone opens.
+	private static let autostartWarmupSeconds: Double = 4
+	private static let autostartMaximumSeconds: Double = 120
 
 	nonisolated static func registerInitialDefaults(in defaults: UserDefaults) {
 		defaults.register(defaults: [

--- a/WhisperaUnitTests/AutoEnginePolicyTests.swift
+++ b/WhisperaUnitTests/AutoEnginePolicyTests.swift
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Testing
+
+@testable import Whispera
+
+/// The `auto` engine's resolution policy, exercised as a pure function of
+/// what discovery found — no network, no backend, no MainActor. See WHI-58
+/// and AUTOCHOOSE-RESULT.md for the decision table this pins.
+struct AutoEnginePolicyTests {
+	private static func server(
+		id: String,
+		label: String? = nil,
+		isOnline: Bool = true,
+		supportsRealtime: Bool = true,
+		isDefault: Bool = false,
+		granularity: StreamingGranularity = .utterance
+	) -> DiscoveredServer {
+		DiscoveredServer(
+			id: id, label: label ?? id, isOnline: isOnline, supportsRealtime: supportsRealtime,
+			isDefault: isDefault, granularity: granularity)
+	}
+
+	// MARK: - No server to talk to
+
+	@Test func noURLConfiguredGoesLocalWithoutAttemptingDiscovery() {
+		let resolution = AutoEnginePolicy.resolve(
+			serverURLConfigured: false, pinnedServerId: "",
+			discovery: .unavailable(reason: "no transcription server configured"))
+
+		#expect(resolution == .local(reason: "no transcription server configured"))
+	}
+
+	@Test func discoveryFailureGoesLocal() {
+		let resolution = AutoEnginePolicy.resolve(
+			serverURLConfigured: true, pinnedServerId: "",
+			discovery: .unavailable(reason: "backend unreachable"))
+
+		#expect(resolution == .local(reason: "backend unreachable"))
+	}
+
+	@Test func noUsableServerInTheListGoesLocal() {
+		let discovery = AutoDiscoveryOutcome.servers([
+			Self.server(id: "offline-one", isOnline: false),
+			Self.server(id: "no-realtime", supportsRealtime: false),
+		])
+
+		let resolution = AutoEnginePolicy.resolve(
+			serverURLConfigured: true, pinnedServerId: "", discovery: discovery)
+
+		#expect(resolution == .local(reason: "no realtime server available"))
+	}
+
+	// MARK: - Granularity ranking
+
+	@Test func nativeDeltaBeatsSynthesizedBeatsUtterance() {
+		let discovery = AutoDiscoveryOutcome.servers([
+			Self.server(id: "utterance-only", granularity: .utterance),
+			Self.server(id: "synthesized", granularity: .synthesizedDelta),
+			Self.server(id: "native", granularity: .nativeDelta),
+		])
+
+		let resolution = AutoEnginePolicy.resolve(
+			serverURLConfigured: true, pinnedServerId: "", discovery: discovery)
+
+		#expect(resolution == .server(id: "native", label: "native", granularity: .nativeDelta))
+	}
+
+	@Test func synthesizedBeatsUtteranceWithNoNativeOnOffer() {
+		let discovery = AutoDiscoveryOutcome.servers([
+			Self.server(id: "utterance-only", granularity: .utterance),
+			Self.server(id: "synthesized", granularity: .synthesizedDelta),
+		])
+
+		let resolution = AutoEnginePolicy.resolve(
+			serverURLConfigured: true, pinnedServerId: "", discovery: discovery)
+
+		#expect(
+			resolution == .server(id: "synthesized", label: "synthesized", granularity: .synthesizedDelta)
+		)
+	}
+
+	/// Absent `granularity` (an older backend, or one whose delta-synthesis
+	/// hasn't landed) reads as `.utterance` — the worst case, not the best.
+	@Test func absentGranularityDegradesToUtteranceRatherThanWinning() {
+		let discovery = AutoDiscoveryOutcome.servers([
+			Self.server(id: "unlabeled"),
+			Self.server(id: "synthesized", granularity: .synthesizedDelta),
+		])
+
+		let resolution = AutoEnginePolicy.resolve(
+			serverURLConfigured: true, pinnedServerId: "", discovery: discovery)
+
+		#expect(
+			resolution == .server(id: "synthesized", label: "synthesized", granularity: .synthesizedDelta)
+		)
+	}
+
+	@Test func aTieInGranularityPrefersTheBackendsOwnDefault() {
+		let discovery = AutoDiscoveryOutcome.servers([
+			Self.server(id: "alpha", isDefault: false, granularity: .synthesizedDelta),
+			Self.server(id: "beta", isDefault: true, granularity: .synthesizedDelta),
+		])
+
+		let resolution = AutoEnginePolicy.resolve(
+			serverURLConfigured: true, pinnedServerId: "", discovery: discovery)
+
+		#expect(resolution == .server(id: "beta", label: "beta", granularity: .synthesizedDelta))
+	}
+
+	// MARK: - Pinning
+
+	@Test func aPinnedServerWinsEvenOverBetterGranularityElsewhere() {
+		let discovery = AutoDiscoveryOutcome.servers([
+			Self.server(id: "native", granularity: .nativeDelta),
+			Self.server(id: "pinned", granularity: .utterance),
+		])
+
+		let resolution = AutoEnginePolicy.resolve(
+			serverURLConfigured: true, pinnedServerId: "pinned", discovery: discovery)
+
+		#expect(resolution == .server(id: "pinned", label: "pinned", granularity: .utterance))
+	}
+
+	/// A pin that no longer names a usable server (renamed, offline, dropped
+	/// realtime support) is not a dead end — falls through to the normal
+	/// ranking instead of going local outright.
+	@Test func aPinThatIsNoLongerUsableFallsThroughToRanking() {
+		let discovery = AutoDiscoveryOutcome.servers([
+			Self.server(id: "native", granularity: .nativeDelta),
+			Self.server(id: "pinned-but-offline", isOnline: false),
+		])
+
+		let resolution = AutoEnginePolicy.resolve(
+			serverURLConfigured: true, pinnedServerId: "pinned-but-offline", discovery: discovery)
+
+		#expect(resolution == .server(id: "native", label: "native", granularity: .nativeDelta))
+	}
+
+	// MARK: - Summary text
+
+	@Test func theSummaryNamesTheChoiceAndWhy() {
+		#expect(
+			AutoEngineResolution.server(id: "speaches-lan", label: "speaches-lan", granularity: .synthesizedDelta)
+				.summary == "auto: server speaches-lan (synthesized-delta)")
+		#expect(
+			AutoEngineResolution.local(reason: "backend unreachable").summary
+				== "auto: local WhisperKit (backend unreachable)")
+	}
+}

--- a/WhisperaUnitTests/AutoEnginePolicyTests.swift
+++ b/WhisperaUnitTests/AutoEnginePolicyTests.swift
@@ -18,8 +18,8 @@ struct AutoEnginePolicyTests {
 		granularity: StreamingGranularity = .utterance
 	) -> DiscoveredServer {
 		DiscoveredServer(
-			id: id, label: label ?? id, isOnline: isOnline, supportsRealtime: supportsRealtime,
-			isDefault: isDefault, granularity: granularity)
+			id: id, label: label ?? id, model: "", isOnline: isOnline,
+			supportsRealtime: supportsRealtime, isDefault: isDefault, granularity: granularity)
 	}
 
 	// MARK: - No server to talk to

--- a/WhisperaUnitTests/DictationHUDWidthTests.swift
+++ b/WhisperaUnitTests/DictationHUDWidthTests.swift
@@ -100,15 +100,96 @@ struct DictationHUDWidthTests {
 		#expect(width < 552)
 	}
 
-	@Test func estimateIsFlatPerCharacterSoWordOrderCannotWobbleIt() {
-		let a = DictationHUDWidth.estimatedWidth(words: ["hello", "world"], hasEllipsis: false)
-		let b = DictationHUDWidth.estimatedWidth(words: ["world", "hello"], hasEllipsis: false)
-		#expect(a == b, "which word is last must not change the estimate")
+	/// The QA screenshot's exact ticker: the old flat 9pt/char price sat far
+	/// above what the rendered text needs, and — because the frame never
+	/// shrinks mid-dictation — that error accumulated into a capsule whose left
+	/// half stayed blank. The estimate now measures the same type PillWordFlow
+	/// renders, so the quantized window fits the text and hugs it within one
+	/// growth step.
+	@Test func estimateHugsTheRenderedTextInsteadOfPricingPerCharacter() {
+		let words = ["Space", "there", "There", "are", "no"]
+		let measured = DictationHUDWidth.estimatedWidth(words: words, hasEllipsis: true)
+		let characters = CGFloat(words.reduce(0) { $0 + $1.count })
+		let oldFlatPrice = characters * 9 + CGFloat(words.count - 1) * 4 + 20 + 32
+		#expect(measured < oldFlatPrice, "the flat price is what left half the capsule blank")
+
+		let width = DictationHUDWidth.width(
+			current: nil, estimated: measured, maximum: maximum, isDictating: true)
+		#expect(width >= measured, "the window must fit the text it shows")
+		#expect(width - measured < DictationHUDWidth.step, "and hug it within one growth step")
+	}
+
+	@Test func estimateGrowsWhenAWordIsAdded() {
+		let shorter = DictationHUDWidth.estimatedWidth(
+			words: ["hello", "there"], hasEllipsis: false)
+		let longer = DictationHUDWidth.estimatedWidth(
+			words: ["hello", "there", "general"], hasEllipsis: false)
+		#expect(longer > shorter)
 	}
 
 	@Test func ellipsisReservesRoom() {
 		let without = DictationHUDWidth.estimatedWidth(words: ["hello"], hasEllipsis: false)
 		let with = DictationHUDWidth.estimatedWidth(words: ["hello"], hasEllipsis: true)
 		#expect(with > without)
+	}
+
+	/// A status line ("Waiting for model...") must price out near the compact
+	/// floor, not race the frame up two growth steps before a word has arrived.
+	@Test func aStatusLineStaysNearTheCompactFloor() {
+		let width = DictationHUDWidth.width(
+			current: nil,
+			estimated: DictationHUDWidth.statusWidth("Waiting for model..."),
+			maximum: maximum,
+			isDictating: true)
+		#expect(width <= DictationHUDWidth.compact + DictationHUDWidth.step)
+	}
+}
+
+/// The HUD may only be on screen while it has something to say — the WHI-58 QA
+/// session photographed a wide, completely empty capsule above the running
+/// pill. Before the first word: a status line or nothing. After words: a
+/// momentarily blank transcript holds the window (DictationView holds the
+/// words), and only the session ending releases it.
+struct DictationHUDContentTests {
+	@Test func aSessionWithNoWordsYetShowsNothing() {
+		#expect(
+			!DictationHUDContent.hasSomethingToSay(
+				overlayError: nil, isWaitingForModel: false, waitingStatusText: "",
+				displayText: "", hasShownWordsThisSession: false))
+	}
+
+	@Test func aWaitingStatusLineIsContent() {
+		#expect(
+			DictationHUDContent.hasSomethingToSay(
+				overlayError: nil, isWaitingForModel: true, waitingStatusText: "Connecting…",
+				displayText: "", hasShownWordsThisSession: false))
+	}
+
+	@Test func waitingWithAnEmptyStatusIsNotContent() {
+		#expect(
+			!DictationHUDContent.hasSomethingToSay(
+				overlayError: nil, isWaitingForModel: true, waitingStatusText: "",
+				displayText: "", hasShownWordsThisSession: false))
+	}
+
+	@Test func wordsAreContent() {
+		#expect(
+			DictationHUDContent.hasSomethingToSay(
+				overlayError: nil, isWaitingForModel: false, waitingStatusText: "",
+				displayText: "hello there", hasShownWordsThisSession: false))
+	}
+
+	@Test func aBlankTranscriptAfterWordsHoldsTheWindow() {
+		#expect(
+			DictationHUDContent.hasSomethingToSay(
+				overlayError: nil, isWaitingForModel: false, waitingStatusText: "",
+				displayText: "", hasShownWordsThisSession: true))
+	}
+
+	@Test func aRecipeErrorIsContent() {
+		#expect(
+			DictationHUDContent.hasSomethingToSay(
+				overlayError: "Recipe failed", isWaitingForModel: false, waitingStatusText: "",
+				displayText: "", hasShownWordsThisSession: false))
 	}
 }

--- a/WhisperaUnitTests/DictationHUDWidthTests.swift
+++ b/WhisperaUnitTests/DictationHUDWidthTests.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025-2026 Ismatulla Mansurov
 
+import AppKit
 import Foundation
 import Testing
 
@@ -56,7 +57,7 @@ struct DictationHUDWidthTests {
 	@Test func smallJitterDoesNotMoveTheFrameAtAll() {
 		var rule = frame(width: 200)
 		let settled = rule.width
-		for (tick, estimated) in [190.0, 205.0, 199.0, 210.0].enumerated() {
+		for (tick, estimated) in [196.0, 210.0, 199.0, 214.0].enumerated() {
 			#expect(
 				rule.update(
 					estimated: estimated, maximum: maximum, isDictating: true,
@@ -85,7 +86,7 @@ struct DictationHUDWidthTests {
 	@Test func aPersistentGapClosesOneQuantumPerDelayUntilTheFrameHugsTheText() {
 		var rule = frame(width: 300)  // quantizes to 312
 		let grown = rule.width ?? 0
-		let need: CGFloat = 150  // quantizes to 168, three steps below
+		let need: CGFloat = 230  // quantizes to 240, three steps below
 
 		#expect(rule.update(estimated: need, maximum: maximum, isDictating: true, now: 1) == grown)
 		#expect(
@@ -177,6 +178,36 @@ struct DictationHUDWidthTests {
 			estimated: measured, maximum: maximum, isDictating: true, now: 0)
 		#expect(width >= measured, "the window must fit the text it shows")
 		#expect(width - measured < DictationHUDWidth.step, "and hug it within one growth step")
+	}
+
+	/// Double-entry audit of the padding chain, on the exact 10.png ticker: the
+	/// estimate must exceed the truly rendered text width by ONLY the intended
+	/// visual inset — DictationView's 12pt-per-side content padding — with no
+	/// double-counted padding and no ellipsis reserve when there is no
+	/// ellipsis. The fonts here are constructed independently, the same way
+	/// PillTypography describes them, so a drift in either side breaks this.
+	@Test func estimateExceedsTheRenderedTextByExactlyTheIntendedInset() {
+		func rounded(_ style: NSFont.TextStyle, weight: NSFont.Weight) -> NSFont {
+			let size = NSFont.preferredFont(forTextStyle: style).pointSize
+			let base = NSFont.systemFont(ofSize: size, weight: weight)
+			guard let descriptor = base.fontDescriptor.withDesign(.rounded),
+				let font = NSFont(descriptor: descriptor, size: size)
+			else { return base }
+			return font
+		}
+		let words = ["One", "other", "good", "is", "leave."]
+		var rendered: CGFloat = 0
+		for (index, word) in words.enumerated() {
+			let font =
+				index == words.count - 1
+				? rounded(.title3, weight: .semibold) : rounded(.body, weight: .regular)
+			rendered += (word as NSString).size(withAttributes: [.font: font]).width
+		}
+		rendered += CGFloat(words.count - 1) * 4  // PillWordFlow's HStack spacing
+
+		let estimate = DictationHUDWidth.estimatedWidth(words: words, hasEllipsis: false)
+
+		#expect(estimate == (rendered + 24).rounded(.up), "text + 12pt per side, nothing else")
 	}
 
 	@Test func estimateGrowsWhenAWordIsAdded() {

--- a/WhisperaUnitTests/DictationHUDWidthTests.swift
+++ b/WhisperaUnitTests/DictationHUDWidthTests.swift
@@ -172,8 +172,9 @@ struct DictationHUDWidthTests {
 		let oldFlatPrice = characters * 9 + CGFloat(words.count - 1) * 4 + 20 + 32
 		#expect(measured < oldFlatPrice, "the flat price is what left half the capsule blank")
 
-		let width = DictationHUDWidth.width(
-			current: nil, estimated: measured, maximum: maximum, isDictating: true)
+		var rule = DictationHUDFrame()
+		let width = rule.update(
+			estimated: measured, maximum: maximum, isDictating: true, now: 0)
 		#expect(width >= measured, "the window must fit the text it shows")
 		#expect(width - measured < DictationHUDWidth.step, "and hug it within one growth step")
 	}
@@ -195,11 +196,12 @@ struct DictationHUDWidthTests {
 	/// A status line ("Waiting for model...") must price out near the compact
 	/// floor, not race the frame up two growth steps before a word has arrived.
 	@Test func aStatusLineStaysNearTheCompactFloor() {
-		let width = DictationHUDWidth.width(
-			current: nil,
+		var rule = DictationHUDFrame()
+		let width = rule.update(
 			estimated: DictationHUDWidth.statusWidth("Waiting for model..."),
 			maximum: maximum,
-			isDictating: true)
+			isDictating: true,
+			now: 0)
 		#expect(width <= DictationHUDWidth.compact + DictationHUDWidth.step)
 	}
 }

--- a/WhisperaUnitTests/DictationHUDWidthTests.swift
+++ b/WhisperaUnitTests/DictationHUDWidthTests.swift
@@ -6,31 +6,45 @@ import Testing
 
 @testable import Whispera
 
-/// Pins the calm-motion contract for the live-words HUD frame — see WHI-58 QA:
-/// while a dictation runs the window may only grow, in coarse quantized steps,
-/// stops entirely at the ceiling, and starts compact again for the next
-/// session. Pure functions, so the contract holds without standing up a window.
+/// Pins the calm-motion contract for the live-words HUD frame — see the WHI-58
+/// QA sessions: while a dictation runs the frame grows immediately in coarse
+/// quantized steps, decays one quantum at a time only after the text has
+/// stopped needing the width for a sustained beat (the ticker's five-word
+/// window is not monotonic, and never-shrink left a permanent blank leading
+/// edge), freezes at the ceiling, and starts compact again for the next
+/// session. Time is injected, so the hysteresis runs at test speed.
 struct DictationHUDWidthTests {
 	private let maximum: CGFloat = 600
+	private let delay = DictationHUDFrame.shrinkDelay
+
+	private func frame(width: CGFloat, at now: TimeInterval = 0) -> DictationHUDFrame {
+		var rule = DictationHUDFrame()
+		_ = rule.update(estimated: width, maximum: maximum, isDictating: true, now: now)
+		return rule
+	}
 
 	@Test func startsCompactForEmptyOrTinyContent() {
+		var rule = DictationHUDFrame()
 		#expect(
-			DictationHUDWidth.width(current: nil, estimated: 0, maximum: maximum, isDictating: true)
+			rule.update(estimated: 0, maximum: maximum, isDictating: true, now: 0)
 				== DictationHUDWidth.compact)
+		rule.reset()
 		#expect(
-			DictationHUDWidth.width(
-				current: nil, estimated: DictationHUDWidth.compact, maximum: maximum, isDictating: true)
+			rule.update(
+				estimated: DictationHUDWidth.compact, maximum: maximum, isDictating: true, now: 0)
 				== DictationHUDWidth.compact)
 	}
 
-	@Test func growsOnTheStepGridNotPerWord() {
-		let width = DictationHUDWidth.width(
-			current: nil, estimated: DictationHUDWidth.compact + 1, maximum: maximum, isDictating: true)
-		#expect(width == DictationHUDWidth.compact + DictationHUDWidth.step)
+	@Test func growsImmediatelyOnTheStepGridNotPerWord() {
+		var rule = DictationHUDFrame()
+		#expect(
+			rule.update(
+				estimated: DictationHUDWidth.compact + 1, maximum: maximum, isDictating: true, now: 0)
+				== DictationHUDWidth.compact + DictationHUDWidth.step)
 
 		for estimated in stride(from: 0.0, through: 560.0, by: 13.0) {
-			let width = DictationHUDWidth.width(
-				current: nil, estimated: estimated, maximum: maximum, isDictating: true)
+			var rule = DictationHUDFrame()
+			let width = rule.update(estimated: estimated, maximum: maximum, isDictating: true, now: 0)
 			if width < maximum {
 				let offGrid = (width - DictationHUDWidth.compact)
 					.truncatingRemainder(dividingBy: DictationHUDWidth.step)
@@ -39,65 +53,110 @@ struct DictationHUDWidthTests {
 		}
 	}
 
-	@Test func neverShrinksWhileDictating() {
-		// A wobbling estimate, like the per-word pricing produces as words stop
-		// being last: the resulting frame must be monotonic anyway.
-		var current: CGFloat?
-		for estimated in [140.0, 210.0, 180.0, 320.0, 60.0, 340.0] {
-			let next = DictationHUDWidth.width(
-				current: current, estimated: estimated, maximum: maximum, isDictating: true)
-			if let previous = current {
-				#expect(next >= previous, "the frame may grow mid-dictation, never shrink")
-			}
-			current = next
-		}
-	}
-
 	@Test func smallJitterDoesNotMoveTheFrameAtAll() {
-		let settled = DictationHUDWidth.width(
-			current: nil, estimated: 200, maximum: maximum, isDictating: true)
-		for estimated in [190.0, 205.0, 199.0, 210.0] {
+		var rule = frame(width: 200)
+		let settled = rule.width
+		for (tick, estimated) in [190.0, 205.0, 199.0, 210.0].enumerated() {
 			#expect(
-				DictationHUDWidth.width(
-					current: settled, estimated: estimated, maximum: maximum, isDictating: true)
-					== settled)
+				rule.update(
+					estimated: estimated, maximum: maximum, isDictating: true,
+					now: Double(tick) * 10)
+					== settled,
+				"a need within one step of the frame never moves it, however long it persists")
 		}
 	}
 
-	@Test func anEmptyDisplayTextMidDictationHoldsTheFrame() {
-		let grown = DictationHUDWidth.width(
-			current: nil, estimated: 300, maximum: maximum, isDictating: true)
+	@Test func aMomentaryNarrowTickerDoesNotShrinkTheFrame() {
+		var rule = frame(width: 300)
+		let grown = rule.update(estimated: 300, maximum: maximum, isDictating: true, now: 0)
+
+		// Narrow for less than the delay, then wide again: no movement at all.
+		#expect(rule.update(estimated: 150, maximum: maximum, isDictating: true, now: 0.3) == grown)
 		#expect(
-			DictationHUDWidth.width(current: grown, estimated: 0, maximum: maximum, isDictating: true)
+			rule.update(estimated: 150, maximum: maximum, isDictating: true, now: 0.3 + delay * 0.9)
+				== grown)
+		#expect(rule.update(estimated: 300, maximum: maximum, isDictating: true, now: 2 * delay) == grown)
+		#expect(
+			rule.update(estimated: 150, maximum: maximum, isDictating: true, now: 2 * delay + 0.1)
 				== grown,
+			"the dip's clock restarts once the text needs the width again")
+	}
+
+	@Test func aPersistentGapClosesOneQuantumPerDelayUntilTheFrameHugsTheText() {
+		var rule = frame(width: 300)  // quantizes to 312
+		let grown = rule.width ?? 0
+		let need: CGFloat = 150  // quantizes to 168, three steps below
+
+		#expect(rule.update(estimated: need, maximum: maximum, isDictating: true, now: 1) == grown)
+		#expect(
+			rule.update(estimated: need, maximum: maximum, isDictating: true, now: 1 + delay)
+				== grown - DictationHUDWidth.step)
+		#expect(
+			rule.update(estimated: need, maximum: maximum, isDictating: true, now: 1 + delay + 0.3)
+				== grown - DictationHUDWidth.step,
+			"consecutive steps are paced by the delay, not by the caller's tick rate")
+		#expect(
+			rule.update(estimated: need, maximum: maximum, isDictating: true, now: 1 + 2 * delay)
+				== grown - 2 * DictationHUDWidth.step)
+		#expect(
+			rule.update(estimated: need, maximum: maximum, isDictating: true, now: 1 + 3 * delay)
+				== DictationHUDWidth.quantized(need),
+			"the decay settles exactly on the text's quantized need")
+		#expect(
+			rule.update(estimated: need, maximum: maximum, isDictating: true, now: 1 + 10 * delay)
+				== DictationHUDWidth.quantized(need),
+			"and never undershoots it")
+	}
+
+	@Test func growthCancelsAPendingShrink() {
+		var rule = frame(width: 300)
+		_ = rule.update(estimated: 150, maximum: maximum, isDictating: true, now: 1)
+		let wider = rule.update(estimated: 400, maximum: maximum, isDictating: true, now: 1.2)
+		#expect(wider > 300, "growth is immediate even with a shrink armed")
+		#expect(
+			rule.update(estimated: 400, maximum: maximum, isDictating: true, now: 1.2 + delay)
+				== wider,
+			"the armed shrink is forgotten, not carried into the new width")
+	}
+
+	@Test func anEmptyDisplayTextMidDictationHoldsTheFrameThroughTheDelay() {
+		var rule = frame(width: 300)
+		let grown = rule.width ?? 0
+		#expect(
+			rule.update(estimated: 0, maximum: maximum, isDictating: true, now: 0.3) == grown,
 			"a momentarily blank transcript must not collapse the window")
+		#expect(
+			rule.update(estimated: 0, maximum: maximum, isDictating: true, now: 0.3 + delay * 0.9)
+				== grown)
 	}
 
 	@Test func clampsAtTheMaximumAndThenStopsChanging() {
-		let atMax = DictationHUDWidth.width(
-			current: nil, estimated: 5000, maximum: maximum, isDictating: true)
+		var rule = DictationHUDFrame()
+		let atMax = rule.update(estimated: 5000, maximum: maximum, isDictating: true, now: 0)
 		#expect(atMax == maximum)
 		#expect(
-			DictationHUDWidth.width(current: atMax, estimated: 9000, maximum: maximum, isDictating: true)
-				== maximum,
+			rule.update(estimated: 9000, maximum: maximum, isDictating: true, now: 1) == maximum)
+		#expect(
+			rule.update(estimated: 100, maximum: maximum, isDictating: true, now: 100) == maximum,
 			"once at the ceiling the frame never changes again")
 	}
 
-	/// `current == nil` is the hidden window: nothing to preserve, so the next
-	/// session starts from compact no matter how far the previous one grew.
+	/// `reset()` is the hidden window: nothing to preserve, so the next session
+	/// starts from compact no matter how far the previous one grew.
 	@Test func aHiddenWindowResetsSoTheNextSessionStartsCompact() {
-		let grown = DictationHUDWidth.width(
-			current: nil, estimated: 500, maximum: maximum, isDictating: true)
-		#expect(grown > DictationHUDWidth.compact)
+		var rule = frame(width: 500)
+		#expect((rule.width ?? 0) > DictationHUDWidth.compact)
+		rule.reset()
 		#expect(
-			DictationHUDWidth.width(current: nil, estimated: 0, maximum: maximum, isDictating: true)
+			rule.update(estimated: 0, maximum: maximum, isDictating: true, now: 100)
 				== DictationHUDWidth.compact)
 	}
 
-	@Test func outsideADictationTheWidthIsFreeToShrink() {
-		let width = DictationHUDWidth.width(
-			current: 552, estimated: 130, maximum: maximum, isDictating: false)
-		#expect(width < 552)
+	@Test func outsideADictationTheWidthIsFreeToShrinkImmediately() {
+		var rule = frame(width: 550)
+		let width = rule.update(estimated: 130, maximum: maximum, isDictating: false, now: 0.1)
+		#expect(width < 550)
+		#expect(width == DictationHUDWidth.quantized(130))
 	}
 
 	/// The QA screenshot's exact ticker: the old flat 9pt/char price sat far

--- a/WhisperaUnitTests/DictationHUDWidthTests.swift
+++ b/WhisperaUnitTests/DictationHUDWidthTests.swift
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import Testing
+
+@testable import Whispera
+
+/// Pins the calm-motion contract for the live-words HUD frame — see WHI-58 QA:
+/// while a dictation runs the window may only grow, in coarse quantized steps,
+/// stops entirely at the ceiling, and starts compact again for the next
+/// session. Pure functions, so the contract holds without standing up a window.
+struct DictationHUDWidthTests {
+	private let maximum: CGFloat = 600
+
+	@Test func startsCompactForEmptyOrTinyContent() {
+		#expect(
+			DictationHUDWidth.width(current: nil, estimated: 0, maximum: maximum, isDictating: true)
+				== DictationHUDWidth.compact)
+		#expect(
+			DictationHUDWidth.width(
+				current: nil, estimated: DictationHUDWidth.compact, maximum: maximum, isDictating: true)
+				== DictationHUDWidth.compact)
+	}
+
+	@Test func growsOnTheStepGridNotPerWord() {
+		let width = DictationHUDWidth.width(
+			current: nil, estimated: DictationHUDWidth.compact + 1, maximum: maximum, isDictating: true)
+		#expect(width == DictationHUDWidth.compact + DictationHUDWidth.step)
+
+		for estimated in stride(from: 0.0, through: 560.0, by: 13.0) {
+			let width = DictationHUDWidth.width(
+				current: nil, estimated: estimated, maximum: maximum, isDictating: true)
+			if width < maximum {
+				let offGrid = (width - DictationHUDWidth.compact)
+					.truncatingRemainder(dividingBy: DictationHUDWidth.step)
+				#expect(offGrid == 0, "every width below the ceiling lands on the step grid")
+			}
+		}
+	}
+
+	@Test func neverShrinksWhileDictating() {
+		// A wobbling estimate, like the per-word pricing produces as words stop
+		// being last: the resulting frame must be monotonic anyway.
+		var current: CGFloat?
+		for estimated in [140.0, 210.0, 180.0, 320.0, 60.0, 340.0] {
+			let next = DictationHUDWidth.width(
+				current: current, estimated: estimated, maximum: maximum, isDictating: true)
+			if let previous = current {
+				#expect(next >= previous, "the frame may grow mid-dictation, never shrink")
+			}
+			current = next
+		}
+	}
+
+	@Test func smallJitterDoesNotMoveTheFrameAtAll() {
+		let settled = DictationHUDWidth.width(
+			current: nil, estimated: 200, maximum: maximum, isDictating: true)
+		for estimated in [190.0, 205.0, 199.0, 210.0] {
+			#expect(
+				DictationHUDWidth.width(
+					current: settled, estimated: estimated, maximum: maximum, isDictating: true)
+					== settled)
+		}
+	}
+
+	@Test func anEmptyDisplayTextMidDictationHoldsTheFrame() {
+		let grown = DictationHUDWidth.width(
+			current: nil, estimated: 300, maximum: maximum, isDictating: true)
+		#expect(
+			DictationHUDWidth.width(current: grown, estimated: 0, maximum: maximum, isDictating: true)
+				== grown,
+			"a momentarily blank transcript must not collapse the window")
+	}
+
+	@Test func clampsAtTheMaximumAndThenStopsChanging() {
+		let atMax = DictationHUDWidth.width(
+			current: nil, estimated: 5000, maximum: maximum, isDictating: true)
+		#expect(atMax == maximum)
+		#expect(
+			DictationHUDWidth.width(current: atMax, estimated: 9000, maximum: maximum, isDictating: true)
+				== maximum,
+			"once at the ceiling the frame never changes again")
+	}
+
+	/// `current == nil` is the hidden window: nothing to preserve, so the next
+	/// session starts from compact no matter how far the previous one grew.
+	@Test func aHiddenWindowResetsSoTheNextSessionStartsCompact() {
+		let grown = DictationHUDWidth.width(
+			current: nil, estimated: 500, maximum: maximum, isDictating: true)
+		#expect(grown > DictationHUDWidth.compact)
+		#expect(
+			DictationHUDWidth.width(current: nil, estimated: 0, maximum: maximum, isDictating: true)
+				== DictationHUDWidth.compact)
+	}
+
+	@Test func outsideADictationTheWidthIsFreeToShrink() {
+		let width = DictationHUDWidth.width(
+			current: 552, estimated: 130, maximum: maximum, isDictating: false)
+		#expect(width < 552)
+	}
+
+	@Test func estimateIsFlatPerCharacterSoWordOrderCannotWobbleIt() {
+		let a = DictationHUDWidth.estimatedWidth(words: ["hello", "world"], hasEllipsis: false)
+		let b = DictationHUDWidth.estimatedWidth(words: ["world", "hello"], hasEllipsis: false)
+		#expect(a == b, "which word is last must not change the estimate")
+	}
+
+	@Test func ellipsisReservesRoom() {
+		let without = DictationHUDWidth.estimatedWidth(words: ["hello"], hasEllipsis: false)
+		let with = DictationHUDWidth.estimatedWidth(words: ["hello"], hasEllipsis: true)
+		#expect(with > without)
+	}
+}

--- a/WhisperaUnitTests/LiveDictationPasteTests.swift
+++ b/WhisperaUnitTests/LiveDictationPasteTests.swift
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Testing
+
+@testable import Whispera
+
+/// The paste-once-at-stop decision for live dictation: nothing pastes while
+/// words are still arriving (see `DictationWordTracker.handleConfirmedTextChange`
+/// and `stopLiveTranscription`'s call site), so the only thing left to decide
+/// once a stream closes is whether it produced anything worth pasting. See
+/// WHI-58, and PASTE-MODEL-RESULT.md for the fuller decision table this pins.
+struct LiveDictationPasteTests {
+	@Test func aFullTranscriptIsReturnedTrimmed() {
+		#expect(
+			AudioManager.textToPaste(afterLiveDictationFinished: "  hello there  ")
+				== "hello there")
+	}
+
+	@Test func anUntrimmedTranscriptWithNoWhitespaceIsUnchanged() {
+		#expect(
+			AudioManager.textToPaste(afterLiveDictationFinished: "the quick brown fox")
+				== "the quick brown fox")
+	}
+
+	@Test func anEmptyTranscriptPastesNothing() {
+		#expect(AudioManager.textToPaste(afterLiveDictationFinished: "") == nil)
+	}
+
+	@Test func aWhitespaceOnlyTranscriptPastesNothing() {
+		#expect(AudioManager.textToPaste(afterLiveDictationFinished: "   \n\t  ") == nil)
+	}
+
+	/// A session that fails before confirming any words hands back "" the same
+	/// way a session with nothing said does — both engines' `stopStreaming()`
+	/// return the empty string in that case, and this function must not
+	/// distinguish "failed" from "silent": either way there is nothing to paste.
+	@Test func aFailedSessionWithNoWordsPastesNothing() {
+		#expect(AudioManager.textToPaste(afterLiveDictationFinished: "") == nil)
+	}
+}

--- a/WhisperaUnitTests/LiveTranscriptionStateTests.swift
+++ b/WhisperaUnitTests/LiveTranscriptionStateTests.swift
@@ -357,3 +357,65 @@ struct UtteranceDraftAccumulatorTests {
 		#expect(state.pendingText == "")
 	}
 }
+
+/// Back-to-back dictations through the real state object — the WHI-58 QA
+/// session found words no longer appearing after a couple of consecutive
+/// dictations. Each test replays the exact call sequence the engines make at
+/// session boundaries and pins that the next session opens clean and shows its
+/// first words.
+@MainActor
+struct LiveTranscriptionBackToBackSessionTests {
+	/// The delta-engine cycle: startStreaming's beginWaiting, the .listening
+	/// handler, partials, then stopStreaming's exact stop sequence — twice.
+	@Test func aSecondDeltaSessionOpensCleanAndShowsItsFirstWords() {
+		let state = LiveTranscriptionState()
+
+		state.beginWaiting()
+		state.isWaitingForModel = false
+		state.isTranscribing = true
+		state.ingest(committed: "", draft: "Hello world")
+		#expect(state.stableDisplayText == "Hello world")
+
+		state.isTranscribing = false
+		state.ingest(committed: "Hello world", draft: "")
+		state.setPending("")
+		state.shouldShowLiveTranscriptionWindow = false
+
+		state.beginWaiting()
+		#expect(state.stableDisplayText.isEmpty, "no leftover words from the previous session")
+		#expect(state.confirmedText.isEmpty, "no leftover confirmation from the previous session")
+		state.isWaitingForModel = false
+		state.isTranscribing = true
+		state.ingest(committed: state.confirmedText, draft: "Again")
+
+		#expect(state.stableDisplayText == "Again", "the new session's first words must appear")
+	}
+
+	/// A segment engine that starts its next session through beginWaiting alone
+	/// must still confirm from its first segment: a confirmation count left
+	/// over from the previous session would silently swallow the new session's
+	/// opening words from the confirmed text.
+	@Test func beginWaitingResetsTheSegmentConfirmationCount() {
+		let state = LiveTranscriptionState()
+		state.ingest(segmentTexts: ["one", "two", "three", "four", "five"])
+		#expect(state.confirmedText == "one two three")
+
+		state.beginWaiting()
+		state.ingest(segmentTexts: ["a", "b", "c"])
+
+		#expect(state.confirmedText == "a")
+		#expect(state.pendingText == "b c")
+	}
+
+	/// The flicker filter compares against the last displayed text; a stale
+	/// value surviving the session boundary could suppress the next session's
+	/// first (short) update. beginWaiting must leave the filter wide open.
+	@Test func theFlickerFilterCannotSuppressANewSessionsFirstWord() {
+		let state = LiveTranscriptionState()
+		state.ingest(committed: "", draft: "Thank you")
+
+		state.beginWaiting()
+
+		#expect(state.shouldUpdatePendingText(newText: "Thank"))
+	}
+}

--- a/WhisperaUnitTests/LiveTranscriptionStateTests.swift
+++ b/WhisperaUnitTests/LiveTranscriptionStateTests.swift
@@ -178,14 +178,72 @@ struct LiveTranscriptionFlickerFilterTests {
 /// so nothing is buffered, but the display still moves on the same rule.
 @MainActor
 struct LiveTranscriptionRemoteIngestTests {
-	@Test func committedTextBecomesConfirmedAndTheDraftIsDisplayed() {
+	@Test func theDisplayCarriesTheCommittedWordsAndTheDraft() {
 		let state = LiveTranscriptionState()
 
 		state.ingest(committed: "the quick brown fox", draft: "jumps over")
 
 		#expect(state.confirmedText == "the quick brown fox")
-		#expect(state.stableDisplayText == "jumps over")
+		#expect(state.pendingText == "jumps over")
+		#expect(state.stableDisplayText == "the quick brown fox jumps over")
 		#expect(state.shouldShowLiveTranscriptionWindow)
+	}
+
+	/// The sequence a native-delta engine produces, as observed in the WHI-58 QA
+	/// session: word-by-word partials, the utterance finalizes and the whole
+	/// accumulated transcript arrives, then the next utterance's partials begin.
+	/// The display must only ever grow — committed words never vanish at an
+	/// utterance boundary.
+	@Test func theDisplayOnlyGrowsAcrossAnUtteranceBoundary() {
+		let state = LiveTranscriptionState()
+		var displays: [String] = []
+		// Mirrors StreamingTranscriber.handle: .partialTranscript carries only the
+		// current utterance; .transcript carries the whole accumulated text.
+		func partial(_ draft: String) {
+			state.ingest(committed: state.confirmedText, draft: draft)
+			displays.append(state.stableDisplayText)
+		}
+		func transcript(_ whole: String) {
+			state.ingest(committed: whole, draft: "")
+			displays.append(state.stableDisplayText)
+		}
+
+		partial("Hello")
+		partial("Hello there.")
+		transcript("Hello there.")
+		partial("General")
+		partial("General Kenobi.")
+		transcript("Hello there. General Kenobi.")
+
+		for (previous, next) in zip(displays, displays.dropFirst()) {
+			#expect(next.hasPrefix(previous))
+		}
+		#expect(state.stableDisplayText == "Hello there. General Kenobi.")
+		#expect(state.confirmedText == "Hello there. General Kenobi.")
+	}
+
+	/// The whole-transcript event already contains the utterance that just
+	/// finalized; it must not appear a second time as a leftover draft.
+	@Test func theWholeTranscriptEventDoesNotRepeatTheFinalizedUtterance() {
+		let state = LiveTranscriptionState()
+
+		state.ingest(committed: "", draft: "Hello.")
+		state.ingest(committed: "Hello.", draft: "")
+
+		#expect(state.stableDisplayText == "Hello.")
+		#expect(state.confirmedText == "Hello.")
+		#expect(state.pendingText == "")
+	}
+
+	/// What stop pastes: the committed words plus any draft still in flight —
+	/// for a native-delta engine the draft is real words the user spoke.
+	@Test func stopComposesCommittedAndDraftIntoOneTranscript() {
+		#expect(
+			LiveTranscriptionState.joined(committed: "Hello there.", draft: "General")
+				== "Hello there. General")
+		#expect(LiveTranscriptionState.joined(committed: "", draft: "Hello") == "Hello")
+		#expect(LiveTranscriptionState.joined(committed: "Hello", draft: "") == "Hello")
+		#expect(LiveTranscriptionState.joined(committed: "", draft: "") == "")
 	}
 
 	@Test func anUnchangedCommitIsNotAnnouncedAgain() {

--- a/WhisperaUnitTests/LiveTranscriptionStateTests.swift
+++ b/WhisperaUnitTests/LiveTranscriptionStateTests.swift
@@ -197,8 +197,9 @@ struct LiveTranscriptionRemoteIngestTests {
 	@Test func theDisplayOnlyGrowsAcrossAnUtteranceBoundary() {
 		let state = LiveTranscriptionState()
 		var displays: [String] = []
-		// Mirrors StreamingTranscriber.handle: .partialTranscript carries only the
-		// current utterance; .transcript carries the whole accumulated text.
+		// Mirrors StreamingTranscriber.handle: each `partial` here stands for the
+		// draft the transcriber has accumulated out of its delta events so far;
+		// .transcript carries the whole accumulated text.
 		func partial(_ draft: String) {
 			state.ingest(committed: state.confirmedText, draft: draft)
 			displays.append(state.stableDisplayText)
@@ -266,5 +267,93 @@ struct LiveTranscriptionRemoteIngestTests {
 		state.ingest(committed: "hello there", draft: "")
 
 		#expect(announced == ["hello", "hello there"])
+	}
+}
+
+/// The transcriber-side accumulation of `.partialTranscript` deltas. A partial
+/// carries only the fragment since the previous event, so the transcriber
+/// appends it into `UtteranceDraftAccumulator` before handing the draft to the
+/// live state; showing a fragment alone replaced the pill's tail instead of
+/// growing it. These tests replay the exact event sequence recorded in the
+/// WHI-58 nemo-stream QA session through the same logic the handler runs.
+@MainActor
+struct UtteranceDraftAccumulatorTests {
+	@Test func fragmentsConcatenateWithoutASeparator() {
+		var accumulator = UtteranceDraftAccumulator()
+
+		accumulator.append(" should be work")
+		accumulator.append("ing right")
+
+		#expect(accumulator.draft == "should be working right")
+	}
+
+	@Test func clearingStartsTheNextUtteranceEmpty() {
+		var accumulator = UtteranceDraftAccumulator()
+		accumulator.append("Hello, hello")
+
+		accumulator.clear()
+
+		#expect(accumulator.draft == "")
+	}
+
+	@Test func theExactQAEventSequenceGrowsThePillInsteadOfReplacingItsTail() {
+		let state = LiveTranscriptionState()
+		var accumulator = UtteranceDraftAccumulator()
+		// Mirrors StreamingTranscriber.handle for a native-delta engine.
+		func partialTranscript(_ delta: String) {
+			accumulator.append(delta)
+			state.ingest(committed: state.confirmedText, draft: accumulator.draft)
+		}
+		func finalTranscript() { accumulator.clear() }
+		func transcript(_ whole: String) {
+			accumulator.clear()
+			state.ingest(committed: whole, draft: "")
+		}
+
+		partialTranscript("Hello, hello")
+		partialTranscript(".")
+		finalTranscript()
+		transcript("Hello, hello.")
+
+		#expect(state.stableDisplayText == "Hello, hello.")
+		#expect(state.confirmedText == "Hello, hello.")
+		#expect(state.pendingText == "")
+
+		partialTranscript("Eh this")
+		partialTranscript(" should be work")
+		partialTranscript("ing right")
+		partialTranscript(", yep.")
+
+		#expect(state.pendingText == "Eh this should be working right, yep.")
+		#expect(state.stableDisplayText == "Hello, hello. Eh this should be working right, yep.")
+
+		partialTranscript("  It is.")
+
+		#expect(state.pendingText == "Eh this should be working right, yep.  It is.")
+
+		// Stopping mid-utterance pastes committed plus the accumulated draft,
+		// exactly as stopStreaming composes them from the live state.
+		let pasted = LiveTranscriptionState.joined(
+			committed: state.confirmedText, draft: state.pendingText
+		).trimmingCharacters(in: .whitespacesAndNewlines)
+		#expect(pasted == "Hello, hello. Eh this should be working right, yep.  It is.")
+	}
+
+	@Test func aWholeTranscriptAfterAccumulatedPartialsShowsTheUtteranceOnce() {
+		let state = LiveTranscriptionState()
+		var accumulator = UtteranceDraftAccumulator()
+
+		accumulator.append("Hello, hello")
+		state.ingest(committed: state.confirmedText, draft: accumulator.draft)
+		accumulator.append(".")
+		state.ingest(committed: state.confirmedText, draft: accumulator.draft)
+		// finalTranscript clears; the whole-transcript event clears again and
+		// commits — the second clear must be harmless.
+		accumulator.clear()
+		accumulator.clear()
+		state.ingest(committed: "Hello, hello.", draft: accumulator.draft)
+
+		#expect(state.stableDisplayText == "Hello, hello.")
+		#expect(state.pendingText == "")
 	}
 }

--- a/WhisperaUnitTests/LiveTranscriptionStateTests.swift
+++ b/WhisperaUnitTests/LiveTranscriptionStateTests.swift
@@ -419,3 +419,148 @@ struct LiveTranscriptionBackToBackSessionTests {
 		#expect(state.shouldUpdatePendingText(newText: "Thank"))
 	}
 }
+
+/// After stop, exactly one surface communicates the two-pass polish: the
+/// listening pill. The 2026-08-10 QA screenshot showed two "Polishing…"
+/// spinner chips at once because stop routed the pass through the same
+/// isWaitingForModel channel both windows render. These tests replay the
+/// engine's exact call sequences through the real state object and pin that
+/// the words window's gate goes down at stop and stays down through the pass,
+/// while the pill's finalize channel carries the status until the paste lands.
+@MainActor
+struct LiveTranscriptionFinalizePassTests {
+	/// The words window's show decision, composed exactly as
+	/// LiveTranscriptionWindow composes it each poll tick: the session gate,
+	/// the transcriber's own wish, and the has-content rule.
+	private func wordsWindowWantsVisible(
+		_ state: LiveTranscriptionState, hasShownWordsThisSession: Bool = true
+	) -> Bool {
+		state.isSessionActive && state.shouldShowLiveTranscriptionWindow
+			&& DictationHUDContent.hasSomethingToSay(
+				overlayError: nil,
+				isWaitingForModel: state.isWaitingForModel,
+				waitingStatusText: state.waitingForModelStatusText,
+				displayText: state.stableDisplayText,
+				hasShownWordsThisSession: hasShownWordsThisSession)
+	}
+
+	/// A running dictation with words on screen: startStreaming's beginWaiting,
+	/// the .listening handler, then a partial.
+	private func dictate(_ state: LiveTranscriptionState) {
+		state.beginWaiting()
+		state.isWaitingForModel = false
+		state.waitingForModelStatusText = ""
+		state.isTranscribing = true
+		state.ingest(committed: "", draft: "Hello world")
+	}
+
+	/// stopStreaming's exact live-state sequence, with the finalizer on.
+	private func stopWithPolish(_ state: LiveTranscriptionState) {
+		state.isWaitingForModel = false
+		state.waitingForModelStatusText = ""
+		state.isTranscribing = false
+		let transcript = LiveTranscriptionState.joined(
+			committed: state.confirmedText, draft: state.pendingText
+		).trimmingCharacters(in: .whitespacesAndNewlines)
+		if !transcript.isEmpty {
+			state.ingest(committed: transcript, draft: "")
+		}
+		state.setPending("")
+		state.shouldShowLiveTranscriptionWindow = false
+		state.beginFinalizing(statusText: "Polishing…")
+	}
+
+	@Test func theWordsWindowGoesDownAtStopAndStaysDownThroughThePolish() {
+		let state = LiveTranscriptionState()
+		dictate(state)
+		#expect(wordsWindowWantsVisible(state), "the running dictation shows its words")
+
+		stopWithPolish(state)
+
+		#expect(!wordsWindowWantsVisible(state), "the words window dismisses at stop")
+		#expect(
+			!state.isSessionActive,
+			"the polish is not a session: the gate must not hold the window up through it")
+
+		state.endFinalizing()
+		#expect(!wordsWindowWantsVisible(state), "and it does not come back when the paste lands")
+	}
+
+	@Test func thePillCarriesThePolishStatusUntilThePasteLands() {
+		let state = LiveTranscriptionState()
+		dictate(state)
+
+		stopWithPolish(state)
+		#expect(state.isFinalizing)
+		#expect(state.finalizingStatusText == "Polishing…")
+		#expect(
+			!state.isWaitingForModel,
+			"the polish must not ride the waiting channel the words window renders")
+
+		state.endFinalizing()
+		#expect(!state.isFinalizing)
+		#expect(state.finalizingStatusText.isEmpty)
+	}
+
+	/// With the finalizer off, stop makes the same sequence minus
+	/// beginFinalizing; the window comes down identically and no finalize
+	/// status ever appears.
+	@Test func theOffPathIsUnchanged() {
+		let state = LiveTranscriptionState()
+		dictate(state)
+
+		state.isWaitingForModel = false
+		state.waitingForModelStatusText = ""
+		state.isTranscribing = false
+		state.ingest(committed: "Hello world", draft: "")
+		state.setPending("")
+		state.shouldShowLiveTranscriptionWindow = false
+
+		#expect(!wordsWindowWantsVisible(state))
+		#expect(!state.isFinalizing)
+		#expect(state.finalizingStatusText.isEmpty)
+	}
+
+	/// A rapid next dictation supersedes the pending pass; its pill must open
+	/// on the new session's status, not the stale "Polishing…".
+	@Test func theNextDictationResetsThePendingPolish() {
+		let state = LiveTranscriptionState()
+		dictate(state)
+		stopWithPolish(state)
+
+		state.beginWaiting()
+
+		#expect(!state.isFinalizing)
+		#expect(state.finalizingStatusText.isEmpty)
+		#expect(state.isSessionActive, "the new session owns the words window again")
+		#expect(wordsWindowWantsVisible(state, hasShownWordsThisSession: false))
+	}
+
+	@Test func resetClearsThePendingPolish() {
+		let state = LiveTranscriptionState()
+		state.beginFinalizing(statusText: "Polishing…")
+
+		state.reset()
+
+		#expect(!state.isFinalizing)
+		#expect(state.finalizingStatusText.isEmpty)
+	}
+
+	/// The session gate itself, pinned directly: mid-session statuses keep the
+	/// words window alive, the finalize pass does not.
+	@Test func isSessionActiveExcludesTheFinalizePass() {
+		let state = LiveTranscriptionState()
+		#expect(!state.isSessionActive)
+
+		state.isTranscribing = true
+		#expect(state.isSessionActive)
+
+		state.isTranscribing = false
+		state.isWaitingForModel = true
+		#expect(state.isSessionActive, "reconnecting and waiting-for-model hold the session open")
+
+		state.isWaitingForModel = false
+		state.isFinalizing = true
+		#expect(!state.isSessionActive)
+	}
+}

--- a/WhisperaUnitTests/LiveTranscriptionStateTests.swift
+++ b/WhisperaUnitTests/LiveTranscriptionStateTests.swift
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Testing
+
+@testable import Whispera
+
+/// Pins the two-segment confirmation buffer and the flicker filter that were
+/// extracted out of WhisperKitTranscriber, so a future engine cannot quietly
+/// change how live text is confirmed. See WHI-58.
+@MainActor
+struct LiveTranscriptionSegmentBufferTests {
+	@Test func fewerSegmentsThanTheBufferConfirmsNothing() {
+		let state = LiveTranscriptionState()
+
+		state.ingest(segmentTexts: ["hello", "there"])
+
+		#expect(state.confirmedText == "")
+		#expect(state.pendingText == "hello there")
+		#expect(state.stableDisplayText == "hello there")
+		#expect(state.shouldShowLiveTranscriptionWindow)
+	}
+
+	@Test func everythingBeforeTheLastTwoSegmentsIsConfirmed() {
+		let state = LiveTranscriptionState()
+
+		state.ingest(segmentTexts: ["one", "two", "three"])
+
+		#expect(state.confirmedText == "one")
+		#expect(state.pendingText == "two three")
+	}
+
+	@Test func asegmentIsNeverConfirmedTwice() {
+		let state = LiveTranscriptionState()
+
+		state.ingest(segmentTexts: ["one", "two", "three"])
+		state.ingest(segmentTexts: ["one", "two", "three"])
+
+		#expect(state.confirmedText == "one")
+	}
+
+	@Test func growingHistoryAppendsOnlyTheNewlySettledSegments() {
+		let state = LiveTranscriptionState()
+
+		state.ingest(segmentTexts: ["one", "two", "three"])
+		state.ingest(segmentTexts: ["one", "two", "three", "four", "five"])
+
+		#expect(state.confirmedText == "one two three")
+		#expect(state.pendingText == "four five")
+	}
+
+	@Test func anEmptySegmentListLeavesTheStateAlone() {
+		let state = LiveTranscriptionState()
+		state.ingest(segmentTexts: ["one", "two", "three"])
+
+		state.ingest(segmentTexts: [])
+
+		#expect(state.confirmedText == "one")
+		#expect(state.pendingText == "two three")
+	}
+
+	@Test func resettingLetsTheNextStreamConfirmFromItsFirstSegment() {
+		let state = LiveTranscriptionState()
+		state.ingest(segmentTexts: ["one", "two", "three"])
+
+		state.reset()
+		state.ingest(segmentTexts: ["alpha", "beta", "gamma"])
+
+		#expect(state.confirmedText == "alpha")
+		#expect(state.pendingText == "beta gamma")
+	}
+
+	@Test func resetClearsEveryDisplayProperty() {
+		let state = LiveTranscriptionState()
+		state.ingest(segmentTexts: ["one", "two", "three"])
+		state.isWaitingForModel = true
+		state.waitingForModelStatusText = "Loading..."
+
+		state.reset()
+
+		#expect(state.confirmedText == "")
+		#expect(state.pendingText == "")
+		#expect(state.stableDisplayText == "")
+		#expect(!state.shouldShowLiveTranscriptionWindow)
+		#expect(!state.isTranscribing)
+		#expect(!state.isWaitingForModel)
+		#expect(state.waitingForModelStatusText == "")
+	}
+
+	@Test func beginWaitingShowsTheWindowWithNoText() {
+		let state = LiveTranscriptionState()
+		state.ingest(segmentTexts: ["one", "two", "three"])
+
+		state.beginWaiting()
+
+		#expect(state.confirmedText == "")
+		#expect(state.stableDisplayText == "")
+		#expect(state.shouldShowLiveTranscriptionWindow)
+		#expect(state.isWaitingForModel)
+		#expect(state.waitingForModelStatusText == "Waiting for model...")
+	}
+
+	@Test func confirmPendingPromotesTheTailAndEmptiesIt() {
+		let state = LiveTranscriptionState()
+		state.ingest(segmentTexts: ["one", "two", "three"])
+
+		state.confirmPending()
+
+		#expect(state.confirmedText == "two three")
+		#expect(state.pendingText == "")
+		#expect(state.stableDisplayText == "two three")
+	}
+
+	@Test func confirmPendingWithNothingPendingLeavesConfirmedTextAlone() {
+		let state = LiveTranscriptionState()
+		state.ingest(segmentTexts: ["one", "two", "three"])
+		state.confirmPending()
+
+		state.confirmPending()
+
+		#expect(state.confirmedText == "two three")
+	}
+
+	@Test func confirmedTextChangesAreAnnouncedOnce() {
+		let state = LiveTranscriptionState()
+		var announced: [String] = []
+		state.onConfirmedTextChange = { announced.append($0) }
+
+		state.ingest(segmentTexts: ["one", "two", "three"])
+		state.ingest(segmentTexts: ["one", "two", "three"])
+
+		#expect(announced == ["one"])
+	}
+}
+
+@MainActor
+struct LiveTranscriptionFlickerFilterTests {
+	@Test func theFirstWordsAlwaysReachTheDisplay() {
+		let state = LiveTranscriptionState()
+
+		state.setPending("hello world")
+
+		#expect(state.stableDisplayText == "hello world")
+	}
+
+	/// A rewrite that leaves the last three words and the word count alone is
+	/// the engine nudging its own output, not new speech.
+	@Test func aRewriteOfTheHeadDoesNotMoveTheDisplay() {
+		let state = LiveTranscriptionState()
+		state.setPending("alpha beta gamma delta")
+
+		state.setPending("omega beta gamma delta")
+
+		#expect(state.pendingText == "omega beta gamma delta")
+		#expect(state.stableDisplayText == "alpha beta gamma delta")
+	}
+
+	@Test func newWordsAtTheTailMoveTheDisplay() {
+		let state = LiveTranscriptionState()
+		state.setPending("alpha beta gamma")
+
+		state.setPending("alpha beta delta")
+
+		#expect(state.stableDisplayText == "alpha beta delta")
+	}
+
+	@Test func clearingAlwaysReachesTheDisplay() {
+		let state = LiveTranscriptionState()
+		state.setPending("alpha beta gamma")
+
+		state.setPending("")
+
+		#expect(state.stableDisplayText == "")
+	}
+}
+
+/// The path a server-side engine uses: it already knows what it has committed,
+/// so nothing is buffered, but the display still moves on the same rule.
+@MainActor
+struct LiveTranscriptionRemoteIngestTests {
+	@Test func committedTextBecomesConfirmedAndTheDraftIsDisplayed() {
+		let state = LiveTranscriptionState()
+
+		state.ingest(committed: "the quick brown fox", draft: "jumps over")
+
+		#expect(state.confirmedText == "the quick brown fox")
+		#expect(state.stableDisplayText == "jumps over")
+		#expect(state.shouldShowLiveTranscriptionWindow)
+	}
+
+	@Test func anUnchangedCommitIsNotAnnouncedAgain() {
+		let state = LiveTranscriptionState()
+		var announced: [String] = []
+		state.onConfirmedTextChange = { announced.append($0) }
+
+		state.ingest(committed: "hello", draft: "there")
+		state.ingest(committed: "hello", draft: "there again")
+
+		#expect(announced == ["hello"])
+	}
+
+	@Test func aGrowingTranscriptIsAnnouncedInFull() {
+		let state = LiveTranscriptionState()
+		var announced: [String] = []
+		state.onConfirmedTextChange = { announced.append($0) }
+
+		state.ingest(committed: "hello", draft: "")
+		state.ingest(committed: "hello there", draft: "")
+
+		#expect(announced == ["hello", "hello there"])
+	}
+}

--- a/WhisperaUnitTests/LocalLLMExecutorTests.swift
+++ b/WhisperaUnitTests/LocalLLMExecutorTests.swift
@@ -76,6 +76,218 @@ struct LocalLLMExecutorChatTests {
 	}
 }
 
+struct LLMTransportRetryPolicyTests {
+
+	@Test func retriesTransientTransportFailures() {
+		let transient: [URLError.Code] = [
+			.timedOut, .cannotConnectToHost, .cannotFindHost,
+			.dnsLookupFailed, .networkConnectionLost, .notConnectedToInternet,
+		]
+		for code in transient {
+			#expect(LLMTransportRetryPolicy.shouldRetry(code), "\(code) should be retryable")
+		}
+	}
+
+	@Test func neverRetriesRealAnswersOrCancellation() {
+		let notTransient: [URLError.Code] = [
+			.cancelled, .badURL, .badServerResponse,
+			.userAuthenticationRequired, .secureConnectionFailed,
+			.appTransportSecurityRequiresSecureConnection,
+		]
+		for code in notTransient {
+			#expect(!LLMTransportRetryPolicy.shouldRetry(code), "\(code) must not be retryable")
+		}
+	}
+
+	@Test func shortReasonsStayHUDSized() {
+		#expect(LLMTransportRetryPolicy.shortReason(for: URLError(.timedOut)) == "the request timed out")
+		#expect(
+			LLMTransportRetryPolicy.shortReason(for: URLError(.cannotConnectToHost))
+				== "the connection was refused")
+		#expect(
+			LLMTransportRetryPolicy.shortReason(for: URLError(.cannotFindHost)) == "the host was not found")
+		#expect(
+			LLMTransportRetryPolicy.shortReason(for: URLError(.networkConnectionLost))
+				== "the connection was lost")
+		#expect(
+			LLMTransportRetryPolicy.shortReason(for: URLError(.notConnectedToInternet))
+				== "the network is offline")
+	}
+
+	@Test func unreachableMessageNamesServerReasonAndRetry() {
+		let retried = LocalLLMError.unreachable(
+			url: "http://192.168.50.190:8317/v1", reason: "the request timed out", retried: true)
+		#expect(
+			retried.errorDescription
+				== "Couldn't reach the model server at http://192.168.50.190:8317/v1 — the request timed out. Retried once.")
+
+		let single = LocalLLMError.unreachable(
+			url: "http://192.168.50.190:8317/v1", reason: "the connection was lost", retried: false)
+		#expect(
+			single.errorDescription
+				== "Couldn't reach the model server at http://192.168.50.190:8317/v1 — the connection was lost.")
+	}
+
+	@Test func unavailableMessageIsAboutConfigurationOnly() {
+		#expect(
+			LocalLLMError.unavailable.errorDescription
+				== "No model server URL configured — set one in Settings or switch to BYOK.")
+	}
+}
+
+/// Thread-safe attempt counter for handlers that must behave differently per call.
+private final class AttemptCounter: @unchecked Sendable {
+	private let lock = NSLock()
+	private var count = 0
+
+	func next() -> Int {
+		lock.lock()
+		defer { lock.unlock() }
+		count += 1
+		return count
+	}
+
+	var value: Int {
+		lock.lock()
+		defer { lock.unlock() }
+		return count
+	}
+}
+
+struct LocalLLMExecutorRetryTests {
+
+	private func executor(mock: MockURLProtocol.Mock) -> LocalLLMExecutor {
+		LocalLLMExecutor(
+			session: mock.session,
+			serverURLProvider: { mock.baseURL.appendingPathComponent("v1") },
+			defaultModelProvider: { "test-model" },
+			apiKeyProvider: { nil },
+			retryDelayNanoseconds: 1_000_000)
+	}
+
+	@Test func transientFailureIsRetriedOnceAndSucceeds() async throws {
+		let attempts = AttemptCounter()
+		let mock = MockURLProtocol.makeResult { request in
+			guard attempts.next() > 1 else { return .failure(URLError(.cannotConnectToHost)) }
+			let response = HTTPURLResponse(
+				url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+			return .success((response, Data(#"{"choices":[{"message":{"content":"ok"}}]}"#.utf8)))
+		}
+		let result = try await executor(mock: mock).chat(
+			system: nil, prompt: "x", model: nil, maxTokens: nil)
+		#expect(result == "ok")
+		#expect(attempts.value == 2)
+	}
+
+	@Test func persistentTransientFailureThrowsUnreachableAfterTwoAttempts() async {
+		let attempts = AttemptCounter()
+		let mock = MockURLProtocol.makeResult { _ in
+			_ = attempts.next()
+			return .failure(URLError(.timedOut))
+		}
+		let exec = executor(mock: mock)
+		do {
+			_ = try await exec.chat(system: nil, prompt: "x", model: nil, maxTokens: nil)
+			Issue.record("expected LocalLLMError.unreachable")
+		} catch let error as LocalLLMError {
+			guard case .unreachable(_, let reason, let retried) = error else {
+				Issue.record("expected .unreachable, got \(error)")
+				return
+			}
+			#expect(reason == "the request timed out")
+			#expect(retried)
+			#expect(error.errorDescription?.hasSuffix("Retried once.") == true)
+		} catch {
+			Issue.record("unexpected error \(error)")
+		}
+		#expect(attempts.value == 2)
+	}
+
+	@Test func httpErrorIsNeverRetried() async {
+		let attempts = AttemptCounter()
+		let mock = MockURLProtocol.makeResult { request in
+			_ = attempts.next()
+			let response = HTTPURLResponse(
+				url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+			return .success((response, Data("boom".utf8)))
+		}
+		let exec = executor(mock: mock)
+		do {
+			_ = try await exec.chat(system: nil, prompt: "x", model: nil, maxTokens: nil)
+			Issue.record("expected LocalLLMError.http")
+		} catch let error as LocalLLMError {
+			guard case .http(let status, _) = error else {
+				Issue.record("expected .http, got \(error)")
+				return
+			}
+			#expect(status == 500)
+		} catch {
+			Issue.record("unexpected error \(error)")
+		}
+		#expect(attempts.value == 1)
+	}
+
+	@Test func nonTransientTransportFailureIsNotRetried() async {
+		let attempts = AttemptCounter()
+		let mock = MockURLProtocol.makeResult { _ in
+			_ = attempts.next()
+			return .failure(URLError(.badServerResponse))
+		}
+		let exec = executor(mock: mock)
+		do {
+			_ = try await exec.chat(system: nil, prompt: "x", model: nil, maxTokens: nil)
+			Issue.record("expected LocalLLMError.unreachable")
+		} catch let error as LocalLLMError {
+			guard case .unreachable(_, _, let retried) = error else {
+				Issue.record("expected .unreachable, got \(error)")
+				return
+			}
+			#expect(!retried)
+			#expect(error.errorDescription?.contains("Retried") == false)
+		} catch {
+			Issue.record("unexpected error \(error)")
+		}
+		#expect(attempts.value == 1)
+	}
+
+	@Test func unconfiguredServerThrowsUnavailableWithoutTouchingNetwork() async {
+		let attempts = AttemptCounter()
+		let mock = MockURLProtocol.makeResult { request in
+			_ = attempts.next()
+			let response = HTTPURLResponse(
+				url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+			return .success((response, Data()))
+		}
+		let exec = LocalLLMExecutor(
+			session: mock.session,
+			serverURLProvider: { nil },
+			defaultModelProvider: { "test-model" },
+			apiKeyProvider: { nil },
+			retryDelayNanoseconds: 1_000_000)
+		do {
+			_ = try await exec.chat(system: nil, prompt: "x", model: nil, maxTokens: nil)
+			Issue.record("expected LocalLLMError.unavailable")
+		} catch let error as LocalLLMError {
+			guard case .unavailable = error else {
+				Issue.record("expected .unavailable, got \(error)")
+				return
+			}
+		} catch {
+			Issue.record("unexpected error \(error)")
+		}
+		#expect(attempts.value == 0)
+	}
+
+	@Test func requestCarriesDeliberateTimeout() async throws {
+		let mock = MockURLProtocol.make(
+			status: 200, json: #"{"choices":[{"message":{"content":"hi"}}]}"#)
+		_ = try await executor(mock: mock).chat(system: nil, prompt: "x", model: nil, maxTokens: nil)
+		#expect(
+			MockURLProtocol.lastRequest(host: mock.host)?.timeoutInterval
+				== LocalLLMExecutor.requestTimeout)
+	}
+}
+
 extension URLRequest {
 	/// URLProtocol delivers the body via a stream; read it back for assertions.
 	fileprivate func httpBodyStreamData() -> Data? {

--- a/WhisperaUnitTests/MockURLProtocol.swift
+++ b/WhisperaUnitTests/MockURLProtocol.swift
@@ -5,7 +5,8 @@ import Foundation
 /// tests running in parallel never clobber each other's responses.
 final class MockURLProtocol: URLProtocol {
 	private static let lock = NSLock()
-	nonisolated(unsafe) private static var handlers: [String: @Sendable (URLRequest) -> (HTTPURLResponse, Data)] = [:]
+	nonisolated(unsafe) private static var handlers:
+		[String: @Sendable (URLRequest) -> Result<(HTTPURLResponse, Data), Error>] = [:]
 	nonisolated(unsafe) private static var lastRequests: [String: URLRequest] = [:]
 
 	struct Mock {
@@ -15,6 +16,14 @@ final class MockURLProtocol: URLProtocol {
 	}
 
 	static func make(handler: @escaping @Sendable (URLRequest) -> (HTTPURLResponse, Data)) -> Mock {
+		makeResult { .success(handler($0)) }
+	}
+
+	/// Variant whose handler may fail the request with a transport error
+	/// (URLError), for exercising retry paths.
+	static func makeResult(
+		handler: @escaping @Sendable (URLRequest) -> Result<(HTTPURLResponse, Data), Error>
+	) -> Mock {
 		let host = "m\(UUID().uuidString.replacingOccurrences(of: "-", with: "")).test"
 		lock.lock()
 		handlers[host] = handler
@@ -55,10 +64,14 @@ final class MockURLProtocol: URLProtocol {
 			client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
 			return
 		}
-		let (response, data) = handler(request)
-		client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-		client?.urlProtocol(self, didLoad: data)
-		client?.urlProtocolDidFinishLoading(self)
+		switch handler(request) {
+		case .success(let (response, data)):
+			client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+			client?.urlProtocol(self, didLoad: data)
+			client?.urlProtocolDidFinishLoading(self)
+		case .failure(let error):
+			client?.urlProtocol(self, didFailWithError: error)
+		}
 	}
 
 	override func stopLoading() {}

--- a/WhisperaUnitTests/PillAnchorTests.swift
+++ b/WhisperaUnitTests/PillAnchorTests.swift
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import AppKit
+import Testing
+
+@testable import Whispera
+
+/// Pins the geometry the live-words HUD uses to sit above the listening pill —
+/// see WHI-58. Pure functions of screen + pill geometry, so the coordination
+/// rule is covered without standing up any NSWindow.
+struct PillAnchorTests {
+	private let screen = NSRect(x: 0, y: 0, width: 1440, height: 900)
+
+	@Test func sitsDirectlyAboveThePillWithTheDesignLanguageGap() {
+		let pill = NSRect(x: 600, y: 80, width: 200, height: 50)
+		let size = CGSize(width: 240, height: 36)
+
+		let frame = PillAnchor.frame(for: size, screenFrame: screen, pillFrame: pill)
+
+		#expect(frame.origin.y == pill.maxY + PillAnchor.gap)
+		#expect(PillAnchor.gap == PillMetrics.controlsGap, "one shared gap, not a second invented number")
+	}
+
+	@Test func neverOverlapsThePill() {
+		let pill = NSRect(x: 600, y: 80, width: 200, height: 50)
+		let size = CGSize(width: 240, height: 200)  // a tall, many-line surface
+
+		let frame = PillAnchor.frame(for: size, screenFrame: screen, pillFrame: pill)
+
+		#expect(frame.minY >= pill.maxY, "the surface's own bottom edge must never dip into the pill")
+	}
+
+	@Test func isHorizontallyCenteredOnThePill() {
+		let pill = NSRect(x: 600, y: 80, width: 200, height: 50)
+		let size = CGSize(width: 240, height: 36)
+
+		let frame = PillAnchor.frame(for: size, screenFrame: screen, pillFrame: pill)
+
+		#expect(frame.midX == pill.midX)
+	}
+
+	/// The requirement is that words "grow upward": the pill's bottom-adjacent
+	/// edge is the anchor, so taller content must extend the frame's top
+	/// without moving its bottom.
+	@Test func growingContentExtendsUpwardNotDownward() {
+		let pill = NSRect(x: 600, y: 80, width: 200, height: 50)
+		let shortFrame = PillAnchor.frame(
+			for: CGSize(width: 240, height: 36), screenFrame: screen, pillFrame: pill)
+		let tallFrame = PillAnchor.frame(
+			for: CGSize(width: 240, height: 120), screenFrame: screen, pillFrame: pill)
+
+		#expect(shortFrame.origin.y == tallFrame.origin.y, "the bottom edge stays put as height grows")
+		#expect(tallFrame.maxY > shortFrame.maxY, "growth reads as extending upward")
+	}
+
+	@Test func followsThePillHorizontallyWhenItMoves() {
+		let size = CGSize(width: 240, height: 36)
+		let leftPill = NSRect(x: 100, y: 80, width: 200, height: 50)
+		let rightPill = NSRect(x: 900, y: 80, width: 200, height: 50)
+
+		let leftFrame = PillAnchor.frame(for: size, screenFrame: screen, pillFrame: leftPill)
+		let rightFrame = PillAnchor.frame(for: size, screenFrame: screen, pillFrame: rightPill)
+
+		#expect(leftFrame.midX == leftPill.midX)
+		#expect(rightFrame.midX == rightPill.midX)
+		#expect(leftFrame.origin.x != rightFrame.origin.x)
+	}
+
+	/// With no pill on screen — a transient racing the pill's own visibility
+	/// notification, or shown before the pill ever appears — the surface still
+	/// lands at the pill's own bottom-center resting spot, never at some other
+	/// improvised location.
+	@Test func fallsBackToThePillsRestingSpotWithNoPillOnScreen() {
+		let size = CGSize(width: 240, height: 36)
+
+		let frame = PillAnchor.frame(for: size, screenFrame: screen, pillFrame: nil)
+
+		let expectedY = screen.origin.y + screen.height * PillMetrics.bottomAnchorFraction
+		let expectedX = screen.origin.x + (screen.width - size.width) / 2
+		#expect(frame.origin.y == expectedY)
+		#expect(frame.origin.x == expectedX)
+	}
+}
+
+/// `PillAnchorProvider` is a one-writer, many-reader broadcast of the pill's
+/// frame. `ListeningWindow` is the only writer in the app; this pins the
+/// contract every reader (today, `LiveTranscriptionWindow`) depends on.
+@MainActor
+struct PillAnchorProviderTests {
+	@Test func startsWithNoPillPublished() {
+		let provider = PillAnchorProvider()
+
+		#expect(provider.pillFrame == nil)
+	}
+
+	@Test func publishesTheFrameItIsGiven() {
+		let provider = PillAnchorProvider()
+		let frame = NSRect(x: 10, y: 20, width: 30, height: 40)
+
+		provider.publish(frame)
+
+		#expect(provider.pillFrame == frame)
+	}
+
+	@Test func publishingNilClearsIt() {
+		let provider = PillAnchorProvider()
+		provider.publish(NSRect(x: 10, y: 20, width: 30, height: 40))
+
+		provider.publish(nil)
+
+		#expect(provider.pillFrame == nil)
+	}
+}

--- a/WhisperaUnitTests/PillAnchorTests.swift
+++ b/WhisperaUnitTests/PillAnchorTests.swift
@@ -22,6 +22,22 @@ struct PillAnchorTests {
 		#expect(PillAnchor.gap == PillMetrics.controlsGap, "one shared gap, not a second invented number")
 	}
 
+	/// The concrete numbers from the WHI-58 QA follow-up: for a pill whose top
+	/// edge is at y=130, a 36pt capsule must sit with its bottom at exactly
+	/// 130 + 8 — the design language's small spacing step — and dead-centered,
+	/// so the two surfaces read as one attached stack, never overlapping.
+	@Test func theGapIsTheDesignLanguageSmallSpacingStep() {
+		#expect(PillAnchor.gap == 8)
+
+		let pill = NSRect(x: 620, y: 86, width: 280, height: 44)
+		let frame = PillAnchor.frame(
+			for: CGSize(width: 216, height: 36), screenFrame: screen, pillFrame: pill)
+
+		#expect(frame.minY == 138)
+		#expect(frame.midX == 760)
+		#expect(frame.minY > pill.maxY, "a visible gap, not touching or overlapping")
+	}
+
 	@Test func neverOverlapsThePill() {
 		let pill = NSRect(x: 600, y: 80, width: 200, height: 50)
 		let size = CGSize(width: 240, height: 200)  // a tall, many-line surface

--- a/WhisperaUnitTests/RecipeMatcherTests.swift
+++ b/WhisperaUnitTests/RecipeMatcherTests.swift
@@ -162,7 +162,7 @@ struct DictationCoordinatorTests {
 		defer { try? FileManager.default.removeItem(at: url) }
 		let coordinator = DictationCoordinator(store: store) { _, _ in throw Boom() }
 		_ = await coordinator.process("make professional hi")
-		#expect(coordinator.overlayError == "kaboom")
+		#expect(coordinator.overlayError == "kaboom Pasted your words unchanged.")
 	}
 
 	// MARK: - Default post-action command (WHI-49)

--- a/WhisperaUnitTests/RecordingWindowPolicyTests.swift
+++ b/WhisperaUnitTests/RecordingWindowPolicyTests.swift
@@ -5,29 +5,23 @@ import Testing
 
 struct RecordingWindowPolicyTests {
 
+	// The listening pill is the persistent home for recording/transcribing
+	// status in both modes now — see WHI-58's presentation pass — so its
+	// visibility depends only on whether a session is active, not on mode.
 	@Test(arguments: [AudioState.initializing, .recording, .transcribing])
-	func liveModeNeverShowsLegacyListeningWindow(state: AudioState) {
-		#expect(
-			!RecordingWindowPolicy.shouldShowListeningWindow(state: state, mode: .liveTranscription),
-			"Live mode renders its own listening surface inside the live transcription window; showing the legacy window too duplicates it"
-		)
+	func anyActiveStateShowsTheListeningPill(state: AudioState) {
+		#expect(RecordingWindowPolicy.shouldShowListeningWindow(state: state))
 	}
 
-	@Test(arguments: [AudioState.initializing, .recording, .transcribing])
-	func textModeShowsLegacyListeningWindow(state: AudioState) {
-		#expect(RecordingWindowPolicy.shouldShowListeningWindow(state: state, mode: .text))
-	}
-
-	@Test(arguments: [RecordingMode.text, .liveTranscription])
-	func idleHidesLegacyListeningWindow(mode: RecordingMode) {
-		#expect(!RecordingWindowPolicy.shouldShowListeningWindow(state: .idle, mode: mode))
+	@Test func idleHidesTheListeningPill() {
+		#expect(!RecordingWindowPolicy.shouldShowListeningWindow(state: .idle))
 	}
 
 	@Test func textModeNeverShowsLiveTranscriptionWindow() {
 		#expect(
 			!RecordingWindowPolicy.shouldShowLiveTranscriptionWindow(
 				mode: .text, transcriberWantsWindow: true),
-			"Text mode renders the legacy listening window; the live window showing too duplicates it"
+			"Text mode has no live words to show; only live mode overlays the pill with them"
 		)
 	}
 

--- a/WhisperaUnitTests/StreamingTranscriberDirectModelsTests.swift
+++ b/WhisperaUnitTests/StreamingTranscriberDirectModelsTests.swift
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import Testing
+
+@testable import Whispera
+
+/// Direct mode has no backend registry to ask what it can run, so `models()`
+/// asks the engine itself via its OpenAI-compatible `/models` endpoint. See
+/// WHI-58, PASTE-MODEL-RESULT.md.
+@MainActor
+struct StreamingTranscriberDirectModelsTests {
+	private func directTranscriber(mock: MockURLProtocol.Mock) -> StreamingTranscriber {
+		StreamingTranscriber(
+			baseURLProvider: { mock.baseURL },
+			directProvider: { true },
+			urlSession: mock.session)
+	}
+
+	@Test func onlyAutomaticSpeechRecognitionModelsAreReturned() async throws {
+		let mock = MockURLProtocol.make(
+			status: 200,
+			json: #"""
+				{"data": [
+					{"id": "Systran/faster-distil-whisper-large-v3", "task": "automatic-speech-recognition"},
+					{"id": "some-embedding-model", "task": "embeddings"},
+					{"id": "Systran/faster-whisper-small", "task": "automatic-speech-recognition"}
+				]}
+				"""#)
+		let transcriber = directTranscriber(mock: mock)
+
+		let models = try await transcriber.models()
+
+		#expect(models.map(\.id) == ["Systran/faster-distil-whisper-large-v3", "Systran/faster-whisper-small"])
+	}
+
+	@Test func requestGoesToTheEnginesModelsEndpoint() async throws {
+		let mock = MockURLProtocol.make(
+			status: 200,
+			json: #"{"data": [{"id": "m", "task": "automatic-speech-recognition"}]}"#)
+		let transcriber = directTranscriber(mock: mock)
+
+		_ = try await transcriber.models()
+
+		let request = MockURLProtocol.lastRequest(host: mock.host)
+		#expect(request?.url?.path == "/models")
+	}
+
+	@Test func anUnreachableEngineFailsLoudlyRatherThanReturningNoModels() async {
+		let mock = MockURLProtocol.make(status: 500, json: "")
+		let transcriber = directTranscriber(mock: mock)
+
+		await #expect(throws: StreamingTranscriberError.self) {
+			_ = try await transcriber.models()
+		}
+	}
+
+	@Test func unparsableJSONIsReportedAsUnreachableRatherThanCrashing() async {
+		let mock = MockURLProtocol.make(status: 200, json: "not json")
+		let transcriber = directTranscriber(mock: mock)
+
+		await #expect(throws: StreamingTranscriberError.self) {
+			_ = try await transcriber.models()
+		}
+	}
+
+	/// An engine that answers but serves nothing transcription can use (an
+	/// LLM-only host, say) is a distinct failure from one that cannot be
+	/// reached at all — worth its own message rather than an empty list.
+	@Test func anEngineWithNoASRModelsThrowsRatherThanReturningAnEmptyList() async {
+		let mock = MockURLProtocol.make(
+			status: 200,
+			json: #"{"data": [{"id": "chat-model", "task": "text-generation"}]}"#)
+		let transcriber = directTranscriber(mock: mock)
+
+		await #expect(throws: StreamingTranscriberError.self) {
+			_ = try await transcriber.models()
+		}
+	}
+}

--- a/WhisperaUnitTests/TranscriptionFailureTests.swift
+++ b/WhisperaUnitTests/TranscriptionFailureTests.swift
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Testing
+import WhisperaDictation
+
+@testable import Whispera
+
+/// What a user is told when a dictation fails. The rule these pin is that the
+/// message names the thing that failed and what to check — a raw
+/// "InternalServerError" is the failure mode, not the message.
+@MainActor
+struct TranscriptionFailureMessageTests {
+	private func message(for error: Error) -> String {
+		StreamingTranscriber.failure(for: error, destination: "speaches-lan").message
+	}
+
+	@Test func everyFailureNamesWhatFailed() {
+		let errors: [DictationError] = [
+			.unauthorized,
+			.credentialUnavailable("keychain locked"),
+			.connectionFailed("The Internet connection appears to be offline."),
+			.closedUnexpectedly(code: 1006, reason: ""),
+			.protocolViolation("not JSON"),
+			.audioUnavailable("no input device"),
+			.server(message: "InternalServerError: Internal Server Error", code: nil),
+		]
+		for error in errors {
+			let message = self.message(for: error)
+			#expect(message.hasSuffix("."), "\(error) produced a fragment: \(message)")
+			#expect(message.count > 40, "\(error) produced nothing actionable: \(message)")
+		}
+	}
+
+	/// The exact failure that made this work necessary: the engine's own words are
+	/// not a message a user can do anything with.
+	@Test func aServerErrorDoesNotEchoTheEnginesOwnWords() {
+		let message = self.message(
+			for: DictationError.server(message: "InternalServerError: Internal Server Error", code: nil)
+		)
+		#expect(!message.contains("InternalServerError"))
+		#expect(message.contains("speaches-lan"))
+	}
+
+	@Test func anUnreachableServerSaysWhereToLook() {
+		let message = self.message(for: DictationError.connectionFailed("offline"))
+		#expect(message.contains("speaches-lan"))
+		#expect(message.lowercased().contains("network"))
+	}
+
+	@Test func aRejectedCredentialPointsAtAccountSettings() {
+		#expect(message(for: DictationError.unauthorized).contains("Account settings"))
+		#expect(message(for: DictationError.credentialUnavailable("x")).contains("Account settings"))
+	}
+
+	@Test func aMissingMicrophonePointsAtPrivacySettings() {
+		#expect(message(for: DictationError.audioUnavailable("denied")).contains("Microphone"))
+	}
+
+	/// The engine's own capture timeout already reads well; it must survive the
+	/// mapping rather than be flattened into the generic fallback.
+	@Test func anEngineErrorKeepsItsOwnDescription() {
+		let message = self.message(for: StreamingTranscriberError.captureTimedOut)
+		#expect(message == StreamingTranscriberError.captureTimedOut.errorDescription)
+	}
+
+	@Test func anUnknownErrorStillSaysWhereToLook() {
+		struct Boom: Error {}
+		#expect(message(for: Boom()).contains("Transcription"))
+	}
+}
+
+/// Which engines need a server, which is what decides whether the URL fields and
+/// the live-transcription default apply.
+struct ServerEngineTests {
+	@Test func onlySocketEnginesStreamFromAServer() {
+		#expect(TranscriptionEngine.whisperaStreaming.streamsFromAServer)
+		#expect(TranscriptionEngine.realtimeDirect.streamsFromAServer)
+		#expect(!TranscriptionEngine.whisperKit.streamsFromAServer)
+		#expect(!TranscriptionEngine.whisperViaBYOK.streamsFromAServer)
+	}
+
+	/// Every engine that streams from a server is one the streaming conformer
+	/// handles, so the two never drift apart.
+	@MainActor
+	@Test func everyServerEngineResolvesToTheStreamingConformer() {
+		for engine in TranscriptionEngine.allCases where engine.streamsFromAServer {
+			#expect(TranscriptionRouter.transcriber(for: engine) is StreamingTranscriber)
+		}
+	}
+}

--- a/WhisperaUnitTests/TranscriptionFailureTests.swift
+++ b/WhisperaUnitTests/TranscriptionFailureTests.swift
@@ -78,6 +78,10 @@ struct ServerEngineTests {
 		#expect(TranscriptionEngine.realtimeDirect.streamsFromAServer)
 		#expect(!TranscriptionEngine.whisperKit.streamsFromAServer)
 		#expect(!TranscriptionEngine.whisperViaBYOK.streamsFromAServer)
+		// `auto` resolves to `AutoTranscriber`, not to `StreamingTranscriber`
+		// itself, even on a run that ends up streaming — see
+		// `everyServerEngineResolvesToTheStreamingConformer` below.
+		#expect(!TranscriptionEngine.auto.streamsFromAServer)
 	}
 
 	/// Every engine that streams from a server is one the streaming conformer

--- a/WhisperaUnitTests/TranscriptionRouterTests.swift
+++ b/WhisperaUnitTests/TranscriptionRouterTests.swift
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import Testing
+
+@testable import Whispera
+
+/// The router is the only place engine identity is switched on, so this is the
+/// one place that has to stay exhaustive. See WHI-58.
+@MainActor
+struct TranscriptionRouterTests {
+	@Test func everyEngineResolvesToAConformer() {
+		for engine in TranscriptionEngine.allCases {
+			let transcriber = TranscriptionRouter.transcriber(for: engine)
+			#expect(transcriber.engine == engine)
+		}
+	}
+
+	@Test func theSelectedEngineIsTheOneHandedBack() {
+		let router = TranscriptionRouter(engineProvider: { .whisperaStreaming })
+
+		#expect(router.selected == .whisperaStreaming)
+		#expect(router.active.engine == .whisperaStreaming)
+	}
+
+	@Test func whisperKitResolvesToTheSharedTranscriber() {
+		let transcriber = TranscriptionRouter.transcriber(for: .whisperKit)
+
+		#expect(transcriber === WhisperKitTranscriber.shared)
+	}
+
+	/// A conformer is reused rather than rebuilt: a streaming engine holds a
+	/// live socket and a local one holds a loaded model.
+	@Test func resolvingTwiceReturnsTheSameInstance() {
+		#expect(
+			TranscriptionRouter.transcriber(for: .whisperaStreaming)
+				=== TranscriptionRouter.transcriber(for: .whisperaStreaming))
+		#expect(
+			TranscriptionRouter.transcriber(for: .whisperViaBYOK)
+				=== TranscriptionRouter.transcriber(for: .whisperViaBYOK))
+	}
+
+	@Test func onlyTheOnDeviceEngineManagesModels() {
+		#expect(
+			TranscriptionRouter.transcriber(for: .whisperKit).capabilities.contains(.managedModels))
+		#expect(
+			!TranscriptionRouter.transcriber(for: .whisperaStreaming).capabilities
+				.contains(.managedModels))
+		#expect(
+			!TranscriptionRouter.transcriber(for: .whisperViaBYOK).capabilities
+				.contains(.managedModels))
+	}
+
+	@Test func uploadOnlyEnginesDoNotClaimStreaming() {
+		#expect(TranscriptionRouter.transcriber(for: .whisperKit).capabilities.contains(.streaming))
+		#expect(
+			TranscriptionRouter.transcriber(for: .whisperaStreaming).capabilities.contains(.streaming))
+		#expect(
+			!TranscriptionRouter.transcriber(for: .whisperViaBYOK).capabilities.contains(.streaming))
+	}
+
+	/// An engine an older build wrote but this one no longer ships must degrade
+	/// on-device rather than trap, the same rule `llmMode` follows.
+	@Test func anUnknownStoredEngineFallsBackOnDevice() {
+		#expect(TranscriptionEngine(rawValue: "subscriptionWhisper") == nil)
+		#expect(TranscriptionEngine(rawValue: "") == nil)
+		#expect(TranscriptionEngine(rawValue: "whisperKit") == .whisperKit)
+	}
+}
+
+@MainActor
+struct RemoteBatchTranscriberTests {
+	@Test func translationIsRefusedRatherThanSilentlyDropped() async {
+		let transcriber = RemoteBatchTranscriber()
+
+		await #expect(throws: TranscriptionEngineError.self) {
+			try await transcriber.transcribe(
+				samples: [0, 0, 0], options: TranscriptionOptions(mode: .translate))
+		}
+	}
+
+	@Test func samplesAreWrappedInAReadableWavContainer() {
+		let samples: [Float] = [0, 0.5, -0.5, 1.0, -1.0]
+
+		let wav = RemoteBatchTranscriber.wav(from: samples, sampleRate: 16000)
+
+		#expect(wav.count == 44 + samples.count * 2)
+		#expect(String(decoding: wav[0..<4], as: UTF8.self) == "RIFF")
+		#expect(String(decoding: wav[8..<12], as: UTF8.self) == "WAVE")
+		#expect(String(decoding: wav[12..<16], as: UTF8.self) == "fmt ")
+		#expect(String(decoding: wav[36..<40], as: UTF8.self) == "data")
+
+		let sampleRate = wav[24..<28].withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+		#expect(UInt32(littleEndian: sampleRate) == 16000)
+
+		let dataBytes = wav[40..<44].withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+		#expect(UInt32(littleEndian: dataBytes) == UInt32(samples.count * 2))
+	}
+
+	@Test func fullScaleSamplesClipRatherThanWrap() {
+		let wav = RemoteBatchTranscriber.wav(from: [1.0, -1.0, 2.0], sampleRate: 16000)
+		let pcm = wav[44...]
+
+		let first = pcm[pcm.startIndex..<pcm.startIndex + 2].withUnsafeBytes {
+			Int16(littleEndian: $0.loadUnaligned(as: Int16.self))
+		}
+		let third = pcm[pcm.startIndex + 4..<pcm.startIndex + 6].withUnsafeBytes {
+			Int16(littleEndian: $0.loadUnaligned(as: Int16.self))
+		}
+
+		#expect(first == Int16.max)
+		#expect(third == Int16.max)
+	}
+}

--- a/WhisperaUnitTests/TranscriptionRouterTests.swift
+++ b/WhisperaUnitTests/TranscriptionRouterTests.swift
@@ -39,6 +39,23 @@ struct TranscriptionRouterTests {
 		#expect(
 			TranscriptionRouter.transcriber(for: .whisperViaBYOK)
 				=== TranscriptionRouter.transcriber(for: .whisperViaBYOK))
+		#expect(
+			TranscriptionRouter.transcriber(for: .auto) === TranscriptionRouter.transcriber(for: .auto))
+	}
+
+	@Test func autoResolvesToTheAutoTranscriber() {
+		#expect(TranscriptionRouter.transcriber(for: .auto) === AutoTranscriber.shared)
+	}
+
+	/// An absent or unrecognised stored value degrades to `auto` rather than
+	/// trapping — a fresh install and a build that shipped an engine this one no
+	/// longer does land on the same default. `auto` degrades further, to
+	/// on-device, whenever nothing is configured, so the fallback is honest
+	/// either way.
+	@Test func anAbsentOrUnknownStoredEngineFallsBackToAuto() {
+		#expect((TranscriptionEngine(rawValue: "") ?? .auto) == .auto)
+		#expect((TranscriptionEngine(rawValue: "subscriptionWhisper") ?? .auto) == .auto)
+		#expect((TranscriptionEngine(rawValue: "whisperKit") ?? .auto) == .whisperKit)
 	}
 
 	@Test func onlyTheOnDeviceEngineManagesModels() {

--- a/WhisperaUnitTests/TranscriptionServerURLMigrationTests.swift
+++ b/WhisperaUnitTests/TranscriptionServerURLMigrationTests.swift
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import Testing
+
+@testable import Whispera
+
+/// The one-time split of the shared transcription-server URL into per-mode
+/// keys. Each test gets its own defaults suite: these run in parallel and the
+/// host app's own @AppStorage bindings watch the standard suite.
+struct TranscriptionServerURLMigrationTests {
+	private static func isolatedDefaults() -> UserDefaults {
+		UserDefaults(suiteName: "TranscriptionServerURLMigrationTests-\(UUID().uuidString)")!
+	}
+
+	@Test func legacyURLForTheDirectEngineLandsInTheDirectKey() {
+		let defaults = Self.isolatedDefaults()
+		defaults.set("http://192.168.50.140:8000/v1", forKey: TranscriptionServerURLMigration.legacyKey)
+		defaults.set(
+			TranscriptionEngine.realtimeDirect.rawValue,
+			forKey: WhisperaSettings.transcriptionEngineKey)
+
+		TranscriptionServerURLMigration.migrateIfNeeded(in: defaults)
+
+		#expect(
+			defaults.string(forKey: WhisperaSettings.transcriptionDirectURLKey)
+				== "http://192.168.50.140:8000/v1")
+		#expect(defaults.string(forKey: WhisperaSettings.transcriptionBackendURLKey) == nil)
+	}
+
+	@Test func legacyURLForABackendEngineLandsInTheBackendKey() {
+		let defaults = Self.isolatedDefaults()
+		defaults.set("http://127.0.0.1:3000", forKey: TranscriptionServerURLMigration.legacyKey)
+		defaults.set(
+			TranscriptionEngine.whisperaStreaming.rawValue,
+			forKey: WhisperaSettings.transcriptionEngineKey)
+
+		TranscriptionServerURLMigration.migrateIfNeeded(in: defaults)
+
+		#expect(
+			defaults.string(forKey: WhisperaSettings.transcriptionBackendURLKey)
+				== "http://127.0.0.1:3000")
+		#expect(defaults.string(forKey: WhisperaSettings.transcriptionDirectURLKey) == nil)
+	}
+
+	/// No stored engine reads as `auto`, which streams through the backend, so
+	/// the legacy URL belongs to the backend key.
+	@Test func absentEngineTreatsTheLegacyURLAsTheBackends() {
+		let defaults = Self.isolatedDefaults()
+		defaults.set("http://127.0.0.1:3000", forKey: TranscriptionServerURLMigration.legacyKey)
+
+		TranscriptionServerURLMigration.migrateIfNeeded(in: defaults)
+
+		#expect(
+			defaults.string(forKey: WhisperaSettings.transcriptionBackendURLKey)
+				== "http://127.0.0.1:3000")
+	}
+
+	/// Runs once: a user who later clears the new key must not have the legacy
+	/// value resurrected behind their back.
+	@Test func migrationDoesNotRunTwice() {
+		let defaults = Self.isolatedDefaults()
+		defaults.set("http://127.0.0.1:3000", forKey: TranscriptionServerURLMigration.legacyKey)
+
+		TranscriptionServerURLMigration.migrateIfNeeded(in: defaults)
+		defaults.removeObject(forKey: WhisperaSettings.transcriptionBackendURLKey)
+		TranscriptionServerURLMigration.migrateIfNeeded(in: defaults)
+
+		#expect(defaults.string(forKey: WhisperaSettings.transcriptionBackendURLKey) == nil)
+	}
+
+	@Test func migrationNeverOverwritesAValueAlreadyInTheNewKey() {
+		let defaults = Self.isolatedDefaults()
+		defaults.set("http://old.example:3000", forKey: TranscriptionServerURLMigration.legacyKey)
+		defaults.set(
+			"http://new.example:3000", forKey: WhisperaSettings.transcriptionBackendURLKey)
+
+		TranscriptionServerURLMigration.migrateIfNeeded(in: defaults)
+
+		#expect(
+			defaults.string(forKey: WhisperaSettings.transcriptionBackendURLKey)
+				== "http://new.example:3000")
+	}
+
+	@Test func emptyLegacyValueMigratesNothingButStillMarksDone() {
+		let defaults = Self.isolatedDefaults()
+
+		TranscriptionServerURLMigration.migrateIfNeeded(in: defaults)
+
+		#expect(defaults.bool(forKey: TranscriptionServerURLMigration.migratedFlagKey))
+		#expect(defaults.string(forKey: WhisperaSettings.transcriptionBackendURLKey) == nil)
+		#expect(defaults.string(forKey: WhisperaSettings.transcriptionDirectURLKey) == nil)
+	}
+
+	/// The Settings server list explains granularity in plain words; the raw
+	/// protocol terms must never leak into the UI.
+	@Test func granularityWordingStaysInPlainWords() {
+		#expect(StreamingGranularity.nativeDelta.plainWords == "word-by-word")
+		#expect(StreamingGranularity.synthesizedDelta.plainWords == "near-live")
+		#expect(StreamingGranularity.utterance.plainWords == "at the end")
+	}
+}

--- a/WhisperaUnitTests/TwoPassFinalizerTests.swift
+++ b/WhisperaUnitTests/TwoPassFinalizerTests.swift
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025-2026 Ismatulla Mansurov
+
+import Foundation
+import Testing
+
+@testable import Whispera
+
+/// The pure halves of the two-pass finalizer: the PCM16 → Float32 downsample
+/// the second pass feeds WhisperKit, the mode table, and the fallback policy
+/// that decides whether the polished text or the streaming draft is pasted.
+/// The wiring around them lives in `StreamingTranscriber.finalizeDictation`.
+
+private func pcm16Data(_ samples: [Int16]) -> Data {
+	var data = Data(capacity: samples.count * 2)
+	for sample in samples {
+		withUnsafeBytes(of: sample.littleEndian) { data.append(contentsOf: $0) }
+	}
+	return data
+}
+
+struct PCM16ResamplerTests {
+	@Test func emptyDataProducesNoSamples() {
+		#expect(
+			PCM16Resampler.float32Samples(fromPCM16LittleEndian: Data(), sourceHz: 24000, targetHz: 16000)
+				.isEmpty)
+	}
+
+	@Test func aTrailingOddByteIsDropped() {
+		var data = pcm16Data([1000])
+		data.append(0x7F)
+		let samples = PCM16Resampler.float32Samples(
+			fromPCM16LittleEndian: data, sourceHz: 16000, targetHz: 16000)
+		#expect(samples.count == 1)
+	}
+
+	@Test func sameRatePassthroughConvertsKnownValues() {
+		let samples = PCM16Resampler.float32Samples(
+			fromPCM16LittleEndian: pcm16Data([0, 16384, -16384, Int16.max, Int16.min]),
+			sourceHz: 16000, targetHz: 16000)
+		#expect(samples.count == 5)
+		#expect(samples[0] == 0)
+		#expect(abs(samples[1] - 0.5) < 0.001)
+		#expect(abs(samples[2] + 0.5) < 0.001)
+		// Divided by 32768, so the extremes stay inside [-1, 1) exactly.
+		#expect(abs(samples[3] - 32767.0 / 32768.0) < 0.0001)
+		#expect(samples[4] == -1.0)
+	}
+
+	@Test func downsampleKeepsTwoThirdsOfTheSamples() {
+		let data = pcm16Data([Int16](repeating: 100, count: 2400))
+		let samples = PCM16Resampler.float32Samples(
+			fromPCM16LittleEndian: data, sourceHz: 24000, targetHz: 16000)
+		#expect(samples.count == 1600)
+	}
+
+	@Test func downsamplePreservesADCSignal() {
+		let data = pcm16Data([Int16](repeating: 16384, count: 300))
+		let samples = PCM16Resampler.float32Samples(
+			fromPCM16LittleEndian: data, sourceHz: 24000, targetHz: 16000)
+		#expect(samples.allSatisfy { abs($0 - 0.5) < 0.001 })
+	}
+
+	@Test func downsampleInterpolatesLinearlyBetweenNeighbours() {
+		// A ramp 0, 3000, 6000, ... sampled at 1.5x spacing must land halfway
+		// between neighbours on the odd output indices: positions 0, 1.5, 3, 4.5.
+		let ramp = (0..<8).map { Int16($0 * 3000) }
+		let samples = PCM16Resampler.float32Samples(
+			fromPCM16LittleEndian: pcm16Data(ramp), sourceHz: 24000, targetHz: 16000)
+		let expected: [Float] = [0, 4500, 9000, 13500, 18000].map { $0 / 32768.0 }
+		#expect(samples.count >= expected.count)
+		for (index, value) in expected.enumerated() {
+			#expect(abs(samples[index] - value) < 0.001)
+		}
+	}
+
+	@Test func aSingleSampleSurvivesWithoutInterpolationPartners() {
+		let samples = PCM16Resampler.float32Samples(
+			fromPCM16LittleEndian: pcm16Data([16384, 16384]), sourceHz: 24000, targetHz: 16000)
+		#expect(samples.count == 1)
+		#expect(abs(samples[0] - 0.5) < 0.001)
+	}
+
+	@Test func nonsenseRatesProduceNothingRatherThanTrapping() {
+		let data = pcm16Data([1, 2, 3])
+		#expect(
+			PCM16Resampler.float32Samples(fromPCM16LittleEndian: data, sourceHz: 0, targetHz: 16000)
+				.isEmpty)
+		#expect(
+			PCM16Resampler.float32Samples(fromPCM16LittleEndian: data, sourceHz: 24000, targetHz: 0)
+				.isEmpty)
+	}
+}
+
+struct TwoPassFinalizerModeTests {
+	@Test func unknownAndAbsentRawValuesReadAsOff() {
+		#expect(TwoPassFinalizerMode.from(nil) == .off)
+		#expect(TwoPassFinalizerMode.from("") == .off)
+		#expect(TwoPassFinalizerMode.from("cloud-gpu") == .off)
+	}
+
+	@Test func storedModesRoundTrip() {
+		#expect(TwoPassFinalizerMode.from("local") == .local)
+		#expect(TwoPassFinalizerMode.from("server") == .server)
+		#expect(TwoPassFinalizerMode.from("off") == .off)
+	}
+
+	@Test func onlyOffIsOff() {
+		#expect(!TwoPassFinalizerMode.off.isOn)
+		#expect(TwoPassFinalizerMode.local.isOn)
+		#expect(TwoPassFinalizerMode.server.isOn)
+	}
+
+	/// The deadlines are the contract the stop path's boundedness rests on.
+	@Test func deadlinesMatchTheDesign() {
+		#expect(TwoPassFinalizerMode.local.deadline == 10)
+		#expect(TwoPassFinalizerMode.server.deadline == 15)
+	}
+}
+
+struct TwoPassPolicyTests {
+	@Test func aFinalizedTranscriptWinsTrimmed() {
+		#expect(TwoPassPolicy.finalizedText(from: .finalized("  polished text ")) == "polished text")
+		#expect(TwoPassPolicy.fallbackReason(for: .finalized("polished text")) == nil)
+	}
+
+	@Test func anEmptyFinalizedTranscriptFallsBackToTheDraft() {
+		#expect(TwoPassPolicy.finalizedText(from: .finalized("   \n ")) == nil)
+		#expect(TwoPassPolicy.fallbackReason(for: .finalized("  ")) != nil)
+	}
+
+	@Test func everyNonFinalizedOutcomeFallsBackWithAReason() {
+		let outcomes: [TwoPassOutcome] = [
+			.failed("the upload failed"), .deadlineExpired, .superseded, .noAudio,
+		]
+		for outcome in outcomes {
+			#expect(TwoPassPolicy.finalizedText(from: outcome) == nil)
+			#expect(TwoPassPolicy.fallbackReason(for: outcome) != nil)
+		}
+	}
+
+	@Test func aFailureCarriesItsOwnReasonIntoTheLog() {
+		#expect(TwoPassPolicy.fallbackReason(for: .failed("engine said no")) == "engine said no")
+	}
+}
+
+struct TwoPassDeadlineTests {
+	@Test func aFastPassWinsTheRace() async {
+		let outcome = await TwoPassDeadline.race(seconds: 5) { .finalized("quick") }
+		#expect(outcome == .finalized("quick"))
+	}
+
+	@Test func aSlowPassLosesToTheDeadline() async {
+		let start = Date()
+		let outcome = await TwoPassDeadline.race(seconds: 0.05) {
+			try? await Task.sleep(nanoseconds: 5_000_000_000)
+			return .finalized("too late")
+		}
+		#expect(outcome == .deadlineExpired)
+		// The race must resolve at the deadline, not when the loser finishes.
+		#expect(Date().timeIntervalSince(start) < 2)
+	}
+
+	@Test func cancellingTheRaceResolvesSuperseded() async {
+		let race = Task {
+			await TwoPassDeadline.race(seconds: 30) {
+				try? await Task.sleep(nanoseconds: 30_000_000_000)
+				return .finalized("never")
+			}
+		}
+		try? await Task.sleep(nanoseconds: 50_000_000)
+		race.cancel()
+		let outcome = await race.value
+		#expect(outcome == .superseded)
+	}
+
+	@Test func aZeroDeadlineRunsThePassUnraced() async {
+		let outcome = await TwoPassDeadline.race(seconds: 0) { .finalized("direct") }
+		#expect(outcome == .finalized("direct"))
+	}
+}


### PR DESCRIPTION
Stacked on #72 (`whi-50-pill-motion`). Review that first; this diff reads clean against it.

Closes the WHI-58 keystone: every transcription engine now sits behind one protocol, and the app gained two remote streaming engines that reach the existing live UI.

## What's here

- **`SpeechTranscribing` protocol + `TranscriptionRouter`** (mirrors `RecipeRouter`): WhisperKit, BYOK batch, Whispera-server streaming, and direct-to-engine streaming are conformers. `AudioManager` no longer names `whisperKitTranscriber` anywhere — it resolves through the router.
- **`LiveTranscriptionState` extracted** so any engine drives the same on-screen text with the existing two-segment anti-flicker logic.
- **Streaming engines** are thin: socket, resampling, credential handling live in the `WhisperaDictation` package (whispera-components); the app maps events to shared state. Engine picker in Settings is live again (was hard-pinned to WhisperKit).
- **Reliability**: failures classified recoverable vs terminal; visible reconnecting state; capture start has a 15 s deadline instead of hanging silently; terminal errors are `.alert()`s.
- **Live UI on the pill's language**: shared components extracted (`PillStyle.swift`); the live-words HUD anchors above the pill (`PillAnchor`), follows it, never overlaps; transients rise from the pill anchor. Caret-following removed from dictation display.
- Test affordance: `WHISPERA_AUTOSTART_DICTATION` (env-gated, inert normally) — lets a harness start dictation without Accessibility.

## Verified by driving the real signed app

- Live dictation through the backend proxy → speaches: `finalTranscript("Testing one, two, three.")` mid-session.
- Direct mode (no backend): same transcript, 73 ms connect-to-listening.
- Suites green (incl. new PillAnchor, TranscriptionFailure, Router tests — the known "never finished bootstrapping" flake aside).

## Still landing on this branch (in flight, will push here)

- Paste-once-at-dictation-end for live mode; Settings model picker fed by the engine's `/v1/models`.
- Package-side: speaches 0.9 transcription-only mode + duplicate-event tolerance + latency tuning.

## Before merge (deliberate leftovers)

- The `whispera-components` package is referenced by **local path** (`../../whispera-components-worktrees/dictation/apple`) — must switch to the pushed branch/tag once the components PR lands.
- speaches upstream quirks and measured latency numbers are documented in the branch's RESULT/LATENCY files.